### PR TITLE
Channel Calendar: Add {cur_month} variable to assist highlight/lowlight on calendar display

### DIFF
--- a/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
@@ -632,12 +632,16 @@ class Channel_calendar extends Channel {
 					{
 						$out = str_replace(LD.'switch'.RD, $switch_c, $out);
 					}
+					
+					$out = str_replace(LD . 'cur_month' . RD, '1', $out);
 				}
 				else
 				{
 					$out .= str_replace($if_blank_m, $if_blank, $row_chunk);
 
 					$out = str_replace(LD.'day_number'.RD, ($day <= 0) ? sprintf($day_num_fmt, $prev_total_days + $day) : sprintf($day_num_fmt, $day - $total_days), $out);
+					
+					$out = str_replace(LD . 'cur_month' . RD, '0', $out);
 				}
 
 				$day++;


### PR DESCRIPTION
Have used this tag recently to output a calendar for data not stored in a channel (loaded from an api).  Needed to be able to lowlight date boxes not in the currently displayed month and discovered this wasn't possible with current variables if you're not displaying a channel.

Thus, add 'cur_month' variable to assist highlighting / lowlighting of month labels when using this tag to output a calendar for other means.