### PR TITLE
Channel field pagination changed to use existing entry query, which i…

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -17,6 +17,7 @@ Bullet list below, e.g.
 - Fixed a bug([\#161](https://github.com/ExpressionEngine/ExpressionEngine/issues/161)) where searching for terms wrapped in quotes using the Search Module would return all entries.
 - Fixed a bug([\#162](https://github.com/ExpressionEngine/ExpressionEngine/issues/162)) where the `{switch=}` variable would not parse inside the Comment Entries tag.
 - Fixed a bug where Channel Form edit forms might not respect the `channel=` parameter.
+- Fixed a bug([\#140](https://github.com/ExpressionEngine/ExpressionEngine/issues/140)) where channel field pagination did not recognize fields using the new table structure.
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/legacy/libraries/Pagination.php
+++ b/system/ee/legacy/libraries/Pagination.php
@@ -674,11 +674,14 @@ class Pagination_object {
 						{
 							if (isset($row['field_id_'.$cfields[$val]]) AND $row['field_id_'.$cfields[$val]] != '')
 							{
-								$m_fields[] = $val;
+								// Need unique field shortnames
+								$m_fields[$val] = $val;
 							}
 						}
 					}
 				}
+
+				$m_fields = array_values($m_fields);
 
 				$this->per_page = 1;
 				$this->total_items = count($m_fields);


### PR DESCRIPTION
…ncludes new field structure.

<!-- What's in this pull request? -->
## Overview

Fix for #140 field pagination not working for fields in their own tables.  It's also an optimization, as it cuts out a query.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#140](https://github.com/ExpressionEngine/ExpressionEngine/issues/140).

## Nature of This Change

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [ ] Yes
- [ ] No
