### PR TITLE
Fix php opening tag

### DIFF
--- a/system/ee/EllisLab/ExpressionEngine/View/utilities/extensions.php
+++ b/system/ee/EllisLab/ExpressionEngine/View/utilities/extensions.php
@@ -5,7 +5,7 @@
 		<h1><?=$cp_heading?></h1>
 		<div class="app-notice-wrap"><?=ee('CP/Alert')->getAllInlines()?></div>
 		<?php $this->embed('_shared/table', $table); ?>
-		<? if (isset($pagination)) echo $pagination; ?>
+		<?php if (isset($pagination)) echo $pagination; ?>
 		<?php if ($table['total_rows'] > 0): ?>
 		<fieldset class="tbl-bulk-act hidden">
 			<select name="bulk_action">


### PR DESCRIPTION
On the Debug Extensions page, if short tags is not on, the pagination would not show. I fixed the opening php tag.

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

I have a lot of extensions, and at a certain point, I was pulling my beard out trying to figure out why some extensions were not showing on the Debug Extensions page. I realized there was no pagination. I noticed that this line used the short open tags, and I don't have short_open_tag enabled. Converted it to a full php open tag.

<!-- If this pull request resolves a project issue, provide a link: -->

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug

https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!


If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
