### PR TITLE
Feature/category validation

### DIFF
--- a/changelogs/minor.md
+++ b/changelogs/minor.md
@@ -4,6 +4,8 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 
 ## Minor Release
 
+   - Added validation for category parent (#411)
+
 Bullet list below, e.g.
    - Added <new feature>
    - Fixed a bug (#<linked issue number>) where <bug behavior>.

--- a/system/ee/EllisLab/ExpressionEngine/Model/Category/Category.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Category/Category.php
@@ -70,7 +70,8 @@ class Category extends ContentModel {
 		'cat_name'			=> 'required|noHtml|xss',
 		'cat_url_title'		=> 'required|alphaDash|unique[group_id]',
 		'cat_description'	=> 'xss',
-		'cat_order'			=> 'isNaturalNoZero'
+		'cat_order'			=> 'isNaturalNoZero',
+		'parent_id'			=> 'validateParentCategory'
 	);
 
 	protected static $_events = array(
@@ -168,6 +169,26 @@ class Category extends ContentModel {
 		}
 
 		return new Collection($children);
+	}
+
+	/**
+	 * Validate parent category
+	 * cannot set parent to self, of category from other group/site
+	 */
+	public function validateParentCategory($key, $value, $params, $rule) {
+		if (!empty($this->cat_id) && !empty($value)) {
+			if ($value == $this->cat_id) {
+				return lang('category_parent_invalid');
+			}
+			$parent = $this->getModelFacade()->get('Category', $value)
+				->filter('group_id', $this->getProperty('group_id'))
+				->filter('site_id', $this->getProperty('site_id'))
+				->first();
+			if (empty($parent)) {
+				return lang('category_parent_invalid');
+			}
+		}
+		return true;
 	}
 }
 

--- a/system/ee/legacy/language/english/channel_lang.php
+++ b/system/ee/legacy/language/english/channel_lang.php
@@ -488,6 +488,8 @@ $lang = array(
 
 'category_updated_desc' => 'The category <b>%s</b> has been updated.',
 
+'category_parent_invalid' => 'Category parent needs to be in same group and different from the category itself',
+
 'create_category' => 'Create Category',
 
 'create_category_btn' => 'Create New Category',


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Added validation for category parent.
Makes sure category cannot set parent to self, of category from other group/site
<!-- If this pull request resolves a project issue, provide a link: -->
Resolves #411

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🚀 Implements a new feature

## Is this backwards compatible?

- [x] Yes
