### PR TITLE
Added extra mime for SVG as some servers report SVG without +xml

### DIFF
--- a/changelogs/minor.rst
+++ b/changelogs/minor.rst
@@ -13,10 +13,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 Minor Release
 *************
 
-.. Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed Bug (#<issue number>) where <bug behavior>.
-
+   - Fixed Bug (#139) where on some servers the mime type of SVG is different then we expected.
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/EllisLab/ExpressionEngine/Config/mimes.php
+++ b/system/ee/EllisLab/ExpressionEngine/Config/mimes.php
@@ -104,6 +104,7 @@ return array(
 	'image/pjpeg', // .jpg, .jpe, .jpeg
 	'image/png', // .png
 	'image/svg+xml', // .svg
+	'image/svg', // .svg
 	'image/tiff', // .tif, .tiff
 	'image/x-png', // .png
 	'message/rfc822', // .eml


### PR DESCRIPTION
# Overview

On some servers, the mime type for `svg` is reported as `image/svg` and not as the expected `image/svg+xml` which result in not able to upload SVG files.
By adding just a new mime type without the `+xml` should fix this issue.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#139](https://github.com/ExpressionEngine/ExpressionEngine/issues/139).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
- changelogs/minor.rst (x.X.x)
