### PR TITLE
Feature/add new options to form declaration

### DIFF
--- a/changelogs/minor.md
+++ b/changelogs/minor.md
@@ -4,9 +4,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 
 ## Minor Release
 
-Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
+- Added ability to add new parameters to form declaration (form_declaration function now accepts an additional array of parameters after the initial data, for use with data attributes, target, or other JavaScript actions)
 
 
 

--- a/system/ee/legacy/libraries/Functions.php
+++ b/system/ee/legacy/libraries/Functions.php
@@ -415,10 +415,11 @@ class EE_Functions {
 	 * This function is used by modules when they need to create forms
 	 *
 	 * @access	public
-	 * @param	string
+	 * @param	array $data
+	 * @param   array $extra (used for additional tags in form, defaults to empty)
 	 * @return	string
 	 */
-	public function form_declaration($data)
+	public function form_declaration($data, $extra = [])
 	{
 		// Load the form helper
 		ee()->load->helper('form');
@@ -488,6 +489,13 @@ class EE_Functions {
 			$data['action'] = substr($data['action'], 0, -1);
 		}
 
+		// Create extra attributes string
+		$extraString = '';
+
+		foreach ($extra as $extraAttribute => $extraValue) {
+			$extraString .= $extraAttribute . '="' . addslashes($extraValue) . '" ';
+		}
+
 		$data['name']	= (isset($data['name']) && $data['name'] != '') ? 'name="'.$data['name'].'" '	: '';
 		$data['id']		= ($data['id'] != '') 							? 'id="'.$data['id'].'" ' 		: '';
 		$data['class']	= ($data['class'] != '')						? 'class="'.$data['class'].'" '	: '';
@@ -497,7 +505,7 @@ class EE_Functions {
 			$data['enctype'] = 'enctype="multipart/form-data" ';
 		}
 
-		$form  = '<form '.$data['id'].$data['class'].$data['name'].'method="post" action="'.$data['action'].'" '.$data['onsubmit'].' '.$data['enctype'].">\n";
+		$form  = '<form '.$data['id'].$data['class'].$data['name'].'method="post" action="'.$data['action'].'" '.$data['onsubmit'].' '.$data['enctype']. ' ' . $extraString . ">\n";
 
 		if ($data['secure'] == TRUE)
 		{


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Adds the ability to add additional parameters to `form_declaration` functions. Updated function will accept an additional array that will allow for use with data attributes, target, or other JavaScript actions.

For example:
```
$form_details = array(
    'action'          => '',
    'name'            => 'upload',
    'id'              => ee()->TMPL->form_id,
    'class'           => ee()->TMPL->form_class,
    'hidden_fields'   => array('new' => 'y'),
    'secure'          => TRUE,
    'onsubmit'        => "validate_form(); return false;"
);

$form_extras = array(
	'target'		=> '_blank',
	'data-id'		=> 'awesome-form',
	'autocomplete'	=> 'off',
);

$r = ee()->functions->form_declaration($form_details, $form_extras);
```
## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [X] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No