### PR TITLE
Fix class not added to select field type

### DIFF
--- a/changelogs/patch.rst
+++ b/changelogs/patch.rst
@@ -19,6 +19,7 @@ Patch Release
 
 - Fixed a bug where a PHP error may appear when the CP homepage newsfeed cannot be fetched.
 - Fixed a bug where extension hooks may run during a one-click upgrade.
+- Fixed a bug where a supplied class was not added to "select" fields in the shared form view.
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/EllisLab/ExpressionEngine/View/_shared/form/field.php
+++ b/system/ee/EllisLab/ExpressionEngine/View/_shared/form/field.php
@@ -121,7 +121,7 @@ if ($field['type'] == 'checkbox' && ! $value) $value = [];
 <?php break;
 
 case 'select':
-	if ( ! $no_results) echo form_dropdown($field_name, $field['choices'], $value, $attrs.' class="<?=$class?>"', isset($field['encode']) ? $field['encode'] : TRUE);
+	if ( ! $no_results) echo form_dropdown($field_name, $field['choices'], $value, $attrs.' class="'.$class.'"', isset($field['encode']) ? $field['encode'] : TRUE);
 break;
 case 'dropdown': ?>
 	<?php $this->embed('ee:_shared/form/fields/dropdown', [


### PR DESCRIPTION
Just a quick fix on a typo in the shared form view.