### PR TITLE
Add additional hooks to Channel, Site, and Template models

### DIFF
--- a/changelogs/minor.rst
+++ b/changelogs/minor.rst
@@ -13,9 +13,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 Minor Release
 *************
 
-.. Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed Bug (#<issue number>) where <bug behavior>.
+   - Added event hooks to the Channel, ChannelFormSettings, ChannelLayout, Site, Snippet, and Specialty Template models.
 
 
 

--- a/system/ee/EllisLab/ExpressionEngine/Model/Channel/Channel.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Channel/Channel.php
@@ -20,7 +20,7 @@ class Channel extends StructureModel {
 
 	protected static $_primary_key = 'channel_id';
 	protected static $_table_name = 'channels';
-	
+
 	protected static $_hook_id = 'channel';
 
 	protected static $_typed_columns = array(

--- a/system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelFormSettings.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelFormSettings.php
@@ -20,6 +20,8 @@ class ChannelFormSettings extends Model {
 	protected static $_primary_key = 'channel_form_settings_id';
 	protected static $_table_name = 'channel_form_settings';
 
+	protected static $_hook_id = 'channel_form_settings';
+
 	protected static $_relationships = array(
 		'Channel' => array(
 			'type' => 'belongsTo'

--- a/system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelLayout.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelLayout.php
@@ -24,6 +24,8 @@ class ChannelLayout extends Model implements LayoutInterface {
 	protected static $_primary_key = 'layout_id';
 	protected static $_table_name = 'layout_publish';
 
+	protected static $_hook_id = 'channel_layout';
+
 	protected static $_typed_columns = array(
 		'field_layout' => 'serialized',
 	);

--- a/system/ee/EllisLab/ExpressionEngine/Model/Site/Site.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Site/Site.php
@@ -24,6 +24,8 @@ class Site extends Model {
 	protected static $_primary_key = 'site_id';
 	protected static $_table_name = 'sites';
 
+	protected static $_hook_id = 'site';
+
 	protected static $_type_classes = array(
 		'ChannelPreferences' => 'EllisLab\ExpressionEngine\Model\Site\Column\ChannelPreferences',
 		'MemberPreferences' => 'EllisLab\ExpressionEngine\Model\Site\Column\MemberPreferences',

--- a/system/ee/EllisLab/ExpressionEngine/Model/Status/Status.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Status/Status.php
@@ -21,6 +21,8 @@ class Status extends Model {
 	protected static $_primary_key = 'status_id';
 	protected static $_table_name = 'statuses';
 
+	protected static $_hook_id = 'status';
+
 	protected static $_typed_columns = array(
 		'site_id'         => 'int',
 		'group_id'        => 'int',

--- a/system/ee/EllisLab/ExpressionEngine/Model/Template/GlobalVariable.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Template/GlobalVariable.php
@@ -22,6 +22,8 @@ class GlobalVariable extends FileSyncedModel {
 	protected static $_primary_key = 'variable_id';
 	protected static $_table_name  = 'global_variables';
 
+	protected static $_hook_id = 'global_variable';
+
 	protected static $_relationships = array(
 		'Site' => array(
 			'type' => 'belongsTo'

--- a/system/ee/EllisLab/ExpressionEngine/Model/Template/Snippet.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Template/Snippet.php
@@ -22,6 +22,8 @@ class Snippet extends FileSyncedModel {
 	protected static $_primary_key = 'snippet_id';
 	protected static $_table_name = 'snippets';
 
+	protected static $_hook_id = 'snippet';
+
 	protected static $_relationships = array(
 		'Site' => array(
 			'type' => 'BelongsTo'

--- a/system/ee/EllisLab/ExpressionEngine/Model/Template/SpecialtyTemplate.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Template/SpecialtyTemplate.php
@@ -20,6 +20,8 @@ class SpecialtyTemplate extends Model {
 	protected static $_primary_key = 'template_id';
 	protected static $_table_name = 'specialty_templates';
 
+	protected static $_hook_id = 'specialty_template';
+
 	protected static $_typed_columns = array(
 		'enable_template' => 'boolString'
 	);


### PR DESCRIPTION
## Overview

Add new/additional event hooks to ChannelFormSettings, ChannelLayout, Site, GlobalVariable, Snippet, Status, and SpecialtyTemplate models.

## Nature of This Change

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [ ] Yes
- [x] No

## Documentation

User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/52
