### PR TITLE
Add `show_date_span` parameter to channel calendar

### DIFF
--- a/changelogs/minor.rst
+++ b/changelogs/minor.rst
@@ -17,6 +17,7 @@ Minor Release
    - Added <new feature>
    - Fixed Bug (#<issue number>) where <bug behavior>.
 
+   - Added a `show_date_span="yes"` parameter to the `{exp:channel:calendar}` tag which displays an entry in every calendar cell between the entry’s publish expiration date.
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/EllisLab/Addons/channel/mod.channel.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel.php
@@ -1471,16 +1471,16 @@ class Channel {
 			{
 				if (ee()->TMPL->fetch_param('show_date_span') != 'yes')
 				{
-                    $sql .= ' AND t.entry_date >= '.$stime;
-                }
+					$sql .= ' AND t.entry_date >= '.$stime;
+				}
 				else
 				{
-                    if (filter_var(ee()->TMPL->fetch_param('show_expired'), FILTER_VALIDATE_BOOLEAN))
+					if (filter_var(ee()->TMPL->fetch_param('show_expired'), FILTER_VALIDATE_BOOLEAN))
 					{
-                        $sql .= ' AND t.expiration_date >= '.$stime;
-                    }
-                }
-                $sql .= ' AND t.entry_date <= '.$etime.' ';
+						$sql .= ' AND t.expiration_date >= '.$stime;
+					}
+				}
+				$sql .= ' AND t.entry_date <= '.$etime.' ';
 			}
 			else
 			{

--- a/system/ee/EllisLab/Addons/channel/mod.channel.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel.php
@@ -1475,7 +1475,7 @@ class Channel {
 				}
 				else
 				{
-					if (filter_var(ee()->TMPL->fetch_param('show_expired'), FILTER_VALIDATE_BOOLEAN))
+					if (get_bool_from_string(ee()->TMPL->fetch_param('show_expired')))
 					{
 						$sql .= ' AND t.expiration_date >= '.$stime;
 					}

--- a/system/ee/EllisLab/Addons/channel/mod.channel.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel.php
@@ -1323,7 +1323,7 @@ class Channel {
 		{
 			$sql .= " AND (t.expiration_date != 0 AND t.expiration_date <= ".$timestamp.") ";
 		}
-		elseif (ee()->TMPL->fetch_param('show_expired') != 'yes')
+		elseif (ee()->TMPL->fetch_param('show_expired') != 'yes' && ee()->TMPL->fetch_param('show_date_span') != 'yes') {
 		{
 			$sql .= " AND (t.expiration_date = 0 OR t.expiration_date > ".$timestamp.") ";
 		}
@@ -1469,7 +1469,18 @@ class Channel {
 
 			if ($stime && $etime)
 			{
-				$sql .= " AND t.entry_date >= ".$stime." AND t.entry_date <= ".$etime." ";
+				if (ee()->TMPL->fetch_param('show_date_span') != 'yes')
+				{
+                    $sql .= ' AND t.entry_date >= '.$stime;
+                }
+				else
+				{
+                    if (filter_var(ee()->TMPL->fetch_param('show_expired'), FILTER_VALIDATE_BOOLEAN))
+					{
+                        $sql .= ' AND t.expiration_date >= '.$stime;
+                    }
+                }
+                $sql .= ' AND t.entry_date <= '.$etime.' ';
 			}
 			else
 			{

--- a/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
@@ -564,10 +564,14 @@ class Channel_calendar extends Channel {
                     $end = clone $start;
 
                     if (filter_var(ee()->TMPL->fetch_param('show_date_span'), FILTER_VALIDATE_BOOLEAN) && $row['expiration_date']) {
+                        if ($start->format('m') < $month) {
+                            $start = new \DateTime("{$year}-{$month}-1");
+							$end = clone $start;
+                        }
                         $expiration = new \DateTime('@'.$row['expiration_date']);
-                        $end = $start->format('Y-m') !== $expiration->format('Y-m')
-							? $end->modify('last day of this month')
-							: $expiration->modify('-1 day');
+                        $end = $start->format('Y-m') === $expiration->format('Y-m')
+                            ? $expiration->modify('-1 day')
+                            : $end->modify('last day of this month');
                     }
 
                     $end->modify('+1 day');

--- a/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
@@ -563,8 +563,10 @@ class Channel_calendar extends Channel {
                     $start = new \DateTime('@'.$row['entry_date']);
                     $end = clone $start;
 
-                    if (filter_var(ee()->TMPL->fetch_param('show_date_span'), FILTER_VALIDATE_BOOLEAN) && $row['expiration_date']) {
-                        if ($start->format('m') < $month) {
+                    if (filter_var(ee()->TMPL->fetch_param('show_date_span'), FILTER_VALIDATE_BOOLEAN) && $row['expiration_date'])
+					{
+                        if ($start->format('m') < $month)
+						{
                             $start = new \DateTime("{$year}-{$month}-1");
 							$end = clone $start;
                         }
@@ -577,8 +579,10 @@ class Channel_calendar extends Channel {
                     $end->modify('+1 day');
                     $period = new \DatePeriod($start, \DateInterval::createFromDateString('1 day'), $end);
 
-                    foreach ($period as $date) {
-						foreach ($day_path as $k => $v) {
+                    foreach ($period as $date)
+					{
+						foreach ($day_path as $k => $v)
+						{
                             $day_path[$k] = substr($day_path[$k], 0, -2).$date->format('d');
                         }
                         $data[$date->format('j')][] = array(

--- a/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
@@ -560,28 +560,36 @@ class Channel_calendar extends Channel {
 					/**  Build Data Array
 					/** ----------------------------------------*/
 
-					$d = ee()->localize->format_date('%d', $row['entry_date']);
+                    $start = new \DateTime('@'.$row['entry_date']);
+                    $end = clone $start;
 
-					if (substr($d, 0, 1) == '0')
-					{
-						$d = substr($d, 1);
-					}
+                    if (filter_var(ee()->TMPL->fetch_param('show_date_span'), FILTER_VALIDATE_BOOLEAN) && $row['expiration_date']) {
+                        $expiration = new \DateTime('@'.$row['expiration_date']);
+                        $end = $start->format('Y-m') !== $expiration->format('Y-m')
+							? $end->modify('last day of this month')
+							: $expiration->modify('-1 day');
+                    }
 
-					$data[$d][] = array(
-						ee()->typography->parse_type($row['title'], array('text_format' => 'lite', 'html_format' => 'none', 'auto_links' => 'n', 'allow_img_url' => 'no')),
-						$row['url_title'],
-						$entry_date,
-						$permalink,
-						$title_permalink,
-						$author,
-						$profile_path,
-						$id_path,
-						$base_fields,
-						$day_path,
-						$comment_auto_path,
-						$comment_url_title_auto_path,
-						$comment_entry_id_auto_path
-					);
+                    $end->modify('+1 day');
+                    $period = new \DatePeriod($start, \DateInterval::createFromDateString('1 day'), $end);
+
+                    foreach ($period as $date) {
+                        $data[$date->format('j')][] = array(
+                            ee()->typography->parse_type($row['title'], ['text_format' => 'lite', 'html_format' => 'none', 'auto_links' => 'n', 'allow_img_url' => 'no']),
+                            $row['url_title'],
+                            $entry_date,
+                            $permalink,
+                            $title_permalink,
+                            $author,
+                            $profile_path,
+                            $id_path,
+                            $base_fields,
+                            $day_path,
+                            $comment_auto_path,
+                            $comment_url_title_auto_path,
+                            $comment_entry_id_auto_path
+						);
+                    }
 
 				} // END FOREACH
 			} // END if ($query->num_rows() > 0)

--- a/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
@@ -560,47 +560,47 @@ class Channel_calendar extends Channel {
 					/**  Build Data Array
 					/** ----------------------------------------*/
 
-                    $start = new \DateTime('@'.$row['entry_date']);
-                    $end = clone $start;
+					$start = new \DateTime('@'.$row['entry_date']);
+					$end = clone $start;
 
-                    if (filter_var(ee()->TMPL->fetch_param('show_date_span'), FILTER_VALIDATE_BOOLEAN) && $row['expiration_date'])
+					if (filter_var(ee()->TMPL->fetch_param('show_date_span'), FILTER_VALIDATE_BOOLEAN) && $row['expiration_date'])
 					{
-                        if ($start->format('m') < $month)
+						if ($start->format('m') < $month)
 						{
-                            $start = new \DateTime("{$year}-{$month}-1");
+							$start = new \DateTime("{$year}-{$month}-1");
 							$end = clone $start;
-                        }
-                        $expiration = new \DateTime('@'.$row['expiration_date']);
-                        $end = $start->format('Y-m') === $expiration->format('Y-m')
-                            ? $expiration->modify('-1 day')
-                            : $end->modify('last day of this month');
-                    }
+						}
+						$expiration = new \DateTime('@'.$row['expiration_date']);
+						$end = $start->format('Y-m') === $expiration->format('Y-m')
+							? $expiration->modify('-1 day')
+							: $end->modify('last day of this month');
+					}
 
-                    $end->modify('+1 day');
-                    $period = new \DatePeriod($start, \DateInterval::createFromDateString('1 day'), $end);
+					$end->modify('+1 day');
+					$period = new \DatePeriod($start, \DateInterval::createFromDateString('1 day'), $end);
 
-                    foreach ($period as $date)
+					foreach ($period as $date)
 					{
 						foreach ($day_path as $k => $v)
 						{
-                            $day_path[$k] = substr($day_path[$k], 0, -2).$date->format('d');
-                        }
-                        $data[$date->format('j')][] = array(
-                            ee()->typography->parse_type($row['title'], ['text_format' => 'lite', 'html_format' => 'none', 'auto_links' => 'n', 'allow_img_url' => 'no']),
-                            $row['url_title'],
-                            $entry_date,
-                            $permalink,
-                            $title_permalink,
-                            $author,
-                            $profile_path,
-                            $id_path,
-                            $base_fields,
-                            $day_path,
-                            $comment_auto_path,
-                            $comment_url_title_auto_path,
-                            $comment_entry_id_auto_path
+							$day_path[$k] = substr($day_path[$k], 0, -2).$date->format('d');
+						}
+						$data[$date->format('j')][] = array(
+							ee()->typography->parse_type($row['title'], ['text_format' => 'lite', 'html_format' => 'none', 'auto_links' => 'n', 'allow_img_url' => 'no']),
+							$row['url_title'],
+							$entry_date,
+							$permalink,
+							$title_permalink,
+							$author,
+							$profile_path,
+							$id_path,
+							$base_fields,
+							$day_path,
+							$comment_auto_path,
+							$comment_url_title_auto_path,
+							$comment_entry_id_auto_path
 						);
-                    }
+					}
 
 				} // END FOREACH
 			} // END if ($query->num_rows() > 0)

--- a/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
@@ -574,6 +574,9 @@ class Channel_calendar extends Channel {
                     $period = new \DatePeriod($start, \DateInterval::createFromDateString('1 day'), $end);
 
                     foreach ($period as $date) {
+						foreach ($day_path as $k => $v) {
+                            $day_path[$k] = substr($day_path[$k], 0, -2).$date->format('d');
+                        }
                         $data[$date->format('j')][] = array(
                             ee()->typography->parse_type($row['title'], ['text_format' => 'lite', 'html_format' => 'none', 'auto_links' => 'n', 'allow_img_url' => 'no']),
                             $row['url_title'],

--- a/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel_calendar.php
@@ -563,7 +563,7 @@ class Channel_calendar extends Channel {
 					$start = new \DateTime('@'.$row['entry_date']);
 					$end = clone $start;
 
-					if (filter_var(ee()->TMPL->fetch_param('show_date_span'), FILTER_VALIDATE_BOOLEAN) && $row['expiration_date'])
+					if (get_bool_from_string(ee()->TMPL->fetch_param('show_date_span')) && $row['expiration_date'])
 					{
 						if ($start->format('m') < $month)
 						{


### PR DESCRIPTION
## Overview

Added a `show_date_span="yes"` parameter to the `{exp:channel:calendar}` tag which repeats the entry across every calendar "day" cell between the entry’s publish and expiration date.

Given a single entry (My Event) with an `entry_date` of **April 1, 2019** and an `expiration_date` of **April 5, 2019** - setting `show_date_span="yes"` would display a calendar with the first week like this:

| S  | M | T | W | T | F | S |
| :-- | :-- | :-- | :-- | :-- | :-- | :-- |
| 31<br>&nbsp; | 1<br>My Event | 2<br>My Event | 3<br>My Event | 4<br>My Event | 5<br>My Event  | 6<br>&nbsp; |

Entires without an `expiration_date` will continue to show on a single day.

When combined with `show_future_entries="yes"`, this would be useful for anyone wanting to build a simple event calendar.

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/41
