### PR TITLE
Remove type attribute from {encode} script

### DIFF
--- a/system/ee/legacy/libraries/Typography.php
+++ b/system/ee/legacy/libraries/Typography.php
@@ -2381,7 +2381,7 @@ class EE_Typography {
 // Regex speed hat tip: http://blog.stevenlevithan.com/archives/faster-trim-javascript
 ?>
 
-<span <?php echo $span_marker; ?>='1'>.<?php echo lang('encoded_email'); ?></span><script type="text/javascript">
+<span <?php echo $span_marker; ?>='1'>.<?php echo lang('encoded_email'); ?></span><script>
 /*<![CDATA[*/
 var out = '',
 	el = document.getElementsByTagName('span'),


### PR DESCRIPTION
## Overview
Removes type="text/javascript" attribute from {encode} script, which makes code valid at [The W3C Markup Validation Service](https://validator.w3.org/nu/).

Resolves [#306](https://github.com/ExpressionEngine/ExpressionEngine/issues/306).

## Nature of This Change
- [x ] 💅 Fixes coding style
- [ x] 🔥 Removes unused files / code

## Is this backwards compatible?
- [x ] Yes

- changelogs/minor.rst (5.3.0)