### PR TITLE
Search module absolute counts were wrong.

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -28,6 +28,8 @@ Bullet list below, e.g.
 - Fixed a bug where POST detection of the Channel Form that fixed [\#70](https://github.com/ExpressionEngine/ExpressionEngine/issues/70) would fail if ACTion IDs were not already inserted.
 - Fixed a bug ([\#145](https://github.com/ExpressionEngine/ExpressionEngine/issues/145)) where Live Preview wouldn't work without entry creation permissions.
 - Fixed a bug ([\#146](https://github.com/ExpressionEngine/ExpressionEngine/issues/146)) where Relationship fields that shared field IDs with Grid Relationship columns may clash.
+- Fixed a bug ([\#141](https://github.com/ExpressionEngine/ExpressionEngine/issues/141)) in the search module where the absolute count variable and the total result tag were incorrect.
+
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/EllisLab/Addons/search/mod.search.php
+++ b/system/ee/EllisLab/Addons/search/mod.search.php
@@ -1065,8 +1065,6 @@ class Search {
 			return FALSE;
 		}
 
-		$this->num_rows = $query->num_rows();
-
 		$return = array(
 			'entries' => array(),
 			'channel_ids' => array(),
@@ -1144,6 +1142,9 @@ class Search {
 				}
 			}
 		}
+
+		// Set absolute count
+		$this->num_rows = count(array_unique($query_parts['entries']));
 
 		return $query_parts;
 	}
@@ -1283,6 +1284,7 @@ class Search {
 		$fields	= ($query->row('custom_fields') == '') ? array() : unserialize(stripslashes($query->row('custom_fields') ));
 		$query_parts = unserialize($query->row('query'));
 
+		$this->num_rows = (int) $query->row('total_results');
 		$pagination->per_page = (int) $query->row('per_page');
 		$res_page = $query->row('result_page');
 
@@ -1377,6 +1379,7 @@ class Search {
 		$channel->pagination->offset = ($pagination->per_page * $pagination->current_page) - $pagination->per_page;
 
 		$channel->query = $query;
+		$channel->absolute_results = $this->num_rows;
 
 		if ($channel->query->num_rows() == 0)
 		{


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Addresses this bug: https://github.com/ExpressionEngine/ExpressionEngine/issues/141 plus the absolute_count wasn't working properly. 

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#141](https://github.com/ExpressionEngine/ExpressionEngine/issues/141).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
