### PR TITLE
Add hook_id to Channel model

### DIFF
--- a/system/ee/EllisLab/ExpressionEngine/Model/Channel/Channel.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Channel/Channel.php
@@ -20,6 +20,8 @@ class Channel extends StructureModel {
 
 	protected static $_primary_key = 'channel_id';
 	protected static $_table_name = 'channels';
+	
+	protected static $_hook_id = 'channel';
 
 	protected static $_typed_columns = array(
 		'deft_comments'              => 'boolString',


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

The Channel model does not currently publish even hooks when a channel is created, updated, or deleted. As an add-on developer it would be nice to be able to subscribe to these events.

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
