### PR TITLE
321/pages uri template validation

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -5,8 +5,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 ## Patch Release
 
 Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
+   - Adds validation for pages URIs without a selected template
 
 
 

--- a/system/ee/EllisLab/Addons/pages/tab.pages.php
+++ b/system/ee/EllisLab/Addons/pages/tab.pages.php
@@ -140,16 +140,41 @@ class Pages_tab {
 	public function validate($entry, $values)
 	{
 		$validator = ee('Validation')->make(array(
-			'pages_template_id' => 'validTemplate',
-			'pages_uri' => 'validURI|validSegmentCount|notDuplicated',
+			'pages_template_id' => 'validTemplate|validHasTemplate',
+			'pages_uri' => 'validURI|validHasTemplate|validSegmentCount|notDuplicated',
 		));
 
 		$validator->defineRule('validTemplate', $this->makeValidTemplateRule($values));
 		$validator->defineRule('validURI', $this->makeValidURIRule());
 		$validator->defineRule('validSegmentCount', $this->makeValidSegmentCountRule());
 		$validator->defineRule('notDuplicated', $this->makeNotDuplicatedRule($entry));
+		$validator->defineRule('validHasTemplate', $this->makeValidHasTemplateRule($values));
 
 		return $validator->validate($values);
+	}
+
+	/**
+	 * Validates whether a pages URI has been selected with a template
+	 * @param  array 	$values array of pages values coming from tab
+	 * @return Closure The logic needed to validate the data.
+	 */
+	private function makeValidHasTemplateRule($values)
+	{
+
+		return function($field, $value) use($values)
+		{
+
+			if(
+				$values['pages_uri'] === ""
+				|| ($values['pages_uri'] !== "" && $values['pages_template_id'] === ""))
+			{
+				return 'invalid_template';
+			}
+
+			return true;
+
+		};
+
 	}
 
 	/**


### PR DESCRIPTION
## Overview

Adds validation for pages URI, checking that, if a pages URI is added, a template is selected as well.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#321](https://github.com/ExpressionEngine/ExpressionEngine/issues/321).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No