### PR TITLE
fixes "Log file path not writable" error on Windows 

### DIFF
--- a/system/ee/installer/updater/boot.php
+++ b/system/ee/installer/updater/boot.php
@@ -30,6 +30,14 @@ else
 	}
 }
 
+// add EE constants
+$constants = require SYSPATH.'ee/EllisLab/ExpressionEngine/Config/constants.php';
+
+foreach ($constants as $k => $v) {
+	if ( ! defined($k)) {
+		define($k, $v);
+	}
+}
 
 /*
  * ------------------------------------------------------


### PR DESCRIPTION
when using 1-click updater

## Overview

When performing 1-click update on Windows, one was getting this error: `Log file path not writable: C:\inetpub\wwwroot\ee531\system/user/cache/ee_update`
The reason is code referencing undefined constants in libraries used in updater. This add all EE constants to updater boot file

## Nature of This Change

- [x ] 🐛 Fixes a bug

## Is this backwards compatible?

- [x ] Yes
