### PR TITLE
Adding check for hooks that should run

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -5,8 +5,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 ## Patch Release
 
 Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
+- Fixes bug where `after_channel_entry_save` hook would run twice.
 
 
 

--- a/system/ee/EllisLab/ExpressionEngine/Service/Model/Model.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Model/Model.php
@@ -68,6 +68,11 @@ class Model extends SerializableEntity implements Subscriber, ValidationAware {
 	protected $_foreign_keys = array();
 
 	/**
+	 * @var check if entry has saved already. Used in hooks
+	 */
+	protected $_has_saved = false;
+
+	/**
 	 * @var Type names and their corresponding classes
 	 */
 	protected static $_type_classes = array(
@@ -600,6 +605,9 @@ class Model extends SerializableEntity implements Subscriber, ValidationAware {
 
 		foreach ($forwarded as $event => $hook)
 		{
+
+			if(!$this->hookShouldTrigger($hook)) continue; 
+
 			$this->on($event, function() use ($trigger, $hook, $that)
 			{
 				$addtl_args = func_get_args();
@@ -608,6 +616,28 @@ class Model extends SerializableEntity implements Subscriber, ValidationAware {
 				call_user_func_array($trigger, array_merge($args, $addtl_args));
 			});
 		}
+	}
+
+	/**
+	 * checks if designated hook should fitre
+	 * @param  string $hook    Name of hook
+	 * @return boolean
+	 */
+	protected function hookShouldTrigger($hook)
+	{
+
+		$process = true;
+
+		if($hook == 'after_channel_entry_save') {
+			
+			if($this->_has_saved) $process = false;
+
+			$this->_has_saved = true;
+			
+		}
+
+		return $process;
+
 	}
 
 	/**


### PR DESCRIPTION
## Overview

This addresses #248, where the `after_channel_entry_save` extension hook would run twice when saving a new channel entry.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#248 ](https://github.com/ExpressionEngine/ExpressionEngine/issues/248).

## Nature of This Change

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No

## Documentation

From what I see, this hook was firing twice due to the `save` function in `EllisLab\ExpressionEngine\Service\Model\Model.php`. The `save` function fires the hook immediately upon invoking this function. When creating a new channel entry, the `insert` method is called on the facade. It appears that, when this happens, it runs through `updateEntryStats` in ChannelEntry.php, which then reruns the save function above, but this time updates the entry. The save hooks are being called twice.

The check I added checks against the specific object that is created to see if it is processed; if the save hook has already run, it won't run it again.

I'm not _entirely_ sure this is the most elegant solution, so I gladly welcome any feedback.