### PR TITLE
adding an override for saving template global vars, separate from tem…

### DIFF
--- a/changelogs/minor.rst
+++ b/changelogs/minor.rst
@@ -15,6 +15,7 @@ Minor Release
 
   - Added event hooks to the Channel, ChannelFormSettings, ChannelLayout, Site, Snippet, and Specialty Template models.
   - Fixed a bug ([#306](https://github.com/ExpressionEngine/ExpressionEngine/issues/306)] where {encode} variable output didn't pass the WC3 validator.
+  - Added a config override `save_tmpl_globals` to allow separate saving behavior for global variables
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/EllisLab/ExpressionEngine/Boot/boot.common.php
+++ b/system/ee/EllisLab/ExpressionEngine/Boot/boot.common.php
@@ -197,7 +197,7 @@ require_once SYSPATH . '/ee/EllisLab/ExpressionEngine/Library/Compat/Random/rand
  */
 	function default_config_items()
 	{
-		return array(
+		return [
 			'allow_extensions'     => 'y',
 			'cache_driver'         => 'file',
 			'cache_path'           => '',
@@ -213,8 +213,8 @@ require_once SYSPATH . '/ee/EllisLab/ExpressionEngine/Library/Compat/Random/rand
 			'uri_protocol'         => 'AUTO',
 			'enable_devlog_alerts' => 'n',
 			'save_tmpl_files'      => 'y',
-			'save_tmpl_globals'    => 'y'
-		);
+			'save_tmpl_globals'    => 'y',
+		];
 	}
 
 /**

--- a/system/ee/EllisLab/ExpressionEngine/Boot/boot.common.php
+++ b/system/ee/EllisLab/ExpressionEngine/Boot/boot.common.php
@@ -212,7 +212,8 @@ require_once SYSPATH . '/ee/EllisLab/ExpressionEngine/Library/Compat/Random/rand
 			'subclass_prefix'      => 'EE_',
 			'uri_protocol'         => 'AUTO',
 			'enable_devlog_alerts' => 'n',
-			'save_tmpl_files'      => 'y'
+			'save_tmpl_files'      => 'y',
+			'save_tmpl_globals'    => 'y'
 		);
 	}
 

--- a/system/ee/EllisLab/ExpressionEngine/Model/Template/GlobalVariable.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Template/GlobalVariable.php
@@ -54,7 +54,7 @@ class GlobalVariable extends FileSyncedModel {
 
 		$basepath = PATH_TMPL;
 
-		if (ee()->config->item('save_tmpl_files') != 'y' || $basepath == '')
+		if (ee()->config->item('save_tmpl_files') != 'y' || ee()->config->item('save_tmpl_globals') != 'y' || $basepath == '')
 		{
 			return NULL;
 		}
@@ -139,7 +139,7 @@ class GlobalVariable extends FileSyncedModel {
 
 		$basepath = PATH_TMPL;
 
-		if (ee()->config->item('save_tmpl_files') != 'y' || $basepath == '')
+		if (ee()->config->item('save_tmpl_files') != 'y' || ee()->config->item('save_tmpl_globals') != 'y' || $basepath == '')
 		{
 			return NULL;
 		}


### PR DESCRIPTION
## Overview

This adds a simple config override, `save_tmpl_globals`, for template global variables to be saved (or not saved) as files. This is separate from the overall `save_tmpl_files` config override. 

Rationale: in some instances, it may be a bad idea to save global variables as files. It's not always appropriate to treat them as if they're ordinary templates; certain third-party addons (such as Low Variables) add UI such that it may not be obvious that they're going to be saved as files. Additionally, in some MSM setups, people make use of symlinks in the templates directory, which could result in subsites getting the wrong variable data.

## Nature of This Change

- [ ] 🐛 Fixes a bug
- [X] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security 

## Is this backwards compatible?

- [X] Yes
- [ ] No

## Documentation

User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/58

