### PR TITLE
Feature/no snippets for actions

### DIFF
--- a/changelogs/patch.rst
+++ b/changelogs/patch.rst
@@ -18,6 +18,7 @@ Patch Release
    - Fixed Bug (#<issue number>) where <bug behavior>.
 
 - Optimized the member delete routine's heir assignments.
+- Optimized ACTION request to not automatically load Template Partials.
 - Fixed a bug where a PHP error may appear when the CP homepage newsfeed cannot be fetched.
 - Fixed a bug where extension hooks may run during a one-click upgrade.
 - Fixed a bug where a supplied class was not added to "select" fields in the shared form view.

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -347,7 +347,7 @@ class EE_Core {
 		}
 
 		// Load up any Snippets
-		if (REQ == 'ACTION' OR REQ == 'PAGE')
+		if (REQ == 'PAGE')
 		{
 			$this->loadSnippets();
 		}


### PR DESCRIPTION
## Overview

By default, Snippets are loaded for each PAGE *and* ACTION request. The latter does not automatically invoke the template renderer, so it seems overkill to automatically load them for those requests. Limiting the automatic load to PAGE requests only improves performance for ACTION requests.

## Nature of This Change

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security

## Is this backwards compatible?

- [ ] Yes
- [x] No