### PR TITLE
Added check on select query column aliases

### DIFF
--- a/system/ee/EllisLab/ExpressionEngine/Service/Model/Query/Select.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Model/Query/Select.php
@@ -202,6 +202,9 @@ class Select extends Query {
 			foreach ($table_fields as $column)
 			{
 				// remember the name so we can translate filters and order_bys
+				// if alias column already exists, skip it
+				if (isset($this->model_fields[$alias]["{$alias}__{$column}"])) continue;
+
 				$this->model_fields[$alias]["{$alias}__{$column}"] = "{$table_alias}.{$column}";
 
 				// but only select it if they did not specify fields to select


### PR DESCRIPTION
This avoids duplicate fields in the SELECT part (eg. ChannelEntry_channel_title.entry_id AS ChannelEntry__entry_id, ChannelEntry_channel_data.entry_id AS ChannelEntry__entry_id) as well as targeting the non-main table in WHERE statements (eg. ChannelEntry_channel_data.site_id = 1), which could potentially lead to performance issues.
