### PR TITLE
Allow mailto: as an optional protocol in URL fields

### DIFF
--- a/changelogs/patch.rst
+++ b/changelogs/patch.rst
@@ -17,6 +17,7 @@ Patch Release
    - Added <new feature>
    - Fixed Bug (#<issue number>) where <bug behavior>.
 
+- Added the ability for URL fields to accept the ``mailto:`` protocol. Or fixed that bug, depending on your 🏔🔭.
 - Fixed a bug where some member validation language keys may appear unparsed in some third-party contexts.
 - Fixed a potential issue (#76) where some jQuery selectors weren't specific enough.
 - Fixed a bug where some SVGs in File fields would not render a preview on the publish form.

--- a/system/ee/EllisLab/Addons/url/ft.url.php
+++ b/system/ee/EllisLab/Addons/url/ft.url.php
@@ -68,6 +68,16 @@ class Url_Ft extends EE_Fieldtype {
 				return TRUE;
 			}
 
+			// mailto: won't have a 'host', but should have a 'path'
+			if (
+				isset($parsed_url['scheme'], $parsed_url['path']) &&
+				$parsed_url['scheme'] == 'mailto' &&
+				in_array('mailto:', $this->get_setting('allowed_url_schemes'))
+				)
+			{
+				return TRUE;
+			}
+
 			return sprintf(lang('url_ft_invalid_url_scheme'), '<code>'.implode('</code>, <code>', $this->get_setting('allowed_url_schemes')).'</code>');
 		}
 
@@ -227,6 +237,7 @@ class Url_Ft extends EE_Fieldtype {
 		$protocols += array(
 			'//'      => '// ('.lang('url_ft_protocol_relative_url').')',
 			'ftp://'  => 'ftp://',
+			'mailto:' => 'mailto:',
 			'sftp://' => 'sftp://',
 			'ssh://'  => 'ssh://',
 		);


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

This addresses a feature/bug fix (hence `feaug`) to allow `mailto:` as an optional protocol in URL fields.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/19

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->