### PR TITLE
Improve DocBlocks

### DIFF
--- a/system/ee/EllisLab/ExpressionEngine/Core/Provider.php
+++ b/system/ee/EllisLab/ExpressionEngine/Core/Provider.php
@@ -21,17 +21,17 @@ use EllisLab\ExpressionEngine\Service\Dependency\InjectionBindingDecorator;
 class Provider extends InjectionBindingDecorator {
 
 	/**
-	 * @var Array The setup file data
+	 * @var array The setup file data
 	 */
 	protected $data;
 
 	/**
-	 * @var String The root directory for this provider
+	 * @var string The root directory for this provider
 	 */
 	protected $path;
 
 	/**
-	 * @var String The prefix this provider was registered with
+	 * @var string The prefix this provider was registered with
 	 */
 	protected $prefix;
 
@@ -41,19 +41,19 @@ class Provider extends InjectionBindingDecorator {
 	protected $autoloader;
 
 	/**
-	 * @var Path to the config directory
+	 * @var string Path to the config directory
 	 */
 	protected $config_path;
 
 	/**
-	 * @var Array of cached config file instances
+	 * @var array Cached config file instances
 	 */
 	protected $config_files = array();
 
 	/**
 	 * @param ServiceProvider $delegate The root dependencies object
-	 * @param String $path Core namespace path
-	 * @param Array $data The setup file contents
+	 * @param string $path Core namespace path
+	 * @param array $data The setup file contents
 	 */
 	public function __construct(ServiceProvider $delegate, $path, array $data)
 	{
@@ -68,7 +68,7 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Override the default config path
 	 *
-	 * We need this, because ee's config is now in the user servicable
+	 * We need this, because ee's config is now in the user serviceable
 	 * directory instead of a fixed location.
 	 */
 	public function setConfigPath($path)
@@ -79,7 +79,7 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Get the default config path
 	 *
-	 * @return String Path to the config directory
+	 * @return string Path to the config directory
 	 */
 	public function getConfigPath()
 	{
@@ -89,7 +89,8 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Set the prefix in use for this provider
 	 *
-	 * @param String $prefix Prefix this was registered under
+	 * @param string $prefix Prefix this was registered under
+	 * @throws \Exception
 	 */
 	public function setPrefix($prefix)
 	{
@@ -118,7 +119,7 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Get the registered path
 	 *
-	 * @return String Path in use
+	 * @return string Path in use
 	 */
 	public function getPath()
 	{
@@ -128,7 +129,7 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Get the registered prefix
 	 *
-	 * @return String Prefix in use
+	 * @return string Prefix in use
 	 */
 	public function getPrefix()
 	{
@@ -138,7 +139,7 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Get the 'author' key
 	 *
-	 * @return String vendor name
+	 * @return string vendor name
 	 */
 	public function getAuthor()
 	{
@@ -148,7 +149,7 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Get the 'name' key
 	 *
-	 * @return String product name
+	 * @return string product name
 	 */
 	public function getName()
 	{
@@ -158,7 +159,7 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Get the 'version' key
 	 *
-	 * @return String version number
+	 * @return string version number
 	 */
 	public function getVersion()
 	{
@@ -168,7 +169,7 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Get the 'namespace' key
 	 *
-	 * @return String namespace name
+	 * @return string namespace name
 	 */
 	public function getNamespace()
 	{
@@ -229,7 +230,7 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Helper function to get a given setup key
 	 *
-	 * @param String $key Key name
+	 * @param string $key Key name
 	 * @param Mixed $default Default value
 	 * @param Closure $map Closure to call on the data before returning
 	 * @return Mixed Setup value
@@ -262,7 +263,8 @@ class Provider extends InjectionBindingDecorator {
 	/**
 	 * Register this provider's services
 	 *
-	 * @param String $prefix The service prefix to use
+	 * @param string $prefix The service prefix to use
+	 * @throws \Exception
 	 */
 	protected function registerServices($prefix)
 	{
@@ -384,8 +386,8 @@ class Provider extends InjectionBindingDecorator {
 	 * Helper function to make sure the DI calls have
 	 * a prefix.
 	 *
-	 * @param String $name Name to prefix
-	 * @return String Prefixed name, if it did not have one
+	 * @param string $name Name to prefix
+	 * @return string Prefixed name, if it did not have one
 	 */
 	protected function ensurePrefix($name)
 	{

--- a/system/ee/EllisLab/ExpressionEngine/Service/Addon/Addon.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Addon/Addon.php
@@ -47,13 +47,11 @@ class Addon {
 	 */
 	public function isInstalled()
 	{
-		$types = array('modules', 'fieldtypes', 'extensions');
-
 		ee()->load->model('addons_model');
-
 
 		if (is_null(self::$installed_modules))
 		{
+			/** @var \CI_DB_result $query */
 			$query = ee()->addons_model->get_installed_modules();
 
 			self::$installed_modules = array();
@@ -71,6 +69,7 @@ class Addon {
 
 		if (is_null(self::$installed_extensions))
 		{
+			/** @var \CI_DB_result $query */
 			$query = ee()->addons_model->get_installed_extensions();
 
 			self::$installed_extensions = array();
@@ -89,9 +88,10 @@ class Addon {
 
 		if (is_null(self::$installed_fieldtypes))
 		{
+			/** @var \CI_DB_result $query */
 			$query = ee()->db->select('name')->get('fieldtypes');
 
-			self::$installed_fieldtypes = array();
+			self::$installed_fieldtypes = [];
 
 			foreach ($query->result() as $row)
 			{
@@ -138,9 +138,9 @@ class Addon {
 			if (is_null($installed_plugins))
 			{
 				$installed_plugins = array_map('array_pop', ee()->db
-				    ->select('plugin_package')
-				    ->get('plugins')
-				    ->result_array());
+					->select('plugin_package')
+					->get('plugins')
+					->result_array());
 
 				self::$installed_plugins = $installed_plugins;
 			}
@@ -236,7 +236,7 @@ class Addon {
 	}
 
 	/**
-	 * Gets the 'name' of the add-on, prefering to use the module's lang() key
+	 * Gets the 'name' of the add-on, preferring to use the module's lang() key
 	 * if it is defined, otherwise using the 'name' key in the provider file.
 	 *
 	 * @return string product name
@@ -437,6 +437,7 @@ class Addon {
 	{
 		$files = $this->getFilesMatching('ft.*.php');
 		$this->requireFieldtypes($files);
+
 		return ! empty($files);
 	}
 
@@ -458,6 +459,7 @@ class Addon {
     public function getFieldtypeClasses()
     {
 		$files = $this->getFilesMatching('ft.*.php');
+
 		return $this->requireFieldtypes($files);
     }
 
@@ -471,7 +473,7 @@ class Addon {
 	 */
 	public function getFieldtypeNames()
 	{
-		$names = array();
+		$names = [];
 
 		$fieldtypes = $this->get('fieldtypes');
 
@@ -484,6 +486,9 @@ class Addon {
 		return $names;
 	}
 
+	/**
+	 * @return array
+	 */
 	public function getInstalledConsentRequests()
 	{
 		$return = [];
@@ -522,6 +527,10 @@ class Addon {
 		}
 	}
 
+	/**
+	 * @param string $name
+	 * @return bool
+	 */
 	private function hasConsentRequestInstalled($name)
 	{
 		return (bool) ee('Model')->get('ConsentRequest')
@@ -529,7 +538,11 @@ class Addon {
 			->count();
 	}
 
-	private function makeConsentRequest($name, $values)
+	/**
+	 * @param string $name
+	 * @param array $values
+	 */
+	private function makeConsentRequest($name, array $values = [])
 	{
 		$request = ee('Model')->make('ConsentRequest');
 		$request->user_created = FALSE; // App-generated request
@@ -588,6 +601,9 @@ class Addon {
 		}
 	}
 
+	/**
+	 * @return string
+	 */
 	private function getConsentPrefix()
 	{
 		if (strpos($this->getPath(), PATH_ADDONS) === 0)
@@ -603,23 +619,24 @@ class Addon {
 	/**
 	 * Find files in this add-on matching a pattern
 	 *
-	 * @return array An array of pathnames
+	 * @param string $glob
+	 * @return array An array of path names
 	 */
     protected function getFilesMatching($glob)
     {
-		return glob($this->getPath()."/{$glob}") ?: array();
+		return glob($this->getPath()."/{$glob}") ?: [];
     }
 
 	/**
-	 * Includes each filetype via PHP's `require_once` command and returns an
+	 * Includes each file type via PHP's `require_once` command and returns an
 	 * array of the classes that were included.
 	 *
 	 * @param array $files An array of file names
 	 * @return array An array of classes
 	 */
-    protected function requireFieldtypes(array $files)
+    protected function requireFieldtypes(array $files = [])
     {
-		$classes = array();
+		$classes = [];
 
 		require_once SYSPATH.'ee/legacy/fieldtypes/EE_Fieldtype.php';
 
@@ -636,7 +653,7 @@ class Addon {
 	/**
 	 * Get the add-on Provider
 	 *
-	 * @return EllisLab\ExpressionEngine\Core\Provider
+	 * @return Provider
 	 */
 	 public function getProvider()
 	 {
@@ -649,7 +666,7 @@ class Addon {
 	 * Checks the namespace and if that doesn't exists falls back to the
 	 * old name
 	 *
-	 * @param string $class The classname relative to their namespace
+	 * @param string $class The class name relative to their namespace
 	 * @return string The fqcn or $class
 	 */
 	protected function getFullyQualified($class)
@@ -669,7 +686,7 @@ class Addon {
 	/**
 	 * Check if the file with a given prefix exists
 	 *
-	 * @param array $prefix A prefix for the file (i.e. 'ft', 'mod', 'mcp')
+	 * @param string $prefix A prefix for the file (i.e. 'ft', 'mod', 'mcp')
 	 * @return bool TRUE if it has the file, FALSE if not
 	 */
 	protected function hasFile($prefix)
@@ -680,7 +697,7 @@ class Addon {
 	/**
 	 * Call require on a given file
 	 *
-	 * @param array $prefix A prefix for the file (i.e. 'ft', 'mod', 'mcp')
+	 * @param string $prefix A prefix for the file (i.e. 'ft', 'mod', 'mcp')
 	 * @return void
 	 */
 	protected function requireFile($prefix)

--- a/system/ee/EllisLab/ExpressionEngine/Service/Addon/Factory.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Addon/Factory.php
@@ -89,6 +89,7 @@ class Factory {
 	/**
 	 * Is a given provider an addon?
 	 *
+	 * @param Provider $provider
 	 * @return bool Is an addon?
 	 */
 	protected function isAddon(Provider $provider)


### PR DESCRIPTION
• Fix some typos
• Remove unused $types variable
• Start using short array syntax since PHP 5.6 is the new minimum version
• Add missing parameters, throws, and return statements to docblocks
• Properly case string and array in docblocks
• Add typehint for anything that returns a DB result (IDE’s appreciate this)