### PR TITLE
Correctly humanise subscription end date

### DIFF
--- a/changelogs/patch.rst
+++ b/changelogs/patch.rst
@@ -19,6 +19,7 @@ Patch Release
 
 - Improved revision listings (`#87 <https://github.com/ExpressionEngine/ExpressionEngine/pull/87>`__) for entry and template versioning, to sort in reverse chronological order.
 - Fixed a bug (`#55 <https://github.com/ExpressionEngine/ExpressionEngine/issues/55>`__) where fields may parse incorrectly if they shared similar names.
+- Fixed a bug (`#119 <https://github.com/ExpressionEngine/ExpressionEngine/issues/119>`__) where Simple Commerce subscription end date was not correctly formatted before output.
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/EllisLab/Addons/simple_commerce/mcp.simple_commerce.php
+++ b/system/ee/EllisLab/Addons/simple_commerce/mcp.simple_commerce.php
@@ -732,7 +732,7 @@ class Simple_commerce_mcp {
 				),
 				$purchase->Member->screen_name,
 				ee()->localize->human_time($purchase->purchase_date),
-				$purchase->subscription_end_date ?: '--',
+				$purchase->subscription_end_date ?  ee()->localize->human_time($purchase->subscription_end_date) : '--',
 				'$'.$purchase->item_cost,
 				array('toolbar_items' => array(
 					'edit' => array(


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes #119

## Nature of This Change

<!-- Check all that apply: -->

- [x ] 🐛 Fixes a bug

## Is this backwards compatible?

- [x ] Yes
- [ ] No