### PR TITLE
Altered password change notifications related to hash algorithm changes.

### DIFF
--- a/system/ee/EllisLab/ExpressionEngine/Model/Member/Member.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Member/Member.php
@@ -300,8 +300,11 @@ class Member extends ContentModel {
 		{
 			if (isset($changed['password']))
 			{
+				// Did the hash length change? Then the algorithm changed
+				$password_change_type = (strlen($changed['password']) != strlen($this->password)) ? 'member_hash_algo_changed' : 'member_changed_password';
+
 				ee()->logger->log_action(sprintf(
-					lang('member_changed_password'),
+					lang($password_change_type),
 					$this->username,
 					$this->member_id
 				));
@@ -342,8 +345,11 @@ class Member extends ContentModel {
 
 		if (isset($changed['password']))
 		{
-			// email the current email address telling them their password changed
-			$this->notifyOfChanges('password_changed_notification', $this->email);
+			if (strlen($changed['password']) == strlen($this->password))
+			{
+				// email the current email address telling them their password changed
+				$this->notifyOfChanges('password_changed_notification', $this->email);
+			}
 		}
 
 		if (isset($changed['screen_name']))

--- a/system/ee/legacy/language/english/cp_lang.php
+++ b/system/ee/legacy/language/english/cp_lang.php
@@ -227,6 +227,8 @@ $lang = array(
 
 'member_anonymized_member' => 'Anonymized member with ID: %d',
 
+'member_hash_algo_changed' => 'Hash algorithm changed for "%s" (%d)',
+
 'member_id' => 'Member ID',
 
 'member_logged_in' => 'Logged in',


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview
Altered notifications when hash alogrithms cause a password hash update.  Related to issue #170 but this is a more general behavior change. That particular bug is already fixed.

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
