### PR TITLE
Fix foreign inverse HasAndBelongstoMany relationships

### DIFF
--- a/changelogs/minor.rst
+++ b/changelogs/minor.rst
@@ -17,7 +17,7 @@ Minor Release
    - Added <new feature>
    - Fixed Bug (#<issue number>) where <bug behavior>.
 
-
+- Fixed model bug where HasAndBelongstoMany relationships wouldn't work properly.
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/EllisLab/ExpressionEngine/Service/Model/Relation/HasAndBelongsToMany.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Model/Relation/HasAndBelongsToMany.php
@@ -36,6 +36,17 @@ class HasAndBelongsToMany extends Relation {
 		return $this->pivot;
 	}
 
+	public function getInverseOptions()
+	{
+		$options = parent::getInverseOptions();
+		$options['pivot'] = [
+			'table' => $this->pivot['table'],
+			'left'  => $this->pivot['right'],
+			'right' => $this->pivot['left'],
+		];
+
+		return $options;
+	}
 
 	/**
 	 *


### PR DESCRIPTION
I originally posted this on the bug tracker [here](https://expressionengine.com/support/bugs/23722/foreign-inverse-hasandbelongstomany-relationships-dont-work).

When creating a foreign hasAndBelongsToMany relationship to a native EE model, EE fails to generate the pivot table on the inverse side.

The example below shows the add-on code that is currently failing:

```php
protected static $_relationships = array(
    'Channels' => array(
        'type'    => 'hasAndBelongsToMany',
        'model'   => 'ee:Channel',
        'pivot'   => array(
            'table' => 'my_addon_campaigns_channels',
            'left'  => 'campaign_id',
        ),
        'weak'    => true,
        'inverse' => array(
            'name' => 'Campaigns',
            'type' => 'hasAndBelongsToMany',
        ),
    ),
);
```

It fails with the following error message:

```
Undefined index: pivot

ee/EllisLab/ExpressionEngine/Service/Model/Relation/HasAndBelongsToMany.php, line 200
```

This pull request fixes this by including the pivot table in the inverse options generate by the relationship.