### PR TITLE
Bug/disabled extensions management

### DIFF
--- a/changelogs/minor.md
+++ b/changelogs/minor.md
@@ -5,8 +5,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 ## Minor Release
 
 Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
+   - Fixed a bug (#480) where there has been no notice when extensions are disabled.
 
 
 

--- a/system/ee/EllisLab/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Addons/Addons.php
@@ -177,6 +177,14 @@ class Addons extends CP_Controller {
 			'third' => lang('third_party_addons')
 		);
 
+		if (ee()->config->item('allow_extensions') == 'n') {
+			ee('CP/Alert')->makeInline('extensions')
+				->asWarning()
+				->withTitle(lang('extensions_disabled'))
+				->addToBody(lang('extensions_disabled_message'))
+				->now();
+		}
+
 		$vars = array(
 			'tables' => array(
 				'first' => NULL,

--- a/system/ee/EllisLab/ExpressionEngine/Controller/Utilities/Extensions.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Utilities/Extensions.php
@@ -52,6 +52,14 @@ class Extensions extends Utilities {
 	 */
 	public function index()
 	{
+		if (ee()->config->item('allow_extensions') == 'n') {
+			ee('CP/Alert')->makeInline('extensions')
+				->asWarning()
+				->withTitle(lang('extensions_disabled'))
+				->addToBody(lang('extensions_disabled_message'))
+				->now();
+		}
+
 		if (ee()->input->post('bulk_action') == 'enable')
 		{
 			$this->enable(ee()->input->post('selection'));

--- a/system/ee/legacy/language/english/addons_lang.php
+++ b/system/ee/legacy/language/english/addons_lang.php
@@ -137,6 +137,8 @@ $lang = array(
 
 'extensions_disabled_desc' => 'Extensions have been disabled.',
 
+'extensions_disabled_message' => 'Extensions have been disabled in system configuration, therefore are not present in this list.',
+
 'extensions_disabled_warning' => 'In order to install this add-on you need to enable extensions. Do you want to enable extensions?',
 
 'extensions_enabled' => 'Extensions Enabled',


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Added banner on Addons and Debug Extensions pages that shows up when extensions are globally disabled

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#480](https://github.com/ExpressionEngine/ExpressionEngine/issues/480).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature

## Is this backwards compatible?

- [x] Yes
- [ ] No


