### PR TITLE
Fix a bug with the :url_slug variable modifier

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -9,6 +9,7 @@ Bullet list below, e.g.
    - Fixed a bug (#<linked issue number>) where <bug behavior>.
 
    - Fixed a bug where the current entry revision did not always show the correct revision author.
+   - Fixed a bug where the lowercase parameter of the :url_slug variable modifier wasn't being applied.
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/EllisLab/ExpressionEngine/Service/Formatter/Formats/Text.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Formatter/Formats/Text.php
@@ -611,7 +611,7 @@ class Text extends Formatter {
 			$options['separator'] = ($this->getConfig('word_separator') == 'underscore') ? '_' : '-';
 		}
 
-		$lowercase = (isset($options['lowercase']) && $options['lowercase'] === FALSE) ? FALSE : TRUE;
+		$lowercase = (isset($options['lowercase']) && get_bool_from_string($options['lowercase']) === FALSE) ? FALSE : TRUE;
 
 		$this->accentsToAscii();
 

--- a/system/ee/EllisLab/Tests/ExpressionEngine/Service/Formatter/TextFormatterTest.php
+++ b/system/ee/EllisLab/Tests/ExpressionEngine/Service/Formatter/TextFormatterTest.php
@@ -487,7 +487,7 @@ And if you made it to this &#x1F573;&#xFE0F; you did pretty good.']
 			[
 				$sample,
 				[
-					'lowercase' => FALSE,
+					'lowercase' => 'no',
 				],
 				'Sample-Title-to-Turn-Into-a-Slug-including-💩-tags-quotes-and-high-ascii-ssae-and-seps____in....content'
 			],


### PR DESCRIPTION
Fix a bug where the _lowercase_ parameter of the `:url_slug` variable modifier wasn't being applied.

## Overview

This fix modifies the `Formatter\Text` class, specifically the `urlSlug()` method, and simply adds the `get_bool_from_string()` function to the _lowercase_ option check. Without this, the check always fails and the option (ie. the parameter to the `:url_slug` variable modifier) always defaults, rendering the option unusable.

## Nature of This Change

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
