### PR TITLE
Fix `strpos` Warning

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -3,10 +3,7 @@
 ExpressionEngine uses semantic versioning. This file contains changes to ExpressionEngine since the last Build / Version release for PATCH version changes only.
 
 ## Patch Release
-
-Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
+- Fixed strpos `Non-string needles will be interpreted as strings in the future.` issue
 
 
 

--- a/system/ee/legacy/models/snippet_model.php
+++ b/system/ee/legacy/models/snippet_model.php
@@ -131,7 +131,7 @@ class Snippet_Entity {
 	 */
 	public function __get($name)
 	{
-		if ( strpos('_', $name) === 0  OR ! property_exists($this, $name))
+		if ( strpos('_', strval($name)) === 0  OR ! property_exists($this, $name))
 		{
 			throw new RuntimeException('Attempt to access non-existent property "' . $name . '"');
 		}
@@ -146,7 +146,7 @@ class Snippet_Entity {
 	 */
 	public function __set($name, $value)
 	{
-		if ( strpos('_', $name) === 0 OR ! property_exists($this, $name))
+		if ( strpos('_', strval($name)) === 0 OR ! property_exists($this, $name))
 		{
 			throw new RuntimeException('Attempt to access non-existent property "' . $name . '"');
 		}

--- a/system/ee/legacy/models/template_model.php
+++ b/system/ee/legacy/models/template_model.php
@@ -1199,7 +1199,7 @@ class Template_Entity {
 	 */
 	public function __get($name)
 	{
-		if ( strpos('_', $name) === 0  OR ! property_exists($this, $name))
+		if ( strpos('_', strval($name)) === 0  OR ! property_exists($this, $name))
 		{
 			throw new RuntimeException('Attempt to access non-existent property "' . $name . '"');
 		}
@@ -1212,7 +1212,7 @@ class Template_Entity {
 	 */
 	public function __set($name, $value)
 	{
-		if ( strpos('_', $name) === 0 OR ! property_exists($this, $name))
+		if ( strpos('_', strval($name)) === 0 OR ! property_exists($this, $name))
 		{
 			throw new RuntimeException('Attempt to access non-existent property "' . $name . '"');
 		}
@@ -1299,7 +1299,7 @@ class Template_Group_Entity
 	 */
 	public function __get($name)
 	{
-		if ( strpos('_', $name) === 0  OR ! property_exists($this, $name))
+		if ( strpos('_', strval($name)) === 0  OR ! property_exists($this, $name))
 		{
 			throw new RuntimeException('Attempt to access non-existent property "' . $name . '"');
 		}
@@ -1312,7 +1312,7 @@ class Template_Group_Entity
 	 */
 	public function __set($name, $value)
 	{
-		if ( strpos('_', $name) === 0 OR ! property_exists($this, $name))
+		if ( strpos('_', strval($name)) === 0 OR ! property_exists($this, $name))
 		{
 			throw new RuntimeException('Attempt to access non-existent property "' . $name . '"');
 		}


### PR DESCRIPTION
## Overview

Fixes strpos `Non-string needles will be interpreted as strings in the future.` notice in PHP7.3 and higher.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#346 ](https://github.com/ExpressionEngine/ExpressionEngine/issues/346).

## Nature of This Change
- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security

## Is this backwards compatible?

- [X] Yes
- [ ] No