### PR TITLE
Added support for Cloudflare forwarding IP headers

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -4,11 +4,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 
 ## Patch Release
 
-Bullet list below, e.g.
-   - Fixed a bug (#[406](https://github.com/ExpressionEngine/ExpressionEngine/issues/406)) where missing iconv extension was causing issues.
-
-   - Fixed a bug ([#399](https://github.com/ExpressionEngine/ExpressionEngine/issues/399)) in the Page's tab where setting a default template forced the Page URI field to be required.
-   - Updates additional files for PHP 7.4 compatibility.
+   - Added support for Cloudflare forwarding IP headers, e.g. HTTP_CF_CONNECTING_IP
     
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/EllisLab/Addons/comment/mod.comment.php
+++ b/system/ee/EllisLab/Addons/comment/mod.comment.php
@@ -2,6 +2,7 @@
 
 namespace EllisLab\Addons\Comment;
 
+use EE_Input;
 use EllisLab\Addons\Comment\Service\Notifications;
 use EllisLab\Addons\Comment\Service\Variables\Comment as CommentVars;
 
@@ -1582,7 +1583,7 @@ class Comment {
 
 		if (ee()->config->item('require_ip_for_posting') == 'y')
 		{
-			if (ee()->input->ip_address() == '0.0.0.0' OR ee()->session->userdata['user_agent'] == "")
+			if (ee()->input->ip_address() == EE_Input::DEFAULT_IP_ADDRESS OR ee()->session->userdata['user_agent'] == "")
 			{
 				return ee()->output->show_user_error('general', array(ee()->lang->line('not_authorized')));
 			}

--- a/system/ee/EllisLab/Addons/forum/mod.forum_core.php
+++ b/system/ee/EllisLab/Addons/forum/mod.forum_core.php
@@ -5524,7 +5524,7 @@ class Forum_Core extends Forum {
 	 	// Is the IP or User Agent unavalable?
 		if (ee()->config->item('require_ip_for_posting') == 'y')
 		{
-			if (ee()->input->ip_address() == '0.0.0.0' OR ee()->session->userdata['user_agent'] == "")
+			if (ee()->input->ip_address() == EE_Input::DEFAULT_IP_ADDRESS OR ee()->session->userdata['user_agent'] == "")
 			{
 				return $this->trigger_error();
 			}

--- a/system/ee/EllisLab/ExpressionEngine/Controller/Utilities/MemberImport.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Utilities/MemberImport.php
@@ -10,6 +10,8 @@
 
 namespace EllisLab\ExpressionEngine\Controller\Utilities;
 
+use EE_Input;
+
 /**
  * Member Import Controller
  */
@@ -685,7 +687,7 @@ class MemberImport extends Utilities {
 		$this->default_fields['date_format']		= $this->input->post('date_format') ?: NULL;
 		$this->default_fields['time_format']		= $this->input->post('time_format') ?: NULL;
 		$this->default_fields['include_seconds']	= $this->input->post('include_seconds') ?: NULL;
-		$this->default_fields['ip_address']			= '0.0.0.0';
+		$this->default_fields['ip_address']			= EE_Input::DEFAULT_IP_ADDRESS;
 		$this->default_fields['join_date']			= $this->localize->now;
 
 		//  Rev it up, no turning back!

--- a/system/ee/legacy/libraries/Messages_send.php
+++ b/system/ee/legacy/libraries/Messages_send.php
@@ -387,7 +387,7 @@ class EE_Messages_send extends EE_Messages {
 		/** ----------------------------------------*/
 		if (ee()->config->item('require_ip_for_posting') == 'y')
 		{
-			if (ee()->input->ip_address() == '0.0.0.0' OR ee()->session->userdata['user_agent'] == '')
+			if (ee()->input->ip_address() == EE_Input::DEFAULT_IP_ADDRESS OR ee()->session->userdata['user_agent'] == '')
 			{
 				return $this->_error_page();
 			}

--- a/system/ee/legacy/libraries/Throttling.php
+++ b/system/ee/legacy/libraries/Throttling.php
@@ -58,8 +58,7 @@ class EE_Throttling {
 
  	function throttle_ip_check()
  	{
-		if (ee()->config->item('banish_masked_ips') == 'y' AND ee()->input->ip_address() == '0.0.0.0' OR ee()->input->ip_address() == '')
-		{
+		if (ee()->config->item('banish_masked_ips') == 'y' && ee()->input->ip_address() == EE_Input::DEFAULT_IP_ADDRESS || ee()->input->ip_address() == '') {
 			$this->banish();
 		}
   	}


### PR DESCRIPTION
This PR was inspired by an article found on dev.to https://dev.to/rogeriotaques/an-easy-way-to-get-the-real-client-ip-in-php-4pii

## Overview

This PR isn't based on any personal experience with getting IP addresses from behind CF, but I suspect this might be a helpful addition to the codebase. I also updated all references of '0.0.0.0' to use a constant. EE uses too many repeated scalar values like this this throughout the codebase, and they should be cleaned up. This is a start.

## Nature of This Change

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [x] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation

I don't think this requires a documentation update, but I could be wrong.