### PR TITLE
Bug/190 consent return

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -5,8 +5,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 ## Patch Release
 
 Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
+   - Added default to same page for consent return
 
 
 

--- a/system/ee/EllisLab/Addons/consent/mod.consent.php
+++ b/system/ee/EllisLab/Addons/consent/mod.consent.php
@@ -155,7 +155,9 @@ class Consent {
 		else
 		{
 			$this->setAlertFlashdata('success', $message);
-			$return = ee('Encrypt')->decode(ee()->input->post('RET'));
+			$return = ee()->input->post('RET')
+						? ee('Encrypt')->decode(ee()->input->post('RET'))
+						: ee()->functions->form_backtrack(1);
 			ee()->functions->redirect(ee()->functions->create_url($return));
 		}
 	}


### PR DESCRIPTION
## Overview

Adds default to same page for consent forms without return parameter.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#190](https://github.com/ExpressionEngine/ExpressionEngine/issues/190).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No