### PR TITLE
Control panel links update to not point to v4/ docs, but to latest docs

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -12,6 +12,7 @@ Bullet list below, e.g.
    - Fixed a bug where relationships in grid fields could prevent parsing of standalone relationship fields.
    - Fixed a bug in the channel form where posting to a different MSM site could corrupt site pages.
    - Fixed a bug([\#212](https://github.com/ExpressionEngine/ExpressionEngine/issues/212)) where the search module did not validate the maximum keyword length.
+   - Fixed a bug([\#224](https://github.com/ExpressionEngine/ExpressionEngine/issues/224)) where several links in the control panel linked to the EE4 docs.
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/EllisLab/Addons/rte/ext.rte.php
+++ b/system/ee/EllisLab/Addons/rte/ext.rte.php
@@ -16,7 +16,7 @@ class Rte_ext {
 	var $name			= 'Rich Text Editor';
 	var $version		= '1.0.1';
 	var $settings_exist	= 'n';
-	var $docs_url		= 'https://docs.expressionengine.com/v4/add-ons/rte/control_panel/index.html';
+	var $docs_url		= DOC_URL.'add-ons/rte/control_panel/index.html';
 	var $required_by	= array('module', 'fieldtype');
 
 	private $module = 'rte';

--- a/system/ee/EllisLab/ExpressionEngine/Controller/Settings/HitTracking.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Settings/HitTracking.php
@@ -49,7 +49,7 @@ class HitTracking extends Settings {
 					'title' => 'dynamic_tracking_disabling',
 					'desc' => sprintf(
 						lang('dynamic_tracking_disabling_desc'),
-						'https://docs.expressionengine.com/v4/cp/settings/hit-tracking.html#suspend-threshold'
+						DOC_URL.'cp/settings/hit-tracking.html#suspend-threshold'
 					),
 					'fields' => array(
 						'dynamic_tracking_disabling' => array('type' => 'text')

--- a/system/ee/EllisLab/ExpressionEngine/Controller/Settings/SecurityPrivacy.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Settings/SecurityPrivacy.php
@@ -80,7 +80,7 @@ class SecurityPrivacy extends Settings {
 				),
 				array(
 					'title' => 'cookie_path',
-					'desc' => sprintf(lang('cookie_path_desc'), ee()->cp->masked_url('https://docs.expressionengine.com/v4/cp/settings/security-privacy.html#path')),
+					'desc' => sprintf(lang('cookie_path_desc'), ee()->cp->masked_url(DOC_URL.'cp/settings/security-privacy.html#path')),
 					'fields' => array(
 						'cookie_path' => array('type' => 'text')
 					)


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Updates hardcoded docs links in the Control Panel to use the `DOCS_URL` constant.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#224](https://github.com/ExpressionEngine/ExpressionEngine/issues/224).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
