### PR TITLE
Added an exif check for image rotation when uploading or saving an image

### DIFF
--- a/system/ee/legacy/libraries/Filemanager.php
+++ b/system/ee/legacy/libraries/Filemanager.php
@@ -377,7 +377,15 @@ class Filemanager {
 				return $this->_save_file_response(FALSE, lang('gd_not_installed'));
 			}
 
-		 	$prefs = $this->max_hw_check($file_path, $prefs);
+			// Check and fix orientation
+			$orientation = $this->orientation_check($file_path, $prefs);
+
+			if ( ! empty($orientation))
+			{
+				$prefs = $orientation;
+			}
+
+			$prefs = $this->max_hw_check($file_path, $prefs);
 
 			if ( ! $prefs)
 			{
@@ -405,6 +413,99 @@ class Filemanager {
 		$this->_xss_on = TRUE;
 
 		return $response;
+	}
+
+	/**
+	 * Reorient main image if exif info indicates we should
+	 *
+	 * @access	public
+	 * @return	void
+	 */
+	function orientation_check($file_path, $prefs)
+	{
+		if ( ! function_exists('exif_read_data'))
+		{
+			return;
+		}
+
+		// Not all images are supported
+		$exif = @exif_read_data($file_path);
+
+		if ( ! $exif OR ! isset($exif['Orientation']))
+		{
+			return;
+		}
+
+		$orientation = $exif['Orientation'];
+
+		if ($orientation == 1)
+		{
+			return;
+		}
+
+		// Image is rotated, let's see by how much
+		$deg = 0;
+
+		switch ($orientation) {
+			case 3:
+				$deg = 180;
+				break;
+			case 6:
+				$deg = 270;
+				break;
+			case 8:
+				$deg = 90;
+				break;
+		}
+
+		if ($deg)
+		{
+			ee()->load->library('image_lib');
+
+			ee()->image_lib->clear();
+
+			// Set required memory
+			try
+			{
+				ee('Memory')->setMemoryForImageManipulation($file_path);
+			}
+			catch (\Exception $e)
+			{
+				log_message('error', $e->getMessage().': '.$file_path);
+				return;
+			}
+
+			$config = array(
+				'rotation_angle'	=> $deg,
+				'library_path'		=> ee()->config->item('image_library_path'),
+				'image_library'		=> ee()->config->item('image_resize_protocol'),
+				'source_image'		=> $file_path
+			);
+
+			ee()->image_lib->initialize($config);
+
+			if ( ! ee()->image_lib->rotate())
+			{
+				return;
+			}
+
+			$new_image = ee()->image_lib->get_image_properties('', TRUE);
+			ee()->image_lib->clear();
+
+			// We need to reset some prefs
+			if ($new_image)
+			{
+				ee()->load->helper('number');
+				$f_size =  get_file_info($file_path);
+				$prefs['file_height'] = $new_image['height'];
+				$prefs['file_width'] = $new_image['width'];
+				$prefs['file_hw_original'] = $new_image['height'].' '.$new_image['width'];
+				$prefs['height'] = $new_image['height'];
+				$prefs['width'] = $new_image['width'];
+			}
+
+			return $prefs;
+		}
 	}
 
 	/**
@@ -1974,7 +2075,15 @@ class Filemanager {
 		// Check to see if its an editable image, if it is, check max h/w
 		if ($this->is_editable_image($file['full_path'], $file['file_type']))
 		{
-		 	$file_data = $this->max_hw_check($file['full_path'], $file_data);
+			// Check and fix orientation
+			$orientation = $this->orientation_check($file['full_path'], $file_data);
+
+			if ( ! empty($orientation))
+			{
+				$file_data = $orientation;
+			}
+
+			$file_data = $this->max_hw_check($file['full_path'], $file_data);
 
 			if ( ! $file_data)
 			{


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Addresses an issue where images are rotated improperly because of how phones use exif data to handle presentation.  This orientation check looks at the exif data and if it indicates the image needs to be rotated, it rotates it and saves the new image.  See discussion  https://expressionengine.com/forums/topic/252416/how-do-i-upload-images-and-resize-them-without-ee-rotating-them

## Nature of This Change

Halfway between a bug fix and a feature.  The code worked as intended, but the result could be unintended.

- [x] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

