### PR TITLE
Updates for PHP 7.4 compatibility

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -3,9 +3,19 @@
 ExpressionEngine uses semantic versioning. This file contains changes to ExpressionEngine since the last Build / Version release for PATCH version changes only.
 
 ## Patch Release
-    - Updates six (6) files for PHP 7.4 compatibility.
-
-
-
+- Updates six (6) files for PHP 7.4 compatibility.
+    - system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelLayout.php
+        - Ternary check on $field_name
+    - system/ee/EllisLab/Addons/channel/mod.channel.php
+        - Swap implode parameter order
+    - system/ee/EllisLab/Addons/rte/libraries/Rte_lib.php
+        - Ternary check on $include['jquery_ui']
+    - system/ee/legacy/libraries/channel_entries_parser/components/Category.php
+        - Ternary check on $cat_image['url']
+    - system/ee/legacy/libraries/Template.php
+        - Ternary checks for $last_time and $last_memory
+    - system/ee/legacy/core/Input.php
+        - PHP version check for magic_quotes_gpc
+    
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -3,10 +3,7 @@
 ExpressionEngine uses semantic versioning. This file contains changes to ExpressionEngine since the last Build / Version release for PATCH version changes only.
 
 ## Patch Release
-
-Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
+    - Updates six (6) files for PHP 7.4 compatibility.
 
 
 

--- a/system/ee/EllisLab/Addons/channel/mod.channel.php
+++ b/system/ee/EllisLab/Addons/channel/mod.channel.php
@@ -461,7 +461,7 @@ class Channel {
 				return;
 			}
 
-			$sql .= implode(array_unique(array_filter($categories)), ',') . ')';
+			$sql .= implode(',', array_unique(array_filter($categories))) . ')';
 
 			$sql .= " ORDER BY c.group_id, c.parent_id, c.cat_order";
 
@@ -2427,7 +2427,7 @@ class Channel {
 		//cache the entry_id
 		ee()->session->cache['channel']['entry_ids'] = $entries;
 
-		$end = "ORDER BY FIELD(t.entry_id, " . implode($entries, ',') . ")";
+		$end = "ORDER BY FIELD(t.entry_id, " . implode(',', $entries) . ")";
 
 		// modify the ORDER BY if displaying by week
 		if ($this->display_by == 'week' && isset($yearweek))
@@ -2521,7 +2521,7 @@ class Channel {
 
 		$sql .= $from;
 
-		$sql .= "WHERE t.entry_id IN (" . implode($entries, ',') . ")";
+		$sql .= "WHERE t.entry_id IN (" . implode(',', $entries) . ")";
 		return $sql;
 	}
 

--- a/system/ee/EllisLab/Addons/rte/libraries/Rte_lib.php
+++ b/system/ee/EllisLab/Addons/rte/libraries/Rte_lib.php
@@ -330,7 +330,9 @@ class Rte_lib {
 			'libraries' 	=> array(
 				'plugin' => array('wysihat')
 			)
-		);
+    );
+    
+    $include['jquery_ui'] = isset($include['jquery_ui']) ? $include['jquery_ui'] : false;
 
 		if ($include['jquery_ui'])
 		{

--- a/system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelLayout.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelLayout.php
@@ -196,7 +196,7 @@ class ChannelLayout extends Model implements LayoutInterface {
 		{
 			foreach ($section['fields'] as $j => $field_info)
 			{
-				$field_name = $field_info['field'];
+				$field_name = isset($field_info['field']) ? $field_info['field'] : 0;
 
 				if (strpos($field_name, 'field_id_') !== 0)
 				{

--- a/system/ee/legacy/core/Input.php
+++ b/system/ee/legacy/core/Input.php
@@ -966,11 +966,13 @@ class EE_Input {
 			return $new_array;
 		}
 
-		// We strip slashes if magic quotes is on to keep things consistent
-		if (get_magic_quotes_gpc())
-		{
-			$str = stripslashes($str);
-		}
+    // We strip slashes if magic quotes is on to keep things consistent
+    
+    if (version_compare(phpversion(), '7.4.0', '<')) {
+      if (get_magic_quotes_gpc()){
+        $str = stripslashes($str);
+      }
+    }
 
 		// Clean UTF-8 if supported
 		if (UTF8_ENABLED === TRUE)

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -2968,7 +2968,7 @@ class EE_Template {
 			'edit_date'				=> ee()->localize->now,
 			'last_author_id'		=> '1',	// assume a super admin
 			'site_id'				=> ee()->config->item('site_id')
-		 );
+		);
 
 		$template_id = ee()->template_model->create_template($data);
 
@@ -3524,11 +3524,12 @@ class EE_Template {
 		$time = microtime(TRUE)-$this->start_microtime;
 
 		$memory_usage = memory_get_usage();
-
 		$last = end($this->log);
-		$time = number_format($time, 6);
-		$time_gain = $time - $last['time'];
-		$memory_gain = $memory_usage - $last['memory'];
+    $time = number_format($time, 6);
+    $last_time = isset($last['time']) ? $last['time'] : 0;
+    $time_gain = $time - $last_time;
+    $last_memory = isset($last['memory']) ? $last['memory'] : 0;
+		$memory_gain = $memory_usage - $last_memory;
 
 		$this->log[] = array(
 			'time' => $time,

--- a/system/ee/legacy/libraries/channel_entries_parser/components/Category.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Category.php
@@ -202,7 +202,7 @@ class EE_Channel_category_parser implements EE_Channel_parser_component {
 						'category_url_title'     => $v[6],
 						'category_description'   => (isset($v[4])) ? ee()->functions->encode_ee_tags($v[4]) : '',
 						'category_group'         => (isset($v[5])) ? $v[5] : '',
-						'category_image'         => $cat_image['url'],
+						'category_image'         => (isset($cat_image['url'])) ? $cat_image['url'] : '',
 						'category_id'            => $v[0],
 						'parent_id'              => $v[1],
 						'active'                 => ($active_cat == $v[0] || $active_cat == $v[6])

--- a/system/ee/legacy/libraries/typography/Markdown/Michelf/Markdown.php
+++ b/system/ee/legacy/libraries/typography/Markdown/Michelf/Markdown.php
@@ -797,7 +797,7 @@ class Markdown implements MarkdownInterface {
 		if ($matches[2] == '-' && preg_match('{^-(?: |$)}', $matches[1]))
 			return $matches[0];
 		
-		$level = $matches[2]{0} == '=' ? 1 : 2;
+		$level = $matches[2][0] == '=' ? 1 : 2;
 
 		# id attribute generation
 		$idAtt = $this->_generateIdFromHeaderValue($matches[1]);
@@ -1137,7 +1137,7 @@ class Markdown implements MarkdownInterface {
 				} else {
 					# Other closing marker: close one em or strong and
 					# change current token state to match the other
-					$token_stack[0] = str_repeat($token{0}, 3-$token_len);
+					$token_stack[0] = str_repeat($token[0], 3-$token_len);
 					$tag = $token_len == 2 ? "strong" : "em";
 					$span = $text_stack[0];
 					$span = $this->runSpanGamut($span);
@@ -1162,7 +1162,7 @@ class Markdown implements MarkdownInterface {
 				} else {
 					# Reached opening three-char emphasis marker. Push on token 
 					# stack; will be handled by the special condition above.
-					$em = $token{0};
+					$em = $token[0];
 					$strong = "$em$em";
 					array_unshift($token_stack, $token);
 					array_unshift($text_stack, '');
@@ -1527,9 +1527,9 @@ class Markdown implements MarkdownInterface {
 	# Handle $token provided by parseSpan by determining its nature and 
 	# returning the corresponding value that should replace it.
 	#
-		switch ($token{0}) {
+		switch ($token[0]) {
 			case "\\":
-				return $this->hashPart("&#". ord($token{1}). ";");
+				return $this->hashPart("&#". ord($token[1]). ";");
 			case "`":
 				# Search for end marker in remaining text.
 				if (preg_match('/^(.*?[^`])'.preg_quote($token).'(?!`)(.*)$/sm', 

--- a/system/ee/legacy/libraries/typography/Markdown/Michelf/MarkdownExtra.php
+++ b/system/ee/legacy/libraries/typography/Markdown/Michelf/MarkdownExtra.php
@@ -160,9 +160,9 @@ class MarkdownExtra extends \Michelf\Markdown {
 		$attributes = array();
 		$id = false;
 		foreach ($elements as $element) {
-			if ($element{0} == '.') {
+			if ($element[0] == '.') {
 				$classes[] = substr($element, 1);
-			} else if ($element{0} == '#') {
+			} else if ($element[0] == '#') {
 				if ($id === false) $id = substr($element, 1);
 			} else if (strpos($element, '=') > 0) {
 				$parts = explode('=', $element, 2);
@@ -431,7 +431,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 			#
 			# Check for: Indented code block.
 			#
-			else if ($tag{0} == "\n" || $tag{0} == " ") {
+			else if ($tag[0] == "\n" || $tag[0] == " ") {
 				# Indented code block: pass it unchanged, will be handled 
 				# later.
 				$parsed .= $tag;
@@ -440,7 +440,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 			# Check for: Code span marker
 			# Note: need to check this after backtick fenced code blocks
 			#
-			else if ($tag{0} == "`") {
+			else if ($tag[0] == "`") {
 				# Find corresponding end marker.
 				$tag_re = preg_quote($tag);
 				if (preg_match('{^(?>.+?|\n(?!\n))*?(?<!`)'.$tag_re.'(?!`)}',
@@ -478,7 +478,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 			#            HTML Comments, processing instructions.
 			#
 			else if (preg_match('{^<(?:'.$this->clean_tags_re.')\b}', $tag) ||
-				$tag{1} == '!' || $tag{1} == '?')
+				$tag[1] == '!' || $tag[1] == '?')
 			{
 				# Need to parse tag and following text using the HTML parser.
 				# (don't check for markdown attribute)
@@ -497,8 +497,8 @@ class MarkdownExtra extends \Michelf\Markdown {
 				#
 				# Increase/decrease nested tag count.
 				#
-				if ($tag{1} == '/')						$depth--;
-				else if ($tag{strlen($tag)-2} != '/')	$depth++;
+				if ($tag[1] == '/')						$depth--;
+				else if ($tag[strlen($tag)-2] != '/')	$depth++;
 
 				if ($depth < 0) {
 					#
@@ -602,7 +602,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 				# first character as filtered to prevent an infinite loop in the 
 				# parent function.
 				#
-				return array($original_text{0}, substr($original_text, 1));
+				return array($original_text[0], substr($original_text, 1));
 			}
 			
 			$block_text .= $parts[0]; # Text before current tag.
@@ -614,7 +614,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 			#			 Comments and Processing Instructions.
 			#
 			if (preg_match('{^</?(?:'.$this->auto_close_tags_re.')\b}', $tag) ||
-				$tag{1} == '!' || $tag{1} == '?')
+				$tag[1] == '!' || $tag[1] == '?')
 			{
 				# Just add the tag to the block as if it was text.
 				$block_text .= $tag;
@@ -625,8 +625,8 @@ class MarkdownExtra extends \Michelf\Markdown {
 				# the tag's name match base tag's.
 				#
 				if (preg_match('{^</?'.$base_tag_name_re.'\b}', $tag)) {
-					if ($tag{1} == '/')						$depth--;
-					else if ($tag{strlen($tag)-2} != '/')	$depth++;
+					if ($tag[1] == '/')						$depth--;
+					else if ($tag[strlen($tag)-2] != '/')	$depth++;
 				}
 				
 				#
@@ -990,7 +990,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 		if ($matches[3] == '-' && preg_match('{^- }', $matches[1]))
 			return $matches[0];
 
-		$level = $matches[3]{0} == '=' ? 1 : 2;
+		$level = $matches[3][0] == '=' ? 1 : 2;
 
 		$defaultId = is_callable($this->header_id_func) ? call_user_func($this->header_id_func, $matches[1]) : null;
 
@@ -1334,7 +1334,7 @@ class MarkdownExtra extends \Michelf\Markdown {
 
 		$classes = array();
 		if ($classname != "") {
-			if ($classname{0} == '.')
+			if ($classname[0] == '.')
 				$classname = substr($classname, 1);
 			$classes[] = $this->code_class_prefix.$classname;
 		}


### PR DESCRIPTION
## Overview

***NEEDS TESTING***

This collection updates just a few lines for PHP 7.4 errors/warnings/deprecation notices.

It's basically just a few ternary statements to make sure something exists before it's called (various files), plus little syntax adjustments in one file (mod.channel.php), and a PHP version check for magic_quotes in another (Input.php).

Changed files include:

system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelLayout.php
system/ee/EllisLab/Addons/channel/mod.channel.php
system/ee/EllisLab/Addons/rte/libraries/Rte_lib.php
system/ee/legacy/libraries/channel_entries_parser/components/Category.php
system/ee/legacy/libraries/Template.php
system/ee/legacy/core/Input.php

## Is this backwards compatible?

Needs proper testing with PHP 5.6 - 7.3.