### PR TITLE
Bug/337 url title n

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -5,10 +5,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 ## Patch Release
 
 Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
-
-
+	- Ignores url_title in fetch param function, for issues related to URL titles called `n`
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -109,6 +109,8 @@ class EE_Template {
 
 	protected $modified_vars      = FALSE;
 
+	protected $ignore_fetch		  = [ 'url_title' ];
+
 	/**
 	 * Constructor
 	 *
@@ -1903,6 +1905,13 @@ class EE_Template {
 	 */
 	public function fetch_param($which, $default = FALSE)
 	{
+
+		if(in_array($which, $this->ignore_fetch)) {
+
+			return $this->tagparams[$which];
+
+		}
+
 		if ( ! isset($this->tagparams[$which]))
 		{
 			return $default;


### PR DESCRIPTION
## Overview

Ignores url title in fetch_param function, catching all URL titles in query. For use in url titles called `n`. Thanks @litzinger for the code on this one!

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#337](https://github.com/ExpressionEngine/ExpressionEngine/issues/337).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No