### PR TITLE
Use correct variable name in Filemanager to avoid thumb creation error on Windows

### DIFF
--- a/system/ee/legacy/libraries/Filemanager.php
+++ b/system/ee/legacy/libraries/Filemanager.php
@@ -1260,7 +1260,7 @@ class Filemanager {
 				return FALSE;
 			}
 
-			$resized_dir = rtrim(realpath($resized_path), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+			$resized_path = rtrim(realpath($resized_path), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
 
 			// Does the thumb image exist
 			if (file_exists($resized_path.$prefs['file_name']))


### PR DESCRIPTION
## Overview

Uploading files was not possible on Windows due to wrong variable name used in legacy Filemanager library for setting the path. This commit is fixing it.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug

## Is this backwards compatible?

- [x] Yes