### PR TITLE
Bug/grid compatibility error

### DIFF
--- a/changelogs/minor.md
+++ b/changelogs/minor.md
@@ -4,6 +4,8 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 
 ## Minor Release
 
+   - Fixed a bug (#428) where Grid was throwing error PHP with certain fieldtypes.
+
 Bullet list below, e.g.
    - Added <new feature>
    - Fixed a bug (#<linked issue number>) where <bug behavior>.

--- a/system/ee/EllisLab/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/EllisLab/Addons/grid/libraries/Grid_lib.php
@@ -678,7 +678,9 @@ class Grid_lib {
 			// Check to see if the fieldtype accepts Grid as a content type;
 			// also, temporarily exlcude Relationships for content types
 			// other than channel
-			if ( ! $fieldtype->accepts_content_type('grid') ||
+			if (empty($fieldtype) ||
+				! method_exists($fieldtype, 'accepts_content_type') ||
+				! $fieldtype->accepts_content_type('grid') ||
 				($this->content_type != 'channel' && $field_short_name == 'relationship'))
 			{
 				unset($fieldtypes[$field_short_name], $compatibility[$field_short_name]);


### PR DESCRIPTION


<!-- What's in this pull request? -->
## Overview

Fixed a bug where Grid was throwing error PHP with certain fieldtypes.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves #428

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug

## Is this backwards compatible?

- [x] Yes