### PR TITLE
Fix a potential malformed query issue in the relationships_query hook 

### DIFF
--- a/changelogs/patch.rst
+++ b/changelogs/patch.rst
@@ -20,6 +20,7 @@ Patch Release
 - Fixed a bug where a PHP error may appear when the CP homepage newsfeed cannot be fetched.
 - Fixed a bug where extension hooks may run during a one-click upgrade.
 - Fixed a bug where a supplied class was not added to "select" fields in the shared form view.
+- Fixed a potential malformed query issue in the relationships_query hook 
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/legacy/models/relationship_model.php
+++ b/system/ee/legacy/models/relationship_model.php
@@ -89,7 +89,7 @@ class Relationship_model extends CI_Model {
 			return $this->overrideWithPreviewData([], $type, $fluid_field_data_id);
 		}
 
-		$db = $this->db;
+		$db = ee('db');
 
 		$db->distinct();
 		$db->select('L0.field_id as L0_field');


### PR DESCRIPTION
## Overview

When the relationships_query hook is called multiple times from within Bloqs, once for each instance of a block, the first query is fine, but subsequent queries are malformed. 

I can't find a way to fix this in Bloqs, b/c the SQL string passed to the hook is malformed before Bloqs even gets to handle it.

Good query:

```SELECT DISTINCT L0.field_id as L0_field, L0.grid_field_id as L0_grid_field_id, L0.grid_col_id as L0_grid_col_id, L0.grid_row_id as L0_grid_row_id, L0.parent_id AS L0_parent, L0.child_id as L0_id, L0.order
FROM (`exp_relationships` as L0)
LEFT JOIN `exp_relationships` as L1 ON `L0`.`child_id` = `L1`.`parent_id` OR L1.parent_id = NULL
WHERE `L0`.`fluid_field_data_id` =  0
AND `L0`.`grid_field_id` =  0
AND `L0`.`parent_id` IN (540) 
ORDER BY `L0`.`order` asc
```

Malformed query:

```SELECT DISTINCT L0.field_id as L0_field, L0.grid_field_id as L0_grid_field_id, L0.grid_col_id as L0_grid_col_id, L0.grid_row_id as L0_grid_row_id, L0.parent_id AS L0_parent, L0.child_id as L0_id, L0.order, L0.field_id as L0_field, L0.grid_field_id as L0_grid_field_id, L0.grid_col_id as L0_grid_col_id, L0.grid_row_id as L0_grid_row_id, L0.grid_row_id AS L0_parent, L0.child_id as L0_id, L0.order
FROM (`exp_relationships` as L0, `exp_relationships` as L0)
LEFT JOIN `exp_relationships` as L1 ON `L0`.`child_id` = `L1`.`parent_id` OR L1.parent_id = NULL
LEFT JOIN `exp_relationships` as L1 ON `L0`.`child_id` = `L1`.`parent_id` OR L1.parent_id = NULL
WHERE `L0`.`fluid_field_data_id` =  0
AND `L0`.`grid_field_id` =  0
AND `L0`.`parent_id` IN (540) 
AND `L0`.`fluid_field_data_id` =  0
AND `L0`.`grid_field_id` IN (8, '0') 
AND `L0`.`grid_row_id` IN (540) 
ORDER BY `L0`.`order` asc, `L0`.`order` asc
```

## Nature of This Change

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security

## Is this backwards compatible?

- [x] Yes
- [ ] No