### PR TITLE
Bug/344 remove magic quotes

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -3,10 +3,7 @@
 ExpressionEngine uses semantic versioning. This file contains changes to ExpressionEngine since the last Build / Version release for PATCH version changes only.
 
 ## Patch Release
-
-Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
+- Remove get_magic_quotes_gpc deprecated function
 
 
 

--- a/system/ee/EllisLab/Addons/simple_commerce/mod.simple_commerce.php
+++ b/system/ee/EllisLab/Addons/simple_commerce/mod.simple_commerce.php
@@ -556,11 +556,7 @@ class Simple_commerce {
 
 		foreach ($_POST as $key => $value)
 		{
-			// str_replace("\n", "\r\n", $value)
-			// put line feeds back to CR+LF as that's how PayPal sends them out
-			// otherwise multi-line data will be rejected as INVALID
-			// Note: get_magic_quotes_gpc FALSE as of PHP 5.4.0
-			$stripped = (get_magic_quotes_gpc()) ? stripslashes(str_replace("\n", "\r\n", $value)) : str_replace("\n", "\r\n", $value);
+			$stripped = str_replace("\n", "\r\n", $value);
 			$postdata .= "&$key=".urlencode($stripped);
 		}
 
@@ -608,11 +604,7 @@ class Simple_commerce {
 
 		foreach ($_POST as $key => $value)
 		{
-			// str_replace("\n", "\r\n", $value)
-			// put line feeds back to CR+LF as that's how PayPal sends them out
-			// otherwise multi-line data will be rejected as INVALID
-			// Note: get_magic_quotes_gpc FALSE as of PHP 5.4.0
-			$stripped = (get_magic_quotes_gpc()) ? stripslashes(str_replace("\n", "\r\n", $value)) : str_replace("\n", "\r\n", $value);
+			$stripped = str_replace("\n", "\r\n", $value);
 			$postdata .= "&$key=".urlencode($stripped);
 		}
 

--- a/system/ee/legacy/core/Input.php
+++ b/system/ee/legacy/core/Input.php
@@ -966,12 +966,6 @@ class EE_Input {
 			return $new_array;
 		}
 
-		// We strip slashes if magic quotes is on to keep things consistent
-		if (get_magic_quotes_gpc())
-		{
-			$str = stripslashes($str);
-		}
-
 		// Clean UTF-8 if supported
 		if (UTF8_ENABLED === TRUE)
 		{


### PR DESCRIPTION
## Overview

This addresses #344, and removes the deprecated `get_magic_quotes_gpc` function checks.

Resolves [#344](https://github.com/ExpressionEngine/ExpressionEngine/issues/344).

## Nature of This Change
- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security

## Is this backwards compatible?

- [X] Yes
- [ ] No