### PR TITLE
Bug/147 system on by update

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -5,8 +5,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 ## Patch Release
 
 Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
+   - Adding `is_system_on` setting caching, so updating does not alter whether the system is on after updating or bailing
 
 
 

--- a/system/ee/EllisLab/ExpressionEngine/Service/Updater/Runner.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Updater/Runner.php
@@ -72,7 +72,11 @@ class Runner {
 		$unpacker->moveUpdater();
 
 		$this->logger->log('Taking the site offline');
-		ee('Config')->getFile()->set('is_system_on', 'n', TRUE);
+
+		// We'll save the current system on setting
+		$config = ee('Config')->getFile();
+		$config->set('is_system_on_before_updater', $config->get('is_system_on', 'y'));
+		$config->set('is_system_on', 'n', TRUE);
 	}
 
 	public function rollback()

--- a/system/ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/Runner.php
+++ b/system/ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/Runner.php
@@ -208,7 +208,7 @@ class Runner {
 	public function selfDestruct($rollback = NULL)
 	{
 		$config = ee('Config')->getFile();
-		$config->set('is_system_on', 'y', TRUE);
+		$config->set('is_system_on', $config->get('is_system_on_before_updater', 'y'), TRUE);
 		$config->set('app_version', APP_VER, TRUE);
 
 		// Legacy logger lib to log to update_log table


### PR DESCRIPTION
## Overview

Adds check for `is_system_on` during updating process, so this setting is not changed once updating is complete. Initially, this defaulted to `y` once the process had completed or failed.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#147](https://github.com/ExpressionEngine/ExpressionEngine/issues/147).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No