### PR TITLE
Fixing join_date variable name, addresses #272

### DIFF
--- a/system/ee/EllisLab/Addons/member/mod.member.php
+++ b/system/ee/EllisLab/Addons/member/mod.member.php
@@ -2378,7 +2378,7 @@ class Member {
 			$dates = array(
 				'last_visit' => (empty($default_fields['last_visit'])) ? '' : $default_fields['last_visit'],
 				'last_activity' => (empty($default_fields['last_activity'])) ? '' : $default_fields['last_activity'],
-				'join_date' => (empty($default_fields['join_date'])) ? '' : $default_fields['last_entry_date'],
+				'join_date' => (empty($default_fields['join_date'])) ? '' : $default_fields['join_date'],
 				'last_entry_date' => (empty($default_fields['last_entry_date'])) ? '' : $default_fields['last_entry_date'],
 				'last_forum_post_date' => (empty($default_fields['last_forum_post_date'])) ? '' : $default_fields['last_forum_post_date'],
 				'last_comment_date' => (empty($default_fields['last_comment_date'])) ? '' : $default_fields['last_comment_date']


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Fixes join_date variable in mod.member.php, addresses #272 

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#272](https://github.com/ExpressionEngine/ExpressionEngine/issues/272).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security

## Is this backwards compatible?

- [X] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
