### PR TITLE
Feature/pass thru parameters to html forms as attributes

### DIFF
--- a/changelogs/minor.md
+++ b/changelogs/minor.md
@@ -4,13 +4,10 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 
 ## Minor Release
 
-- Fixed a bug where checking for updates might produce an error.
-- Fixed a bug where removing database record for template that is used as "No access redirect" would cause error
+- Added new feature to allow HTML Form attributes to be specified as parameters in the EE tag creating the form
 
 Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
-
+   - Added new feature to allow HTML Form attributes to be specified as parameters in the EE tag creating the form (address [issue #441](https://github.com/ExpressionEngine/ExpressionEngine/issues/441))
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (release/next-minor) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

This fixes a couple of minor errors in original code for the function `form_declaration` in Functions.php

It also adds a new attribute pass-through function.  When called the function inspects the current tagparams and if any of the parameters specified match valid HTML attributes for use in a form it creates these in the opening <FORM> tag including the parameter value as an attribute value if one is provided.  

If one of the parameters specified in the tag matches one that is also assigned because of information passed from calling function the value from the calling function is given priority.  

So, for example, if the calling function specifies a value for an attribute (e.g. `id="form"`) a separately specified parameter within the tag with the same name (e.g. `id="stuff"`) will be ignored.

The only exception to this case is for attribute `class`.  In this case the value of an additional `class` parameter is appended to any value for `class` generated from information provided by the calling function.

So a tag with this construction
```
{exp:search:simple_form 
    channel="articles" 
    url_title="eric" 
    role="main"
    aria-role="form"
    id="testing"
    onstalled="cats"
    form_class="whoop"
    class="it up"
    data-Stuff="and nonsense" 
    hidden
    return="{current_path}"
}
```
will generate this output (reformated to ease legibility)
```
<form 
    id="testing" 
    class="whoop it up"  <--- Note class elements are combined
    method="post" 
    action="https://2gc.jcogs.net/" 
    role="main"               <--- Note these additional parameters 'passed through' to HTML tag
    aria-role="form" 
    onstalled="cats" 
    data-stuff="and nonsense"
>
```
If no value is assigned to the parameter in the EE tag (e.g. `{exp... novalidate}` rather than `{exp... novalidate=""}`) the value is ignored since EE does not pass this element through tagparams.

If a parameter is assigned a null value (e.g. `{exp... novalidate=""}`) it is passed through to the HTML form as a simple token (e.g. `<form ... novalidate>`).

The list of valid attributes for HTML FORM elements combines attributes for [FORM]([https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form]), [HTML Global Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes) and [ARIA Search role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role). 

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#441](https://github.com/ExpressionEngine/ExpressionEngine/issues/441).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [X] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No

## Documentation
<!-- Required for new features -->

User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/minor.rst (release/next-minor)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
