### PR TITLE
Modify the anchor tag to link from add-ons to their manuals 

### DIFF
--- a/system/ee/EllisLab/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Addons/Addons.php
@@ -345,7 +345,8 @@ class Addons extends CP_Controller {
 
 						if ($info['manual_external'])
 						{
-							$toolbar['manual']['target'] = '_external';
+							$toolbar['manual']['target'] = '_blank';
+							$toolbar['manual']['rel'] = 'external';
 						}
 					}
 

--- a/system/ee/EllisLab/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Addons/Addons.php
@@ -345,7 +345,6 @@ class Addons extends CP_Controller {
 
 						if ($info['manual_external'])
 						{
-							$toolbar['manual']['target'] = '_blank';
 							$toolbar['manual']['rel'] = 'external';
 						}
 					}


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Modify the anchor tag to link from add-ons to their manuals 

https://github.com/ExpressionEngine/ExpressionEngine/blob/stability/system/ee/EllisLab/ExpressionEngine/Controller/Addons/Addons.php
line 348

## Nature of This Change

<!-- Check all that apply: -->

- [ x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ x] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x ] Yes
- [ ] No

