### PR TITLE
Bug/member field url check in simple parser

### DIFF
--- a/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
@@ -285,8 +285,12 @@ class EE_Channel_simple_variable_parser implements EE_Channel_parser_component {
 	 */
 	protected function _urls($data, $tagdata, $key, $val, $prefix, $mfields)
 	{
-			// URL was moved to a custom member field or dropped
-			$member_url = (isset($mfields['url'])) ? $data['m_field_id_'.$mfields['url'][0]] : '';
+		// URL was moved to a custom member field or dropped
+		if(isset($mfields['url']) && isset($data['m_field_id_'.$mfields['url'][0]])) {
+			$member_url = $data['m_field_id_'.$mfields['url'][0]];
+		} else {
+			$member_url = '';
+		}
 
 		if ($key == $prefix.'url_title')
 		{

--- a/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
@@ -273,7 +273,7 @@ class EE_Channel_simple_variable_parser implements EE_Channel_parser_component {
 	}
 
 	/**
-	 * Handle variables that end in _url.
+	 * Handle variables that contain "url"
 	 *
 	 * @param Array		The row data
 	 * @param String	The template text

--- a/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
@@ -286,9 +286,12 @@ class EE_Channel_simple_variable_parser implements EE_Channel_parser_component {
 	protected function _urls($data, $tagdata, $key, $val, $prefix, $mfields)
 	{
 		// URL was moved to a custom member field or dropped
-		if(isset($mfields['url']) && isset($data['m_field_id_'.$mfields['url'][0]])) {
+		if (isset($mfields['url']) && isset($data['m_field_id_'.$mfields['url'][0]]))
+		{
 			$member_url = $data['m_field_id_'.$mfields['url'][0]];
-		} else {
+		}
+		else
+		{
 			$member_url = '';
 		}
 


### PR DESCRIPTION
## Overview

Added a check to make sure `$data['m_field_id_'.$mfields['url'][0]]` is set before using it. PHP throws a warning if it it tries to access it and it is not set.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#45](https://github.com/ExpressionEngine/ExpressionEngine/issues/45).

## Nature of This Change

<!-- Check all that apply: -->

- [X ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X ] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
