### PR TITLE
Upgrader and CLI features

### DIFF
--- a/changelogs/minor.md
+++ b/changelogs/minor.md
@@ -4,30 +4,8 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 
 ## Minor Release
 
-- Added relationship_entries_tagdata hook, which is functionally identical to the channel_entries_tagdata hook 
-   - Fixed a bug (#383) where Moblog wasn't functioning.
-- Fixed a bug where checking for updates might produce an error.
-- Fixed a bug where removing database record for template that is used as "No access redirect" would cause error
-- Added support for SameSite cookies
-   - Fixed a bug (#438) where JS combo loader was throwing error if extra `v` was passed into URL.
-   - Fixed a bug (#91, #417) where link button was not working and formatting not displayed in RTE field on frontend.
-   - Added validation for category parent (#411)
-   - Fixed a bug (#428) where Grid was throwing error PHP with certain fieldtypes.
-   - Fixed a bug (#421) where attachments were not sent from Communicate page.
-
-Bullet list below, e.g.
-   - Added config override to ignore channel stats
-   - Add stats module action to run stats
-   - Fixed a bug where searching entries in CP in content only could produce SQL error.
-
-
-   - Added dabatase column type selector for textarea and RTE fields (#464)
-   - Added post-upgrade and utility check for broken template tags and missing fieldtypes
-   - Fixed a bug (#480) where there has been no notice when extensions are disabled.
-   - Fixed a bug (#499) where categories hidden from channel layout might get lost upon saving the entry.
-   - Fixed a bug where unsaved entried were not pulled in for live preview when using `status="open|closed"` parameter.
-
-
+- Adds namespacing to v2 upgrades for ease of upgrading from v2 to v5
+- Adds CLI feature
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/eecli
+++ b/eecli
@@ -7,7 +7,7 @@ $system_path = realpath(dirname($_SERVER['SCRIPT_FILENAME'])) . '/system';
 
 if (PHP_SAPI !== 'cli') {
     header('HTTP/1.1 503 Service Unavailable.', true, '503');
-    exit("Invlid request\n");
+    exit("Invalid request\n");
 }
 
 // Error Reporting

--- a/eecli
+++ b/eecli
@@ -1,0 +1,105 @@
+#!/usr/bin/env php
+<?php
+
+define('EE_START', microtime(true));
+
+$system_path = realpath(dirname($_SERVER['SCRIPT_FILENAME'])) . '/system';
+
+if (PHP_SAPI !== 'cli') {
+    header('HTTP/1.1 503 Service Unavailable.', true, '503');
+    exit("Invlid request\n");
+}
+
+// Error Reporting
+$debug = 1;
+
+// Get CLI
+define('REQ', 'CLI');
+
+// Define some server vars, so as not to break anything
+$_SERVER['SERVER_NAME'] = null;
+$_SERVER['REMOTE_ADDR'] = null;
+$_SERVER['HTTP_HOST'] = null;
+
+
+/*
+ * ---------------------------------------------------------------
+ *  Disable all routing, send everything to the frontend
+ * ---------------------------------------------------------------
+ */
+$routing['directory'] = '';
+$routing['controller'] = 'ee';
+$routing['function'] = 'index';
+
+/*
+ * --------------------------------------------------------------------
+ *  Resolve the system path for increased reliability
+ * --------------------------------------------------------------------
+ */
+
+if (realpath($system_path) !== false) {
+    $system_path = realpath($system_path);
+}
+
+$system_path = rtrim($system_path, '/').'/';
+
+/*
+ * --------------------------------------------------------------------
+ *  Now that we know the path, set the main constants
+ * --------------------------------------------------------------------
+ */
+// The name of this file
+defined('SELF') || define('SELF', basename(__FILE__));
+
+// Path to this file
+defined('FCPATH') || define('FCPATH', __DIR__.'/');
+
+// Path to the "system" folder
+defined('SYSPATH') || define('SYSPATH', $system_path);
+
+// Name of the "system folder"
+defined('SYSDIR') || define('SYSDIR', basename($system_path));
+
+// The $debug value as a constant for global access
+defined('DEBUG') || define('DEBUG', $debug);
+
+// If EE is not installed, we will not boot the core, but CLI commands are more limited as well.
+defined('EE_INSTALLED') || define('EE_INSTALLED', file_exists(SYSPATH . 'user/config/config.php'));
+
+/*
+ * --------------------------------------------------------------------
+ *  Set the error reporting level
+ * --------------------------------------------------------------------
+ */
+if (DEBUG == 1) {
+    error_reporting(E_ALL);
+    @ini_set('display_errors', 1);
+} else {
+    error_reporting(0);
+}
+
+// Always turn off HTML Errors
+ini_set('html_errors', 0);
+
+// Since this is the CLI, we disable CSRF protection so our request can go through
+$assign_to_config['disable_csrf_protection'] = 'y';
+
+/*
+ *---------------------------------------------------------------
+ * LOAD THE BOOTSTRAP FILE
+ *---------------------------------------------------------------
+ *
+ * And away we go...
+ *
+ */
+if (! file_exists(SYSPATH . 'ee/EllisLab/ExpressionEngine/Boot/boot.php')) {
+    exit("\033[31mYour system folder path does not appear to be set correctly.\n");
+}
+
+// Bootstrap the standalone CLI if EE isn't installed
+if (! EE_INSTALLED) {
+    include SYSPATH . 'ee/EllisLab/ExpressionEngine/Cli/StandaloneCli/StandaloneCli.php';
+    die();
+}
+
+require_once SYSPATH . 'ee/EllisLab/ExpressionEngine/Boot/boot.php';

--- a/system/ee/EllisLab/Addons/consent/upd.consent.php
+++ b/system/ee/EllisLab/Addons/consent/upd.consent.php
@@ -17,7 +17,7 @@ class Consent_upd {
 	{
 		ee()->load->dbforge();
 		$addon = ee('Addon')->get('consent');
-		$this->version = $addon->getVersion();
+		$this->version = $addon ? $addon->getVersion() : '1.0.0';
 	}
 
 	/**

--- a/system/ee/EllisLab/ExpressionEngine/Boot/boot.common.php
+++ b/system/ee/EllisLab/ExpressionEngine/Boot/boot.common.php
@@ -653,4 +653,60 @@ if( ! function_exists('hash_equals'))
 	}
 }
 
+/**
+ * CLI Shutdown handler
+ * @return bool|mixed
+ */
+function cliShutdownHandler()
+{
+    if (@is_array($error = @error_get_last())) {
+        return(@call_user_func_array('cliErrorHandler', $error));
+    }
+
+    return true;
+}
+
+/**
+ * CLI Error handler
+ * @param $type
+ * @param $message
+ * @param $file
+ * @param $line
+ */
+function cliErrorHandler($type, $message, $file, $line)
+{
+    if (! error_reporting()) {
+        return;
+    }
+
+    $errors = array(
+        0x0001 => 'E_ERROR',
+        0x0002 => 'E_WARNING',
+        0x0004 => 'E_PARSE',
+        0x0008 => 'E_NOTICE',
+        0x0010 => 'E_CORE_ERROR',
+        0x0020 => 'E_CORE_WARNING',
+        0x0040 => 'E_COMPILE_ERROR',
+        0x0080 => 'E_COMPILE_WARNING',
+        0x0100 => 'E_USER_ERROR',
+        0x0200 => 'E_USER_WARNING',
+        0x0400 => 'E_USER_NOTICE',
+        0x0800 => 'E_STRICT',
+        0x1000 => 'E_RECOVERABLE_ERROR',
+        0x2000 => 'E_DEPRECATED',
+        0x4000 => 'E_USER_DEPRECATED'
+    );
+
+    if (! @is_string($name = @array_search($type, @array_flip($errors)))) {
+        $name = 'E_UNKNOWN';
+    }
+
+    /** @var ConsoleService $consoleService */
+    echo "\033[0;31mThe following error occurred: \n\033[0m";
+    echo "\033[0;31m{$name}: {$message} \n\033[0m";
+    echo "File: {$file}\n";
+    echo "Line: {$line}\n";
+    echo '';
+}
+
 // EOF

--- a/system/ee/EllisLab/ExpressionEngine/Boot/boot.php
+++ b/system/ee/EllisLab/ExpressionEngine/Boot/boot.php
@@ -16,7 +16,7 @@
  *             files check for this (`if ! defined ...`)
  * ------------------------------------------------------
  */
-	define('BASEPATH', SYSPATH.'ee/legacy/');
+	defined('BASEPATH') || define('BASEPATH', SYSPATH.'ee/legacy/');
 
 	// load user configurable constants
 	$constants = require SYSPATH.'ee/EllisLab/ExpressionEngine/Config/constants.php';
@@ -29,7 +29,7 @@
 
 	foreach ($constants as $k => $v)
 	{
-		define($k, $v);
+		defined($k) || define($k, $v);
 	}
 
 /*
@@ -57,7 +57,12 @@
  *  Define a custom error handler so we can log PHP errors
  * ------------------------------------------------------
  */
-	set_error_handler('_exception_handler');
+	if(defined('REQ') && REQ === 'CLI') {
+	    set_error_handler('cliErrorHandler');
+	    register_shutdown_function('cliShutdownHandler');
+	} else {
+	    set_error_handler('_exception_handler');
+	}
 
 /*
  * ------------------------------------------------------

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Cli.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Cli.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace EllisLab\ExpressionEngine\Cli;
+
+use EllisLab\ExpressionEngine\Cli\CliFactory;
+use EllisLab\ExpressionEngine\Cli\Help;
+use EllisLab\ExpressionEngine\Cli\Status;
+use EllisLab\ExpressionEngine\Cli\Context\OptionFactory;
+
+class Cli
+{
+
+    /**
+     * Primary CLI object
+     * @var \EllisLab\ExpressionEngine\Cli\Context
+     */
+    public $command;
+
+    /**
+     * stdio for output
+     * @var EllisLab\ExpressionEngine\Cli\Stdio
+     */
+    public $output;
+
+    /**
+     * stdio for Input
+     * @var EllisLab\ExpressionEngine\Cli\Stdio
+     */
+    public $input;
+
+    /**
+     * command line argv
+     * @var \EllisLab\ExpressionEngine\Cli\Context\Argv
+     */
+    public $argv;
+
+    /**
+     * [$arguments description]
+     * @var [type]
+     */
+    public $arguments;
+
+    /**
+     * list of commands available from EE
+     * @var array
+     */
+    public $internalCommands = [
+        'hello'           => Commands\CommandHelloWorld::class,
+        'list'            => Commands\CommandListCommands::class,
+        'update'          => Commands\CommandUpdate::class,
+        'prepare-upgrade' => Commands\CommandPrepareUpgrade::class,
+        'run-update-hook' => Commands\CommandRunUpdateHook::class,
+        'cache:clear'     => Commands\CommandClearCaches::class,
+    ];
+
+    /**
+     * full list of commands available
+     * @var array
+     */
+    public $availableCommands;
+
+    /**
+     * Run CLI as standalone
+     * @var [type]
+     */
+    public $isStandalone;
+
+    /**
+     * list of commands available for standalone-mode only
+     * @var array
+     */
+    public $standaloneCommands = [];
+
+    /**
+     * command called on CLI
+     * @var string
+     */
+    protected $commandCalled;
+
+    public function __construct()
+    {
+
+        // Initialize the object
+        $factory = new CliFactory;
+
+        $this->command = $factory->newContext($GLOBALS);
+        $this->output = $factory->newStdio();
+        $this->input = $factory->newStdio();
+        $this->argv = $this->command->argv->get();
+
+        if (! isset($this->argv[1])) {
+            $this->fail('No command given');
+        }
+
+        $this->arguments = array_slice($this->command->argv->get(), 2);
+
+        // Get command called
+        $this->commandCalled = $this->argv[1];
+    }
+
+    /**
+     * core CLI command processing
+     * @return void
+     */
+    public function process()
+    {
+        $this->standalone = defined('EE_INSTALLED') && EE_INSTALLED == false;
+
+        $this->availableCommands = $this->availableCommands();
+
+
+        // Check if command exists
+        // If not, return
+        if (! $this->commandExists()) {
+            return $this->fail('Command not found');
+        }
+
+        $commandClass = $this->getCommand($this->commandCalled);
+
+        if (! class_exists($commandClass)) {
+            return $this->fail('Command not found');
+        }
+
+        // Try and initialize command
+        $command = new $commandClass;
+
+        $command->loadOptions();
+
+        if ($command->option('-h', false)) {
+            return $command->help();
+        }
+
+        // Run command
+        $message = $command->handle();
+
+        // Return output and end
+        $this->complete($message);
+    }
+
+    /**
+     * get command's help information
+     * @return null
+     */
+    public function help()
+    {
+        $help = new Help(new OptionFactory);
+
+        $help->setSummary($this->summary)
+                ->setDescr($this->description)
+                ->setUsage($this->usage)
+                ->setOptions($this->commandOptions);
+
+        $this->output->outln($help->getHelp($this->name));
+
+        exit();
+    }
+
+    /**
+     * fail the command and die
+     * @param  string $message
+     * @return null
+     */
+    public function fail($message = null)
+    {
+        if ($message) {
+            $this->output->errln("<<red>>{$message}<<reset>>");
+        }
+
+        exit(Status::FAILURE);
+    }
+
+    /**
+     * complete the command and die
+     * @param  string $message
+     * @return null
+     */
+    public function complete($message = null)
+    {
+        if ($message) {
+            $this->output->outln("<<green>>{$message}<<reset>>");
+        }
+
+        exit(Status::SUCCESS);
+    }
+
+    /**
+     * write info to the console
+     * @param  string
+     * @return null
+     */
+    public function write($message = null)
+    {
+        $this->output->outln($message);
+    }
+
+    /**
+     * write info to the console
+     * @param  string
+     * @return null
+     */
+    public function info($message = null)
+    {
+        $this->output->outln("<<green>>{$message}<<reset>>");
+    }
+
+    /**
+     * write error info to the console
+     * @param  string
+     * @return null
+     */
+    public function error($message = null)
+    {
+        $this->output->outln("<<red>>{$message}<<reset>>");
+    }
+
+    /**
+     * Ask question and get input
+     * @param  string $question
+     * @return mixed
+     */
+    public function ask($question, $default = '')
+    {
+        $this->output->out($question . ' ');
+
+        $result = $this->input->in();
+
+        return $result ?? $default;
+    }
+
+    /**
+     * Ask question and get boolean answer
+     * @param  string $question
+     * @return bool
+     */
+    public function confirm($question, $default = false)
+    {
+        $choices = '(yes/no)';
+
+        $defaultText = $default ? 'yes' : 'no';
+
+        $defaultChoice = "<<white>>[<<yellow>>{$defaultText}<<white>>]<<reset>>";
+
+        $this->output->outln("<<green>>{$question} {$choices} {$defaultChoice}");
+
+        $answer = $this->input->in();
+
+        if (is_bool($answer)) {
+            return $answer;
+        }
+
+        $confirmationRegex = '/^y/i';
+
+        $answerIsTrue = (bool) preg_match($confirmationRegex, $answer);
+
+        if ($default === false) {
+            return $answer && $answerIsTrue;
+        }
+
+        return '' === $answer || $answerIsTrue;
+    }
+
+    /**
+     * check if command is defined among the addons
+     * @param  string $command [defaults to whatever command was called]
+     * @return bool
+     */
+    protected function commandExists($command = null)
+    {
+        $commandToParse = $command ?? $this->commandCalled;
+
+        if (EE_INSTALLED) {
+            return array_key_exists($commandToParse, $this->availableCommands);
+        } else {
+            $this->error('EE is not currently installed.');
+            return array_key_exists($commandToParse, $this->standaloneCommands);
+        }
+    }
+
+    /**
+     * get command class
+     * @param  string $command [defaults to whatever command was called]
+     * @return mixed
+     */
+    protected function getCommand($command = null)
+    {
+        $commandToParse = $command ?? $this->commandCalled;
+
+        return $this->availableCommands[$commandToParse];
+    }
+
+    /**
+     * gets all available commands as defined by addons
+     * @return array
+     */
+    protected function availableCommands()
+    {
+        // If EE isn't installed, we will just pull use the standalone commands list
+
+        $this->loadInternalCommands();
+
+        if (! EE_INSTALLED) {
+            return $this->standaloneCommands;
+        }
+
+        $commands = $this->internalCommands;
+
+        $providers = ee('App')->getProviders();
+
+        foreach ($providers as $providerKey => $provider) {
+            if ($provider->get('commands')) {
+                $commands = array_merge($commands, $provider->get('commands'));
+            }
+        }
+
+        return $commands;
+    }
+
+    /**
+     * loads specific command options
+     * @return null
+     */
+    protected function loadOptions()
+    {
+        if (! isset($this->commandOptions)) {
+            return [];
+        }
+
+        $commandOptions = array_merge(
+            $this->commandOptions,
+            [
+                'help,h'    => 'See help'
+            ]
+        );
+
+        $this->options = $this->command->getopt(array_keys($commandOptions));
+
+        if ($this->options->hasErrors()) {
+            $errors = $this->options->getErrors();
+
+            foreach ($errors as $error) {
+
+                // print error messages to stderr using a Stdio object
+                $this->error($error->getMessage());
+            }
+
+            $this->fail();
+        };
+    }
+
+    /**
+     * gets specific option with possibility for fallback
+     * @param  string $name
+     * @param  string $default
+     * @return mixed
+     */
+    protected function option($name, $default = null)
+    {
+        return $this->options->get($name, $default);
+    }
+
+
+    /**
+     * Loads EE Core commands
+     * @return void
+     */
+    private function loadInternalCommands()
+    {
+        foreach ($this->internalCommands as $key => $value) {
+            $obj = new $value;
+
+            if (isset($obj->standalone) && $obj->standalone) {
+                $this->standaloneCommands[$key] = $value;
+            }
+        }
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Cli.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Cli.php
@@ -224,7 +224,7 @@ class Cli
 
         $result = $this->input->in();
 
-        return $result ?? $default;
+        return $result ? $result : $default;
     }
 
     /**
@@ -266,7 +266,7 @@ class Cli
      */
     protected function commandExists($command = null)
     {
-        $commandToParse = $command ?? $this->commandCalled;
+        $commandToParse = $command ? $command : $this->commandCalled;
 
         if (EE_INSTALLED) {
             return array_key_exists($commandToParse, $this->availableCommands);
@@ -283,7 +283,7 @@ class Cli
      */
     protected function getCommand($command = null)
     {
-        $commandToParse = $command ?? $this->commandCalled;
+        $commandToParse = $command ? $command : $this->commandCalled;
 
         return $this->availableCommands[$commandToParse];
     }

--- a/system/ee/EllisLab/ExpressionEngine/Cli/CliFactory.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/CliFactory.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli;
+
+use EllisLab\ExpressionEngine\Cli\Context\Argv;
+use EllisLab\ExpressionEngine\Cli\Context\Env;
+use EllisLab\ExpressionEngine\Cli\Context\GetoptFactory;
+use EllisLab\ExpressionEngine\Cli\Context\GetoptParser;
+use EllisLab\ExpressionEngine\Cli\Context\OptionFactory;
+use EllisLab\ExpressionEngine\Cli\Context\Server;
+use EllisLab\ExpressionEngine\Cli\Stdio\Formatter;
+use EllisLab\ExpressionEngine\Cli\Stdio\Handle;
+
+/**
+ *
+ * A factory for creating Context and Stdio objects.
+ *
+ * @package Aura.Cli
+ *
+ */
+class CliFactory
+{
+    /**
+     *
+     * Returns a new Context object.
+     *
+     * @param array $globals A copy of $GLOBALS.
+     *
+     * @return Context
+     *
+     */
+    public function newContext(array $globals)
+    {
+        $env    = isset($globals['_ENV'])
+                ? new Env($globals['_ENV'])
+                : new Env;
+
+        $server = isset($globals['_SERVER'])
+                ? new Server($globals['_SERVER'])
+                : new Server;
+
+        $argv   = isset($globals['argv'])
+                ? new Argv($globals['argv'])
+                : new Argv;
+
+        $getopt_factory = new GetoptFactory(new GetoptParser(new OptionFactory));
+
+        return new Context(
+            $env,
+            $server,
+            $argv,
+            $getopt_factory
+        );
+    }
+
+    /**
+     *
+     * Returns a new Stdio object.
+     *
+     * @param string $stdin The resource to open for stdin.
+     *
+     * @param string $stdout The resource to open for stdout.
+     *
+     * @param string $stderr The resource to open for stderr.
+     *
+     * @return Stdio
+     *
+     */
+    public function newStdio(
+        $stdin  = 'php://stdin',
+        $stdout = 'php://stdout',
+        $stderr = 'php://stderr'
+    ) {
+        return new Stdio(
+            new Handle($stdin, 'r'),
+            new Handle($stdout, 'w+'),
+            new Handle($stderr, 'w+'),
+            new Formatter
+        );
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandClearCaches.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandClearCaches.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace EllisLab\ExpressionEngine\Cli\Commands;
+
+use EllisLab\ExpressionEngine\Cli\Cli;
+
+/**
+ * Command to clear selected caches
+ */
+class CommandClearCaches extends Cli
+{
+
+    /**
+     * name of command
+     * @var string
+     */
+    public $name = 'Clear Cache';
+
+    /**
+     * signature of command
+     * @var string
+     */
+    public $signature = 'cache-clear';
+
+    /**
+     * Public description of command
+     * @var string
+     */
+    public $description = 'Clears all EE caches';
+
+    /**
+     * Summary of command functionality
+     * @var [type]
+     */
+    public $summary;
+
+    /**
+     * How to use command
+     * @var string
+     */
+    public $usage = 'php eecli cache:clear --type=tag | php eecli cache:clear --t tag';
+
+    /**
+     * options available for use in command
+     * @var array
+     */
+    public $commandOptions = [
+        'type,t:'   => 'Type of cache to clear (default: all)',
+    ];
+
+    /**
+     * list of available caches
+     * @var array
+     */
+    private $availableCaches = [
+        'all',
+        'page',
+        'tag',
+        'db',
+    ];
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->summary = $this->getSummaryText();
+    }
+
+    /**
+     * Run the command
+     * @return mixed
+     */
+    public function handle()
+    {
+        $type = $this->option('-t', 'all');
+
+        if (! in_array($type, $this->availableCaches)) {
+            $this->fail('Cache does not exist. Use --help to see available caches.');
+        }
+
+        ee()->functions->clear_caching($type);
+
+        $this->info(ucfirst($type) . ' caches are cleared!');
+    }
+
+    /**
+     * Get summary text for help function
+     * @return string
+     */
+    private function getSummaryText()
+    {
+        return <<<HELPTEXT
+This allows for EE caches to be cleared.
+
+    Available options:
+    'all': Clear all caches
+    'page': Clear template caches
+    'tag': Clear tag caches
+    'db': Clear database caches
+HELPTEXT;
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandHelloWorld.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandHelloWorld.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace EllisLab\ExpressionEngine\Cli\Commands;
+
+use EllisLab\ExpressionEngine\Cli\Cli;
+
+class CommandHelloWorld extends Cli
+{
+
+    /**
+     * name of command
+     * @var string
+     */
+    public $name = 'Hello World';
+
+    /**
+     * signature of command
+     * @var string
+     */
+    public $signature = 'hello';
+
+    /**
+     * Public description of command
+     * @var string
+     */
+    public $description = 'The most basic of commands';
+
+    /**
+     * Summary of command functionality
+     * @var [type]
+     */
+    public $summary = 'This is a sample command used to test the CLI';
+
+    /**
+     * How to use command
+     * @var string
+     */
+    public $usage = 'php eecli hello';
+
+    /**
+     * options available for use in command
+     * @var array
+     */
+    public $commandOptions = [
+        'verbose,v'     => 'Hello world, but longer',
+        'interactive,i' => 'Let\'s interact!',
+        'confirm,c'     => 'Test the confirmation',
+    ];
+
+    /**
+     * Command can run without EE Core
+     * @var boolean
+     */
+    public $standalone = true;
+
+    /**
+     * Run the command
+     * @return mixed
+     */
+    public function handle()
+    {
+        $verbose = $this->option('-v', false);
+
+        $interactive = $this->option('-i', false);
+
+        $confirm = $this->option('-c', false);
+
+        $this->info('Hello world');
+
+        if ($interactive) {
+            $name = $this->ask('What\'s your name?');
+
+            $name
+                ? $this->info("Pleasure to meet you, {$name}!")
+                : $this->info("I mean, you don't have to tell me, I suppose. 😭");
+        }
+
+        if ($confirm) {
+            $answer = $this->confirm("Are you liking these questions?");
+
+            $answer
+                ? $this->info("That's good to hear!")
+                : $this->info("Well, that's no good.");
+        }
+
+        if ($verbose) {
+            $this->info('Happy ' . date('l') . '!');
+        }
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandListCommands.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandListCommands.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace EllisLab\ExpressionEngine\Cli\Commands;
+
+use EllisLab\ExpressionEngine\Cli\Cli;
+
+/**
+ * List all availabe commands
+ */
+class CommandListCommands extends Cli
+{
+
+    /**
+     * name of command
+     * @var string
+     */
+    public $name = 'List Commands';
+
+    /**
+     * signature of command
+     * @var string
+     */
+    public $signature = 'list';
+
+    /**
+     * Public description of command
+     * @var string
+     */
+    public $description = 'Lists all available commands';
+
+    /**
+     * Summary of command functionality
+     * @var [type]
+     */
+    public $summary = 'This gives a full listing of all commands.';
+
+    /**
+     * How to use command
+     * @var string
+     */
+    public $usage = 'php eecli list';
+
+    /**
+     * options available for use in command
+     * @var array
+     */
+    public $commandOptions = [];
+
+    /**
+     * Command can run without EE Core
+     * @var boolean
+     */
+    public $standalone = true;
+
+    /**
+     * Run the command
+     * @return mixed
+     */
+    public function handle()
+    {
+        $available = $this->availableCommands();
+
+        $this->info('<<bold>>Available Commands');
+        $this->info('');
+
+        $mask = "|%-20.20s |%-60.60s |\n";
+
+        printf($mask, ' Command', ' Description');
+        $this->info('-------------------------------------------------------------------------------------');
+
+        foreach ($available as $availableCommand => $availableClass) {
+            $availableHydratedClass = new $availableClass;
+
+            printf($mask, " {$availableCommand} ", " {$availableHydratedClass->description}");
+        }
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandPrepareUpgrade.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandPrepareUpgrade.php
@@ -1,0 +1,453 @@
+<?php
+
+namespace EllisLab\ExpressionEngine\Cli\Commands;
+
+use EllisLab\ExpressionEngine\Cli\Cli;
+use EllisLab\ExpressionEngine\Cli\Commands\Upgrade\UpgradeMap;
+use EllisLab\ExpressionEngine\Library\Filesystem\Filesystem;
+
+class CommandPrepareUpgrade extends Cli
+{
+
+    /**
+     * name of command
+     * @var string
+     */
+    public $name = 'Prepare Upgrade';
+
+    /**
+     * signature of command
+     * @var string
+     */
+    public $signature = 'prepare-upgrade';
+
+    /**
+     * Public description of command
+     * @var string
+     */
+    public $description = 'Prepare a different site to be upgraded using these files';
+
+    /**
+     * Summary of command functionality
+     * @var [type]
+     */
+    public $summary = 'This command copies all files necessary for upgrading into a different ExpressionEngine site and restructures it';
+
+    /**
+     * How to use command
+     * @var string
+     */
+    public $usage = 'php eecli prepare-upgrade';
+
+    /**
+     * options available for use in command
+     * @var array
+     */
+    public $commandOptions = [
+        'upgrade-ee'                => 'Start the upgrade after moving files',
+        'force-add-on-upgrade'      => 'After upgrading EE, runs addon upgrades',
+        'old-base-path:'            => 'Absolute path of old site',
+        'new-base-path:'            => 'Absolute path of new site',
+        'old-public-path:'          => 'Absolute path of old site public path',
+        'new-public-path:'          => 'Absolute path of new site public path',
+        'no-config-file'            => 'Ignores the config file and doesn\'t check for it',
+        'ee-version'                => 'The current site ',
+        'should-move-system-path'   => 'Whether the upgrade process should move the old theme folder to the new site',
+        'old-system-path:'          => 'Absolute path of old site system folder',
+        'new-system-path:'          => 'Absolute path of new site system folder',
+        'should-move-template-path' => 'Whether the upgrade process should move the old template folder to the new site',
+        'old-template-path:'        => 'Absolute path of old site template folder',
+        'new-template-path:'        => 'Absolute path of new site template folder',
+        'should-move-theme-path'    => 'Whether the upgrade process should move the old theme folder to the new site',
+        'old-theme-path:'           => 'Absolute path of old site user theme folder',
+        'new-theme-path:'           => 'Absolute path of new site user theme folder',
+        'run-preflight-hooks'       => 'Whether the upgrade process should run defined preflight hooks',
+        'run-postflight-hooks'      => 'Whether the upgrade process should run defined postflight hooks',
+        'temp-directory'            => 'The directory we work magic in',
+    ];
+
+    protected $upgradeConfigFile = [];
+
+    protected $upgradeConfig = [];
+
+    protected $configKeys = [
+        'upgrade_ee'                => 'bool',
+        'ee_version'                => 'string',
+        'old_base_path'             => 'string',
+        'new_base_path'             => 'string',
+        'should_move_system_path'   => 'bool',
+        'old_system_path'           => 'string',
+        'new_system_path'           => 'string',
+        'should_move_template_path' => 'bool',
+        'old_template_path'         => 'string',
+        'new_template_path'         => 'string',
+        'should_move_theme_path'    => 'bool',
+        'old_theme_path'            => 'string',
+        'new_theme_path'            => 'string',
+        'run_preflight_hooks'       => 'bool',
+        'run_postflight_hooks'      => 'bool',
+        'preflight_hooks'           => 'array',
+        'postflight_hooks'          => 'array',
+        'old_public_path'           => 'string',
+        'new_public_path'           => 'string',
+        'temp_directory'            => 'string',
+    ];
+
+    protected $filemap;
+
+    /**
+     * Command can run without EE Core
+     * @var boolean
+     */
+    public $standalone = true;
+
+    /**
+     * Run the command
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->info('Preparing the upgrade for a site.');
+
+        // Collect all the info we need before we can start
+        // pull in the config
+        $this->preloadConfig();
+
+        $this->preChecks();
+
+        $this->runPreflightHooks();
+
+        $this->moveOriginalSiteToTmp();
+        $this->copyNewEEFiles();
+        $this->copyOriginalConfig();
+
+        // Move templates
+        $this->moveTemplates();
+        
+        // @TODO: Move addons
+        $this->moveAddons();
+
+        // Done preparing - if they wanted the upgrade to be run after, run it here
+        if ($upgrade = ($this->option('upgrade-ee') || $this->upgradeConfig['upgrade_ee'])) {
+            $this->info('Running EE upgrade');
+            $this->runUpgrade();
+        }
+
+        $this->runPostflightHooks();
+
+        $this->complete('Process complete!');
+    }
+
+    private function runPreflightHooks()
+    {
+        if (!$this->upgradeConfig['run_preflight_hooks']) {
+            return;
+        }
+
+        $this->info('Running preflight hooks');
+
+        foreach ($this->upgradeConfig['preflight_hooks'] as $hook) {
+ 
+            call_user_func_array($hook, func_get_args());
+
+        }
+    }
+
+    private function runPostflightHooks()
+    {
+        if (!$this->upgradeConfig['run_postflight_hooks']) {
+            return;
+        }
+
+        $this->info('Running postflight hooks');
+
+        foreach ($this->upgradeConfig['postflight_hooks'] as $hook) {
+
+            call_user_func_array($hook, func_get_args());
+
+        }
+    }
+
+    private function preChecks()
+    {
+        $this->info("Here's how things are configured:");
+
+        foreach ($this->upgradeConfig as $upgradeKey => $upgradeValue) {
+            if (is_bool($upgradeValue)) {
+                $upgradeValue = $upgradeValue ? 'true' : 'false';
+            }
+
+            if(! is_array($upgradeValue)) {
+                $this->write("<<green>>{$upgradeKey}<<reset>>: {$upgradeValue}");
+            }
+        }
+
+        $this->info("We are about to move X file to tmp/X and Y to system/Y");
+        $this->info("Make sure you have backups!");
+
+        $continue = $this->confirm('Are you sure you want to proceed?');
+
+        // User does not want to continue - abort!
+        if (! $continue) {
+            $this->error('Upgrade aborted');
+            exit;
+        }
+
+        // Check if upgrade too
+        if ($this->option('upgrade-ee')) {
+            $this->info("You also said you want to upgrade EE after moving these files around.");
+
+            $continue = $this->confirm('Are you sure you want to proceed?');
+
+            // User does not want to continue - abort!
+            if (! $continue) {
+                $this->error('Upgrade aborted');
+                exit;
+            }
+        }
+
+        return true;
+    }
+
+    private function preloadConfig()
+    {
+        // First up, load config file
+        $this->getConfigFile();
+        $this->parseConfig();
+    }
+
+    private function getConfigFile()
+    {
+        if ($this->option('no-config-file')) {
+            return;
+        }
+
+        $filesystem = new Filesystem;
+
+        $customConfig = $this->getConfigPath();
+
+        if( ! $customConfig) {
+            $path = $this->ask('What is the path to your upgrade.config.php? (defaults to SYSPATH, currently ' . SYSPATH . ')');
+
+            if (! ($customConfig = $this->getConfigPath($path))) {
+                $this->error('Custom config not found.');
+                return;
+            }
+        }
+
+        $this->upgradeConfigFile = include $customConfig;
+    }
+
+    private function runUpgrade()
+    {
+        $command = "php {$this->upgradeConfig['new_base_path']}/eecli update -y";
+
+        if ($this->option('--force-add-on-upgrade')) {
+            $command .= ' --force-addon-upgrades';
+        }
+
+        exec($command);
+    }
+
+    private function parseConfig()
+    {
+        foreach ($this->configKeys as $key => $type) {
+            $value = null;
+
+            $flag = str_replace('_', '-', $key);
+
+            // Check for the flag
+            if ($flagData = $this->option($flag, false)) {
+                $value = $flagData;
+            }
+
+            // If no flag, check the file
+            if (!$value && isset($this->upgradeConfigFile[$key])) {
+                $value = $this->upgradeConfigFile[$key];
+            }
+
+            // If neither of those, we'll ask
+            if (!$value) {
+                if ($type == 'array') {
+                    $value = [];
+                }
+
+                if ($type == 'string') {
+                    $value = $this->ask("Please set {$key}:");
+                }
+
+                if ($type == 'bool') {
+                    $value = $this->confirm("{$key}?");
+                }
+            }
+
+            $this->upgradeConfig[$key] = $value;
+        }
+
+        // Load upgrade file map
+        if ($this->upgradeConfigFile['upgrade_map']) {
+            $filemap = $this->upgradeConfigFile['upgrade_map'];
+        } else {
+            $version = $this->upgradeConfig['ee_version'];
+
+            $filemap = UpgradeMap::get($version);
+        }
+
+        $this->filemap = UpgradeMap::prepare($filemap);
+    }
+
+    private function getConfigPath($path = null)
+    {
+        $customConfig = ($path ? rtrim($path, '/') : SYSPATH) . '/upgrade.config.php';
+
+        if (! file_exists($customConfig)) {
+            return false;
+        }
+
+        return $customConfig;
+    }
+
+    private function moveOriginalSiteToTmp()
+    {
+        // Need to copy system/, index.php, admin.php and themes folder
+        $filesystem = new Filesystem;
+
+        $tmp_folder = $this->prepTmpDirectory();
+
+        $filesystem->rename($this->upgradeConfig['old_public_path'] . $this->filemap['index_file_old'], $tmp_folder . $this->filemap['index_file_old']);
+        $filesystem->rename($this->upgradeConfig['old_public_path'] . $this->filemap['admin_file_old'], $tmp_folder . $this->filemap['admin_file_old']);
+
+        $filesystem->rename($this->upgradeConfig['old_system_path'], $tmp_folder . 'system');
+
+        if ($this->upgradeConfig['should_move_theme_path']) {
+            $filesystem->rename($this->upgradeConfig['old_theme_path'], $tmp_folder . 'themes');
+        }
+    }
+
+    private function prepTmpDirectory()
+    {
+        $filesystem = new Filesystem;
+
+        $tmp_folder = rtrim($this->upgradeConfig['old_base_path'], '/') . '/' . $this->upgradeConfig['temp_directory'];
+
+        if ($filesystem->isDir($tmp_folder)) {
+            $filesystem->delete($tmp_folder);
+        } else {
+            $filesystem->mkdir($tmp_folder);
+        }
+
+        return rtrim($tmp_folder, '/') . '/';
+    }
+
+    private function copyNewEEFiles()
+    {
+        $filesystem = new Filesystem;
+
+        $filesystem->copy(
+            SYSPATH,
+            $this->upgradeConfig['new_system_path']
+        );
+
+        if ($this->upgradeConfig['should_move_theme_path']) {
+            $filesystem->copy(
+                FCPATH . 'themes',
+                $this->upgradeConfig['new_theme_path']
+            );
+        }
+
+        $filesystem->copy(
+            FCPATH . $this->filemap['admin_file'],
+            $this->upgradeConfig['new_public_path'] . $this->filemap['admin_file']
+        );
+
+        $filesystem->copy(
+            FCPATH . $this->filemap['index_file'],
+            $this->upgradeConfig['new_public_path'] . $this->filemap['index_file']
+        );
+
+        $filesystem->copy(
+            FCPATH . 'eecli',
+            $this->upgradeConfig['new_base_path'] . 'eecli'
+        );
+    }
+
+    private function copyOriginalConfig()
+    {
+        $filesystem = new Filesystem;
+
+        $tmp_folder = rtrim($this->upgradeConfig['old_base_path'], '/') . '/' . $this->upgradeConfig['temp_directory'] . '/';
+
+        // We should check if this is EE2 or EE3+
+        if($filesystem->exists($tmp_folder . '/system/expressionengine')) {
+            // It's EE2!
+            $filesystem->copy(
+                $tmp_folder . rtrim($this->filemap['config_path'], '/') . '/' . $this->filemap['config_file'],
+                rtrim($this->upgradeConfig['new_system_path'], '/') . '/user/config/' . ltrim($this->filemap['config_file'], '/')
+            );
+
+            if(isset($this->filemap['database_file']) && $this->filemap['database_file'] !== 'config.php') {
+                $filesystem->copy(
+                    $tmp_folder . rtrim($this->filemap['config_path'], '/') . '/' . $this->filemap['database_file'],
+                    rtrim($this->upgradeConfig['new_system_path'], '/') . '/user/config/' . ltrim($this->filemap['database_file'], '/')
+                );
+
+                $this->info('We found a database file. Please move this information in to config.php');
+            }
+
+        } else {
+            // It's EE3+!
+            $filesystem->copy(
+                $tmp_folder . $this->filemap['config_path'] . $this->filemap['config_file'],
+                rtrim($this->upgradeConfig['new_system_path'], '/') . '/user/config/' . ltrim($this->filemap['config_file'], '/')
+            );
+
+            $filesystem->copy(
+                $tmp_folder . $this->filemap['config_path'] . $this->filemap['database_file'],
+                rtrim($this->upgradeConfig['new_system_path'], '/') . '/user/config/' . ltrim($this->filemap['database_file'], '/')
+            );
+        }
+    }
+
+    private function moveTemplates()
+    {
+
+        if( ! $this->upgradeConfig['should_move_template_path']) {
+            return;
+        }
+
+        $filesystem = new Filesystem;
+
+        // $tmp_folder = rtrim($this->upgradeConfig['old_base_path'], '/') . '/' . $this->upgradeConfig['temp_directory'] . '/';
+
+        $filesystem->rename(
+            rtrim($this->upgradeConfig['old_template_path'], '/'),
+            rtrim($this->upgradeConfig['new_template_path'], '/')
+        );
+
+    }
+
+    private function moveAddons()
+    {
+
+    }
+
+    private function checkIfPathAllowed($path)
+    {
+        // Check if path exists
+        if (! file_exists($path)) {
+            $this->fail("{$path} does not exist.");
+        }
+
+        // Check if it is a directory
+        if (! is_dir($path)) {
+            $this->fail("{$path} is not a directory.");
+        }
+
+        // Check if it writable
+        if (! is_writable($path)) {
+            $this->fail("{$path} is not writable.");
+        }
+
+        return true;
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandPrepareUpgrade.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandPrepareUpgrade.php
@@ -52,7 +52,7 @@ class CommandPrepareUpgrade extends Cli
         'new-public-path:'          => 'Absolute path of new site public path',
         'no-config-file'            => 'Ignores the config file and doesn\'t check for it',
         'ee-version'                => 'The current site ',
-        'should-move-system-path'   => 'Whether the upgrade process should move the old theme folder to the new site',
+        'should-move-system-path'   => 'Whether the upgrade process should move the old system folder to the new site',
         'old-system-path:'          => 'Absolute path of old site system folder',
         'new-system-path:'          => 'Absolute path of new site system folder',
         'should-move-template-path' => 'Whether the upgrade process should move the old template folder to the new site',

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandRunUpdateHook.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandRunUpdateHook.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace EllisLab\ExpressionEngine\Cli\Commands;
+
+use EllisLab\ExpressionEngine\Cli\Cli;
+
+/**
+ * Update or upgrade EE
+ */
+class CommandRunUpdateHook extends Cli
+{
+
+    /**
+     * name of command
+     * @var string
+     */
+    public $name = 'Run Update Hook';
+
+    /**
+     * signature of command
+     * @var string
+     */
+    public $signature = 'run-update-hook';
+
+    /**
+     * Public description of command
+     * @var string
+     */
+    public $description = 'Runs specific update hooks from your upgrade.config file (advanced)';
+
+    /**
+     * Summary of command functionality
+     * @var [type]
+     */
+    public $summary = 'This will run one of the preflight or postflight hooks as defined in the upgrade.config file. This can be a destructive action, so use with caution.';
+
+    /**
+     * How to use command
+     * @var string
+     */
+    public $usage = 'php eecli run-update-hook functionName';
+
+    /**
+     * options available for use in command
+     * @var array
+     */
+    public $commandOptions = [];
+
+    /**
+     * sets the possible upgrade hooks
+     * @var array
+     */
+    private $hooks;
+
+    /**
+     * The upgraded file confi
+     * @var [type]
+     */
+    private $upgradeConfigFile;
+
+
+    /**
+     * Run the command
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->getConfigFile();
+
+        $this->setHooks();
+
+        foreach ($this->arguments as $hook) {
+            if (array_key_exists($hook, $this->hooks)) {
+                $this->info("Running {$hook}");
+
+                call_user_func($this->hooks[$hook]);
+            } else {
+                $this->error("Hook {$hook} not found.");
+            }
+        }
+
+        $this->complete('Success!');
+    }
+
+    private function getConfigFile()
+    {
+        if ($this->option('no-config-file')) {
+            return;
+        }
+
+        $path = $this->ask('What is the path to your upgrade.config.php? (defaults to SYSPATH)');
+
+        if (! ($customConfig = $this->getConfigPath($path))) {
+            $this->fail('Custom config not found.');
+        }
+
+        $this->upgradeConfigFile = include $customConfig;
+    }
+
+    private function setHooks()
+    {
+        $this->hooks = array_merge(
+            $this->upgradeConfigFile['preflight_hooks'],
+            $this->upgradeConfigFile['postflight_hooks']
+        );
+    }
+
+    private function getConfigPath($path)
+    {
+        $customConfig = ($path ? rtrim($path, '/') : SYSPATH) . '/upgrade.config.php';
+
+        if (! file_exists($customConfig)) {
+            return false;
+        }
+
+        return $customConfig;
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandUpdate.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandUpdate.php
@@ -1,0 +1,445 @@
+<?php
+
+namespace EllisLab\ExpressionEngine\Cli\Commands;
+
+use EllisLab\ExpressionEngine\Cli\Cli;
+use EllisLab\ExpressionEngine\Cli\Commands\Upgrade\UpgradeMap;
+use EllisLab\ExpressionEngine\Cli\Commands\Upgrade\UpgradeUtility;
+
+/**
+ * Update or upgrade EE
+ */
+class CommandUpdate extends Cli {
+
+	/**
+	 * name of command
+	 * @var string
+	 */
+	public $name = 'Update';
+
+	/**
+	 * signature of command
+	 * @var string
+	 */
+	public $signature = 'update';
+
+	/**
+	 * Public description of command
+	 * @var string
+	 */
+	public $description = 'Updates EE';
+
+	/**
+	 * Summary of command functionality
+	 * @var [type]
+	 */
+	public $summary = 'This will run the update process of EE';
+
+	/**
+	 * How to use command
+	 * @var string
+	 */
+	public $usage = 'php eecli update';
+
+	/**
+	 * options available for use in command
+	 * @var array
+	 */
+	public $commandOptions = [
+		'rollback'				=> 'Rollsback last update',
+		'verbose,v'				=> 'Verbose output',
+		'microapp'				=> 'Run as microapp',
+		'step:'					=> 'Step in process (param required)',
+		'no-bootstrap'			=> 'Runs with no bootstrap',
+		'force-addon-upgrades'	=> 'Automatically runs all addon updaters at end of update (advanced)',
+		'y'						=> 'Skip all confirmations. Don\'t do this.'
+	];
+
+	protected $verbose;
+	protected $isRollback;
+	protected $isMicroapp;
+	protected $shouldBootstrap;
+	protected $step;
+	protected $defaultToYes;
+
+	public $currentVersion;
+	public $updateType;
+	public $updateVersion;
+
+	/**
+	 * Run the command
+	 * @return mixed
+	 */
+	public function handle()
+	{
+
+		// Preflight checks, download and unpack update
+		$this->initUpgrade();
+
+		if (version_compare($this->currentVersion, $this->updateVersion, '>='))
+		{
+			$this->complete('ExpressionEngine ' . $this->currentVersion . ' is already up-to-date!');
+		}
+
+		// Advanced param checks
+		$this->checkAdvancedParams();
+
+		$this->info("There is a new version of ExpressionEngine available: {$this->updateVersion}\n");
+
+		if(! $this->defaultToYes) {
+			if(! $this->confirm("Would you like to upgrade?")) {
+				$this->complete("Update not run");
+			}
+		}
+
+		$this->runUpgrade();
+
+		$this->complete('Success! Create something awesome!');
+
+	}
+
+	protected function runUpdater($step = null, $microapp = false, $noBootstrap = false, $rollback = false)
+	{
+
+		try
+		{
+			if ($microapp) {
+
+				return $this->updaterMicroapp($step);
+
+			}
+
+			if ($rollback) {
+
+				return $this->updaterMicroapp('rollback');
+
+			}
+
+			$this->runUpdater($step, true, true); //'update --microapp --no-bootstrap');
+
+		} catch (\Exception $e) {
+
+			$this->fail("{$e->getCode()}: {$e->getMessage()}");
+
+		}
+
+	}
+
+	/**
+	 * creates micro app
+	 * @param  $step
+	 * @return null
+	 */
+	private function updaterMicroapp($step = null)
+	{
+		if ( ! class_exists('EllisLab\ExpressionEngine\Updater\Service\Updater\Runner'))
+		{
+			$this->loadMicroapp();
+		}
+
+		$runner = new \EllisLab\ExpressionEngine\Updater\Service\Updater\Runner();
+
+		if ( ! $step ) {
+
+			$step = $runner->getFirstStep();
+
+		}
+
+		$runner->runStep($step);
+
+		// runUpdater($step = null, $microapp = false, $noBootstrap = false, $rollback = false)
+
+		// Perform each step as its own command so we can control the scope of
+		// files loaded into the app's memory
+		if (($next_step = $runner->getNextStep()) !== false) {
+
+			if ($next_step == 'rollback') {
+
+				return $this->runUpdater(null, false, false, true); // 'upgrade --rollback'
+
+			}
+
+			$this->runUpdater($next_step, true, $next_step == 'updateFiles');
+
+		}
+
+	}
+
+	/**
+	 * begins upgrade
+	 * @return null
+	 */
+	private function initUpgrade()
+	{
+
+		$this->getCurrentVersion();
+
+		defined('CLI_VERBOSE') || define('CLI_VERBOSE', $this->option('-v', false));
+		defined('PATH_CACHE') || define('PATH_CACHE',  SYSPATH . 'user/cache/');
+		defined('PATH_THIRD') || define('PATH_THIRD',  SYSPATH . 'user/addons/');
+		defined('APP_VER') || define('APP_VER', $this->currentVersion);
+		defined('IS_CORE') ||define('IS_CORE', FALSE);
+		defined('DOC_URL') || define('DOC_URL', 'https://docs.expressionengine.com/v5/');
+
+		$this->verbose = CLI_VERBOSE;
+		$this->defaultToYes = $this->option('-y', false);
+
+		// Load what we need in EE
+		ee()->load->library('core');
+		
+		ee()->load->helper('language');
+		ee()->load->helper('string');
+		// We only need this one for the upgrade.
+		ee()->load->helper('cli');
+		ee()->load->driver('cache');
+
+		// Load database
+		$databaseConfig = ee()->config->item('database');
+
+		ee()->load->database();
+		ee()->db->swap_pre = 'exp_';
+		ee()->db->dbprefix = $databaseConfig['expressionengine']['dbprefix'] ?? 'exp_';
+		ee()->db->db_debug = FALSE;
+
+		ee()->load->add_package_path(EE_APPPATH);
+		ee()->load->library('functions');
+		ee()->load->library('extensions');
+		ee()->load->library('api');
+		ee()->load->library('localize');
+		ee()->load->helper('language');
+		ee()->lang->loadfile('installer');
+		ee()->load->library('progress');
+		ee()->load->model('installer_template_model', 'template_model');
+
+		$this->getUpgradeInfo();
+
+	}
+
+	private function getCurrentVersion()
+	{
+
+		$version = ee()->config->item('app_version');
+
+		$this->currentVersion = (strpos($version, '.') == false)
+            ? $version = implode('.', str_split($version, 1))
+            : $version;
+
+	}
+
+	/**
+	 * load necessary files for microapp
+	 * @return void
+	 */
+	private function loadMicroapp()
+	{
+		$this->autoload(SYSPATH . 'ee/updater/EllisLab/ExpressionEngine/Updater/Library/');
+		$this->autoload(SYSPATH . 'ee/updater/EllisLab/ExpressionEngine/Updater/Service/Logger/');
+		$this->autoload(SYSPATH . 'ee/installer/updates/');
+
+		require_once SYSPATH . 'ee/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/SteppableTrait.php';
+		require_once SYSPATH . 'ee/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/Logger.php';
+		require_once SYSPATH . 'ee/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/Verifier.php';
+		require_once SYSPATH . 'ee/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/FileUpdater.php';
+		require_once SYSPATH . 'ee/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/DatabaseUpdater.php';
+		require_once SYSPATH . 'ee/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/Runner.php';
+	}
+
+	/**
+	 * autoload directories for microapp
+	 * @param  string $dir
+	 * @return void
+	 */
+	private function autoload($dir)
+	{
+
+	    foreach ( scandir( $dir ) as $file ) {
+
+	    	if ( is_dir( $dir . $file ) && substr( $file, 0, 1 ) == '.' ) {
+	    		continue;
+	    	}
+			if ( is_dir( $dir . $file ) ) {
+				$this->autoload( $dir . $file . '/' );
+			}
+
+			// php file?
+			if (
+				substr( $file, 0, 2 ) !== '._'
+				&& preg_match( "/.php$/i" , $file ))
+			{
+				include $dir . $file;
+			}
+
+	    }
+
+	}
+
+	/**
+	 * check for any possible destructive params during upgrader
+	 * @return void
+	 */
+	private function checkAdvancedParams()
+	{
+
+		if($this->option('--force-addon-upgrades', false)) {
+
+			$this->write("<<red>>You have indicated you want to upgrade all addons.<<reset>>");
+
+			if($this->defaultToYes || $this->confirm('Are you sure? This may be a destructive action.') ) {
+
+				defined('CLI_UPDATE_FORCE_ADDON_UPDATE') || define('CLI_UPDATE_FORCE_ADDON_UPDATE', $this->option('--force-addon-upgrades', false));
+
+			} else {
+
+				$this->write('<<red>>Addon update halted<<reset>>');
+
+			}
+
+		}
+
+	}
+
+	private function getUpgradeInfo()
+	{
+
+		return $this->doesInstallerFolderExist()
+				? $this->getUpgradeVersionFromLocal()
+				: $this->getUpgradeVersionFromCurl();
+
+	}
+
+	private function doesInstallerFolderExist()
+	{
+
+		$path = SYSPATH . '/ee/installer';
+
+		return file_exists($path) && is_dir($path);
+
+	}
+
+	private function getUpgradeVersionFromLocal()
+	{
+
+		$this->autoload(SYSPATH . 'ee/installer/controllers/');
+
+		if(! class_exists('Wizard')) {
+			return $this->getUpgradeVersionFromCurl();
+		}
+
+		$wizard = get_class_vars('Wizard');
+
+		$this->info('Getting upgrade information from your local environment');
+
+		$this->updateType = 'local';
+		$this->updateVersion = $wizard['version'];
+
+	}
+
+	private function getUpgradeVersionFromCurl()
+	{
+
+		$this->info('Getting upgrade information from ExpressionEngine.com');
+
+		ee()->load->library('el_pings');
+
+		$version_file = ee()->el_pings->get_version_info(true);
+
+		$this->updateType == 'curl';
+		$this->updateVersion = $version_file['latest_version'];
+
+	}
+
+	protected function runUpgrade()
+	{
+
+		return $this->updateType == 'local'
+				? $this->upgradeFromLocalVersion()
+				: $this->upgradeFromDownloadedVersion();
+
+	}
+
+	protected function upgradeFromLocalVersion()
+	{
+
+		// We have to initialize differently for local files
+		require_once SYSPATH . 'ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/SteppableTrait.php';
+
+		$this->autoload(SYSPATH . 'ee/installer/updates/');
+
+		ee()->load->library('session');
+		ee()->load->library('smartforge');
+		ee()->load->library('logger');
+		ee()->load->library('update_notices');
+		define('PATH_TMPL',   SYSPATH.'user/templates/');
+		defined('USERNAME_MAX_LENGTH') || define('USERNAME_MAX_LENGTH', 75);
+		defined('PASSWORD_MAX_LENGTH') || define('PASSWORD_MAX_LENGTH', 72);
+		defined('URL_TITLE_MAX_LENGTH') || define('URL_TITLE_MAX_LENGTH', 200);
+		defined('PATH_CACHE') || define('PATH_CACHE',  SYSPATH.'user/cache/');
+		defined('PATH_TMPL') || define('PATH_TMPL',   SYSPATH.'user/templates/');
+		defined('DOC_URL') || define('DOC_URL', 'https://docs.expressionengine.com/v5/');
+
+		// Load versions of EE
+		$upgradeMap = UpgradeMap::$versionsSupported;
+
+		$next_version = $this->currentVersion;
+
+		// For early version 2, we didn't use dots. 
+		if (strpos($next_version, '.') == false) {
+		    $next_version = implode('.', str_split($next_version, 1));
+		}
+
+		$currentVersionKey = array_search($next_version, $upgradeMap);
+
+		$end_version = $this->updateVersion;
+
+		// This will loop through all versions of EE
+		do {
+
+			$this->info('Updating to version ' . $next_version);
+
+			// Instantiate the updater class
+			if (class_exists('Updater')) {
+				$UD = new Updater;
+			} else {
+				$class = '\EllisLab\ExpressionEngine\Updater\Version_' . str_replace('.', '_', $next_version) . '\Updater';
+				$UD = new $class;
+			}
+
+			if (($status = $UD->do_update()) === false) {
+				$this->fail('Failed on version ' . $next_version);
+			}
+
+			$currentVersionKey--;
+
+			ee()->config->set_item('app_version', $upgradeMap[$currentVersionKey]);
+			ee()->config
+					->_update_config([
+								'app_version'	=> $upgradeMap[$currentVersionKey]
+					]);
+
+			$next_version = $upgradeMap[$currentVersionKey];
+
+		} while (version_compare($next_version, $end_version, '<'));
+
+		// Complete upgrades
+		UpgradeUtility::run();
+
+	}
+
+	protected function upgradeFromDownloadedVersion()
+	{
+
+		try {
+
+			ee('Updater/Runner')->run();
+
+		} catch (\Exception $e) {
+
+			$this->fail("{$e->getCode()}: {$e->getMessage()}\n\n\n{$e->getTraceAsString()}");
+
+		}
+
+		$this->runUpdater();
+
+	}
+
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandUpdate.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandUpdate.php
@@ -198,7 +198,9 @@ class CommandUpdate extends Cli {
 
 		ee()->load->database();
 		ee()->db->swap_pre = 'exp_';
-		ee()->db->dbprefix = $databaseConfig['expressionengine']['dbprefix'] ?? 'exp_';
+		ee()->db->dbprefix = isset($databaseConfig['expressionengine']['dbprefix'])
+								? $databaseConfig['expressionengine']['dbprefix']
+								: 'exp_';
 		ee()->db->db_debug = FALSE;
 
 		ee()->load->add_package_path(EE_APPPATH);

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandUpdate.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/CommandUpdate.php
@@ -46,7 +46,7 @@ class CommandUpdate extends Cli {
 	 * @var array
 	 */
 	public $commandOptions = [
-		'rollback'				=> 'Rollsback last update',
+		'rollback'				=> 'Rollback last update',
 		'verbose,v'				=> 'Verbose output',
 		'microapp'				=> 'Run as microapp',
 		'step:'					=> 'Step in process (param required)',

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/Upgrade/UpgradeMap.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/Upgrade/UpgradeMap.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace EllisLab\ExpressionEngine\Cli\Commands\Upgrade;
+
+use EllisLab\ExpressionEngine\Library\Filesystem\Filesystem;
+
+class UpgradeMap
+{
+    public static $versionsSupported = [
+        '5.3.2',
+        '5.3.1',
+        '5.3.0',
+        '5.2.6',
+        '5.2.5',
+        '5.2.4',
+        '5.2.3',
+        '5.2.2',
+        '5.2.1',
+        '5.2.0',
+        '5.1.3',
+        '5.1.2',
+        '5.1.1',
+        '5.1.0',
+        '5.0.2',
+        '5.0.1',
+        '5.0.0',
+        '4.3.8',
+        '4.3.7',
+        '4.3.6',
+        '4.3.5',
+        '4.3.4',
+        '4.3.3',
+        '4.3.2',
+        '4.3.1',
+        '4.3.0',
+        '4.2.3',
+        '4.2.2',
+        '4.2.1',
+        '4.2.0',
+        '4.1.3',
+        '4.1.2',
+        '4.1.1',
+        '4.1.0',
+        '4.0.9',
+        '4.0.8',
+        '4.0.7',
+        '4.0.6',
+        '4.0.5',
+        '4.0.4',
+        '4.0.3',
+        '4.0.2',
+        '4.0.1',
+        '4.0.0',
+        '3.5.17',
+        '3.5.16',
+        '3.5.15',
+        '3.5.14',
+        '3.5.13',
+        '3.5.12',
+        '3.5.11',
+        '3.5.10',
+        '3.5.9',
+        '3.5.8',
+        '3.5.7',
+        '3.5.6',
+        '3.5.5',
+        '3.5.4',
+        '3.5.3',
+        '3.5.2',
+        '3.5.1',
+        '3.5.0',
+        '3.4.7',
+        '3.4.6',
+        '3.4.5',
+        '3.4.4',
+        '3.4.3',
+        '3.4.2',
+        '3.4.1',
+        '3.4.0',
+        '3.3.4',
+        '3.3.3',
+        '3.3.2',
+        '3.3.1',
+        '3.3.0',
+        '3.2.1',
+        '3.2.0',
+        '3.1.4',
+        '3.1.3',
+        '3.1.2',
+        '3.1.1',
+        '3.1.0',
+        '3.0.6',
+        '3.0.5',
+        '3.0.4',
+        '3.0.3',
+        '3.0.2',
+        '3.0.1',
+        '3.0.0',
+        '2.11.9',
+        '2.11.8',
+        '2.11.7',
+        '2.11.6',
+        '2.11.5',
+        '2.11.4',
+        '2.11.3',
+        '2.11.2',
+        '2.11.1',
+        '2.11.0',
+        '2.10.3',
+        '2.10.2',
+        '2.10.1',
+        '2.10.0',
+        '2.9.3',
+        '2.9.2',
+        '2.9.1',
+        '2.9.0',
+        '2.8.1',
+        '2.8.0',
+        '2.7.3',
+        '2.7.2',
+        '2.7.1',
+        '2.7.0',
+        '2.6.1',
+        '2.6.0',
+        '2.5.5',
+        '2.5.4',
+        '2.5.3',
+        '2.5.2',
+        '2.5.1',
+        '2.5.0',
+        '2.4.0',
+        '2.3.1',
+        '2.3.0',
+        '2.2.2',
+        '2.2.1',
+        '2.2.0',
+        '2.1.5',
+        '2.1.4',
+        '2.1.3',
+        '2.1.2',
+        '2.1.1',
+        '2.1.0',
+    ];
+
+    public static $versionMap = [
+        '2.11.9',
+        '3.0.4',
+        '3.5.11',
+        '4.0.0',
+        '5.0.0',
+    ];
+
+    // This is all the maps
+    public static function get($version)
+    {
+        $versionName = self::parseVersion($version);
+
+        $map = self::getMapVersion($version);
+
+        if (! $map) {
+            return false;
+        }
+
+        $functionName = "version_{$map}_map";
+
+        return self::$functionName();
+    }
+
+    public static function prepare($filemap)
+    {
+        foreach ($filemap as $filemapKey => &$filemapValue) {
+
+            // If it's a file
+            if (strpos($filemapKey, '_file') !== false) {
+                $filemapValue = ltrim($filemapValue, '/');
+            } else {
+                // Else, it's a directory and we need to make sure the system is in there
+                // Let's check if it has the system path and a leading slash
+                $filemapValue = ltrim($filemapValue, '/');
+            }
+        }
+
+        return $filemap;
+    }
+
+    public static function version_2_11_9_map()
+    {
+        return [
+            'config_path'       => 'expressionengine/config',
+            'database_path'     => 'expressionengine/database',
+            'config_file'       => 'config.php',
+            'database_file'     => 'database.php',
+            'template_path'     => 'expressionengine/templates',
+            'index_file'        => 'index.php',
+            'admin_file'        => 'admin.php',
+            'index_file_old'    => 'index.php',
+            'admin_file_old'    => 'admin.php',
+        ];
+    }
+
+    public static function version_3_0_4_map()
+    {
+        return [
+            'config_path'       => 'user/config',
+            'database_path'     => 'user/config',
+            'config_file'       => 'config.php',
+            'database_file'     => 'config.php',
+            'template_path'     => 'user/templates',
+            'index_file'        => 'index.php',
+            'admin_file'        => 'admin.php',
+            'index_file_old'    => 'index.php',
+            'admin_file_old'    => 'admin.php',
+        ];
+    }
+
+    public static function version_3_5_11_map()
+    {
+        return [
+            'config_path'       => 'user/config',
+            'database_path'     => 'user/config',
+            'config_file'       => 'config.php',
+            'database_file'     => 'config.php',
+            'template_path'     => 'user/templates',
+            'index_file'        => 'index.php',
+            'admin_file'        => 'admin.php',
+            'index_file_old'    => 'index.php',
+            'admin_file_old'    => 'admin.php',
+        ];
+    }
+
+    public static function version_4_0_0_map()
+    {
+        return [
+            'config_path'       => 'user/config',
+            'database_path'     => 'user/config',
+            'config_file'       => 'config.php',
+            'database_file'     => 'config.php',
+            'template_path'     => 'user/templates',
+            'index_file'        => 'index.php',
+            'admin_file'        => 'admin.php',
+            'index_file_old'    => 'index.php',
+            'admin_file_old'    => 'admin.php',
+        ];
+    }
+
+    public static function version_5_0_0_map()
+    {
+        return [
+            'config_path'       => 'user/config',
+            'database_path'     => 'user/config',
+            'config_file'       => 'config.php',
+            'database_file'     => 'config.php',
+            'template_path'     => 'user/templates',
+            'index_file'        => 'index.php',
+            'admin_file'        => 'admin.php',
+            'index_file_old'    => 'index.php',
+            'admin_file_old'    => 'admin.php',
+        ];
+    }
+
+    // Private functions
+    private static function parseVersion($version)
+    {
+
+        // For early EE2 version that didn't use dotted syntax
+        if (strpos($version, '.') == false) {
+            $version = implode('.', str_split($version, 1));
+        }
+
+        return $version;
+    }
+
+    private static function getMapVersion($version)
+    {
+        foreach (self::$versionMap as $EEversion) {
+            if (version_compare($EEversion, $version, '<=')) {
+                return str_replace('.', '_', $EEversion);
+            }
+        }
+
+        return false;
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Commands/Upgrade/UpgradeUtility.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Commands/Upgrade/UpgradeUtility.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace EllisLab\ExpressionEngine\Cli\Commands\Upgrade;
+
+use EllisLab\ExpressionEngine\Library\Filesystem\Filesystem;
+
+class UpgradeUtility
+{
+
+	public static function run()
+	{
+		self::install_modules();
+		self::remove_installer_directory();
+	}
+
+	protected static function install_modules()
+	{
+
+		$required_modules = [
+			'channel',
+			'comment',
+			'consent',
+			'member',
+			'stats',
+			'rte',
+			'file',
+			'filepicker',
+			'relationship',
+			'search'
+		];
+
+		ee()->load->library('addons');
+		ee()->addons->install_modules($required_modules);
+
+		$consent = ee('Addon')->get('consent');
+		$consent->installConsentRequests();
+
+	}
+
+	protected static function remove_installer_directory()
+	{
+
+		$installerPath = SYSPATH . 'ee/installer';
+
+		if(is_dir($installerPath)) {
+			rmdir($installerPath);
+		}
+
+	}
+
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Context.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Context.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli;
+
+use EllisLab\ExpressionEngine\Cli\Context\Argv;
+use EllisLab\ExpressionEngine\Cli\Context\Env;
+use EllisLab\ExpressionEngine\Cli\Context\Getopt;
+use EllisLab\ExpressionEngine\Cli\Context\GetoptFactory;
+use EllisLab\ExpressionEngine\Cli\Context\Server;
+
+/**
+ *
+ * Collection point for information about the command line execution context.
+ *
+ * @package Aura.Cli
+ *
+ */
+class Context
+{
+    /**
+     *
+     * Imported $argv values.
+     *
+     * @var Argv
+     *
+     */
+    protected $argv;
+
+    /**
+     *
+     * Imported $_ENV values.
+     *
+     * @var Env
+     *
+     */
+    protected $env;
+
+    /**
+     *
+     * A factory for Getopt objects.
+     *
+     * @var Getopt
+     *
+     */
+    protected $getopt_factory;
+
+    /**
+     *
+     * Imported $_SERVER values.
+     *
+     * @var Server
+     *
+     */
+    protected $server;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param Env $env Imported $_ENV values.
+     *
+     * @param Server $server Imported $_SERVER values.
+     *
+     * @param Argv $argv Imported $argv values.
+     *
+     * @param GetoptFactory $getopt_factory A factory for Getopt objects.
+     *
+     */
+    public function __construct(
+        Env $env,
+        Server $server,
+        Argv $argv,
+        GetoptFactory $getopt_factory
+    ) {
+        $this->env = $env;
+        $this->server = $server;
+        $this->argv = $argv;
+        $this->getopt_factory = $getopt_factory;
+    }
+
+    /**
+     *
+     * Magic read for property objects.
+     *
+     * @param string $key The property to get.
+     *
+     * @return mixed A property object.
+     *
+     */
+    public function __get($key)
+    {
+        return $this->$key;
+    }
+
+    /**
+     *
+     * Returns a new Getopt instance.
+     *
+     * @param array $options Option definitions for the Getopt instance.
+     *
+     * @return Getopt
+     *
+     */
+    public function getopt(array $options)
+    {
+        return $this->getopt_factory->newInstance(
+            $this->argv->get(),
+            $options
+        );
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Context/AbstractValues.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Context/AbstractValues.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Context;
+
+/**
+ *
+ * A read-only representation of data values.
+ *
+ * @package Aura.Cli
+ *
+ */
+class AbstractValues
+{
+    /**
+     *
+     * The values represented by this object.
+     *
+     * @var array
+     *
+     */
+    protected $values;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param array $values The values to be represented by this object.
+     *
+     */
+    public function __construct(array $values = array())
+    {
+        $this->values = $values;
+    }
+
+    /**
+     *
+     * Returns a value by key, an alternative value if that key does not exist,
+     * or all values if no key is passed.
+     *
+     * @param string $key The key, if any, to get the value of; if null, will
+     * return all values.
+     *
+     * @param string $alt The alternative default value to return if the
+     * requested key does not exist.
+     *
+     * @return mixed The requested value, or the alternative default
+     * value; or, if no key was passed, all values.
+     *
+     */
+    public function get($key = null, $alt = null)
+    {
+        if ($key === null) {
+            return $this->values;
+        }
+
+        if (array_key_exists($key, $this->values)) {
+            return $this->values[$key];
+        }
+
+        return $alt;
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Context/Argv.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Context/Argv.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Context;
+
+/**
+ *
+ * A read-only representation of $argv values.
+ *
+ * @package Aura.Cli
+ *
+ */
+class Argv extends AbstractValues
+{
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Context/Env.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Context/Env.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Context;
+
+/**
+ *
+ * A read-only representation of $_ENV values; falls back to getenv() when the
+ * value does not exist in $_ENV.
+ *
+ * @package Aura.Cli
+ *
+ */
+class Env extends AbstractValues
+{
+    /**
+     *
+     * Returns a value.
+     *
+     * @param string $key The key, if any, to get the value of; if null, will
+     * return all values.
+     *
+     * @param string $alt The alternative default value to return if the
+     * requested key does not exist.
+     *
+     * @return mixed The requested value, or the alternative default
+     * value.
+     *
+     */
+    public function get($key = null, $alt = null)
+    {
+        $val = parent::get($key, $alt);
+        if ($val !== $alt) {
+            return $val;
+        }
+
+        $val = getenv($key);
+        if ($val !== false) {
+            return $val;
+        }
+
+        return $alt;
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Context/Getopt.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Context/Getopt.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Context;
+
+/**
+ *
+ * A read-only representation of named option and numeric argument values.
+ *
+ * @package Aura.Cli
+ *
+ */
+class Getopt extends AbstractValues
+{
+    /**
+     *
+     * Any getopt parsing errors.
+     *
+     * @var array
+     *
+     */
+    protected $errors = array();
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param array $values The values to be represented by this object.
+     *
+     * @param array $errors Any getopt parsing errors.
+     *
+     */
+    public function __construct(
+        array $values = array(),
+        array $errors = array()
+    ) {
+        parent::__construct($values);
+        $this->errors = $errors;
+    }
+
+    /**
+      *
+      * Are there error messages related to getopt parsing?
+      *
+      * @return bool
+      *
+      */
+    public function hasErrors()
+    {
+        return $this->errors ? true : false;
+    }
+
+    /**
+     *
+     * Returns the error messages related to getopt parsing.
+     *
+     * @return array
+     *
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Context/GetoptFactory.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Context/GetoptFactory.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Context;
+
+use EllisLab\ExpressionEngine\Cli\Context\Getopt;
+
+/**
+ *
+ * A factory to create Getopt objects.
+ *
+ * @package Aura.Cli
+ *
+ */
+class GetoptFactory
+{
+    /**
+     *
+     * A getopt parser.
+     *
+     * @var GetoptParser
+     *
+     */
+    protected $getopt_parser;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param GetoptParser $getopt_parser A getopt parser.
+     *
+     */
+    public function __construct(GetoptParser $getopt_parser)
+    {
+        $this->getopt_parser = $getopt_parser;
+    }
+
+    /**
+     *
+     * Returns the getopt parser.
+     *
+     * @return GetoptParser
+     *
+     */
+    public function getGetoptParser()
+    {
+        return $this->getopt_parser;
+    }
+
+    /**
+     *
+     * Returns a new Getopt instance.
+     *
+     * @param array $input The command line input array, as from $argv.
+     *
+     * @param array $options An options defintion array.
+     *
+     * @return Getopt
+     *
+     */
+    public function newInstance(array $input, array $options)
+    {
+        $this->getopt_parser->setOptions($options);
+        $this->getopt_parser->parseInput($input);
+        return new Getopt(
+            $this->getopt_parser->getValues(),
+            $this->getopt_parser->getErrors()
+        );
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Context/GetoptParser.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Context/GetoptParser.php
@@ -1,0 +1,508 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Context;
+
+use EllisLab\ExpressionEngine\Cli\Exception;
+use StdClass;
+
+/**
+ *
+ * Parses command line input for named option and numeric argument values.
+ *
+ * @package Aura.Cli
+ *
+ */
+class GetoptParser
+{
+    /**
+     *
+     * Any parsing errors.
+     *
+     * @var array
+     *
+     */
+    protected $errors;
+
+    /**
+     *
+     * The command line input to be parsed.
+     *
+     * @var array
+     *
+     */
+    protected $input;
+
+    /**
+     *
+     * Use these option definitions when parsing input.
+     *
+     * @var array
+     *
+     */
+    protected $options;
+
+    /**
+     *
+     * The values parsed from the command line input.
+     *
+     * @var array
+     *
+     */
+    protected $values;
+
+    /**
+     *
+     * A factory to create option objects.
+     *
+     * @var OptionFactory
+     *
+     */
+    protected $option_factory;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param OptionFactory $option_factory A factory to create option objects.
+     *
+     */
+    public function __construct(OptionFactory $option_factory)
+    {
+        $this->option_factory = $option_factory;
+    }
+
+    /**
+     *
+     * Sets the options to be used when parsing input.
+     *
+     * @param array $options The array of option definitions.
+     *
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = array();
+        foreach ($options as $string => $descr) {
+            $this->setOption($string, $descr);
+        }
+    }
+
+    /**
+     *
+     * Sets one option to be used when parsing input.
+     *
+     * @param string $string The option definition string.
+     *
+     * @param string $descr The option help description.
+     *
+     */
+    protected function setOption($string, $descr)
+    {
+        $option = $this->option_factory->newInstance($string, $descr);
+        if (! $option->name) {
+            $this->options[] = $option;
+        } else {
+            $this->options[$option->name] = $option;
+        }
+    }
+
+    /**
+     *
+     * Parses the input array according to the defined options.
+     *
+     * @param array $input The input array.
+     *
+     * @return bool False if there were parsing errors, true if there were no
+     * errors.
+     *
+     */
+    public function parseInput(array $input = array())
+    {
+        $this->input = $input;
+        $this->errors = array();
+        $this->values = array();
+
+        // flag to say when we've reached the end of options
+        $done = false;
+
+        // sequential argument count;
+        $args = 0;
+
+        // loop through a copy of the input values to be parsed
+        while ($this->input) {
+
+            // shift each element from the top of the $this->input source
+            $arg = array_shift($this->input);
+
+            // after a plain double-dash, all values are args (not options)
+            if ($arg == '--') {
+                $done = true;
+                continue;
+            }
+
+            // long option, short option, or numeric argument?
+            if (! $done && substr($arg, 0, 2) == '--') {
+                $this->setLongOptionValue($arg);
+            } elseif (! $done && substr($arg, 0, 1) == '-') {
+                $this->setShortFlagValue($arg);
+            } else {
+                $this->values[$args ++] = $arg;
+            }
+        }
+
+        // done
+        return $this->errors ? false : true;
+    }
+
+    /**
+     *
+     * Gets a single option definition converted to an array.
+     *
+     * Looking for an undefined option will cause an error message, but will
+     * otherwise proceed. Undefined short flags are treated as rejecting a
+     * param, and undefined long options are treated as taking an optional
+     * param.
+     *
+     * @param string $name The definition key to look for.
+     *
+     * @return StdClass An option struct.
+     *
+     */
+    public function getOption($name)
+    {
+        if (isset($this->options[$name])) {
+            $option = $this->options[$name];
+        } else {
+            $option = $this->getOptionByAlias($name);
+        }
+
+        if (! $option) {
+            $this->errors[] = new Exception\OptionNotDefined(
+                "The option '$name' is not defined."
+            );
+            $option = $this->option_factory->newUndefined($name);
+        }
+
+        return $option;
+    }
+
+    /**
+     *
+     * Gets an option by its alias.
+     *
+     * @param string $alias The option alias.
+     *
+     * @return StdClass|null Returns the matching option struct, or null if no
+     * option was found with that alias.
+     *
+     */
+    protected function getOptionByAlias($alias)
+    {
+        foreach ($this->options as $option) {
+            if ($option->alias == $alias) {
+                return $option;
+            }
+        }
+    }
+
+    /**
+     *
+     * Sets the value for a long option.
+     *
+     * @param string $input The current input element, e.g. "--foo" or
+     * "--bar=baz" or "--bar baz".
+     *
+     * @return bool|null
+     *
+     */
+    protected function setLongOptionValue($input)
+    {
+        list($name, $value) = $this->splitLongOptionInput($input);
+        $option = $this->getOption($name);
+
+        if ($this->longOptionRequiresValue($option, $value)) {
+            $value = array_shift($this->input);
+        }
+
+        return $this->longOptionRequiresValue($option, $value, $name)
+            || $this->longOptionRejectsValue($option, $value, $name)
+            || $this->setValue($option, trim($value) === '' ? true : $value);
+    }
+
+    /**
+     *
+     * Splits the long option input into name and value.
+     *
+     * @param string $input The current input element, e.g. "--foo" or
+     * "--bar=baz".
+     *
+     * @return array An array of the long option name and value.
+     *
+     */
+    protected function splitLongOptionInput($input)
+    {
+        $pos = strpos($input, '=');
+        if ($pos === false) {
+            $name = $input;
+            $value = null;
+        } else {
+            $name = substr($input, 0, $pos);
+            $value = substr($input, $pos + 1);
+        }
+        return array($name, $value);
+    }
+
+    /**
+     *
+     * Does the long option require a param value?
+     *
+     * @param StdClass $option An option struct.
+     *
+     * @param mixed $value The option value.
+     *
+     * @param string $name The option name as passed.
+     *
+     * @return bool
+     *
+     */
+    protected function longOptionRequiresValue($option, $value, $name = null)
+    {
+        if ($option->param == 'required' && trim($value) === '') {
+            if ($name !== null) {
+                $this->errors[] = new Exception\OptionParamRequired(
+                    "The option '$name' requires a parameter."
+                );
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     * Does the long option reject a param value?
+     *
+     * @param StdClass $option An option struct.
+     *
+     * @param mixed $value The option value.
+     *
+     * @param string $name The option name as passed.
+     *
+     * @return bool
+     *
+     */
+    protected function longOptionRejectsValue($option, $value, $name)
+    {
+        if ($option->param == 'rejected' && trim($value) !== '') {
+            $this->errors[] = new Exception\OptionParamRejected(
+                "The option '$name' does not accept a parameter."
+            );
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     * Parses a short option or cluster of short options.
+     *
+     * @param string $name The current input element, e.g. "-f" or "-fbz".
+     *
+     * @return null
+     *
+     */
+    protected function setShortFlagValue($name)
+    {
+        if (strlen($name) > 2) {
+            return $this->setShortFlagValues($name);
+        }
+
+        $option = $this->getOption($name);
+
+        return $this->shortOptionRejectsValue($option)
+            || $this->shortOptionCapturesValue($option)
+            || $this->shortOptionRequiresValue($option, $name)
+            || $this->setValue($option, true);
+    }
+
+    /**
+     *
+     * Does the short option reject a value?
+     *
+     * @param StdClass $option An option struct.
+     *
+     * @return bool
+     *
+     */
+    protected function shortOptionRejectsValue($option)
+    {
+        if ($option->param == 'rejected') {
+            $this->setValue($option, true);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     * Does the short option capture the next input element as a value?
+     *
+     * @param StdClass $option An option struct.
+     *
+     * @return bool
+     *
+     */
+    protected function shortOptionCapturesValue($option)
+    {
+        $value = reset($this->input);
+        $is_value = ! empty($value) && substr($value, 0, 1) != '-';
+        if ($is_value) {
+            $this->setValue($option, array_shift($this->input));
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     * Does the short option require the next input element to be a value?
+     *
+     * @param StdClass $option An option struct.
+     *
+     * @param string $name The option name.
+     *
+     * @return bool
+     *
+     */
+    protected function shortOptionRequiresValue($option, $name)
+    {
+        if ($option->param == 'required') {
+            $this->errors[] = new Exception\OptionParamRequired(
+                "The option '$name' requires a parameter."
+            );
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     *
+     * Parses a cluster of short options.
+     *
+     * @param string $chars The short-option cluster (e.g. "-abcd").
+     *
+     * @return null
+     *
+     */
+    protected function setShortFlagValues($chars)
+    {
+        // drop the leading dash in the cluster and split into single chars
+        $chars = str_split(substr($chars, 1));
+        while ($char = array_shift($chars)) {
+            $name = "-$char";
+            $option = $this->getOption($name);
+            if (! $this->shortOptionRequiresValue($option, $name)) {
+                $this->setValue($option, true);
+            }
+        }
+    }
+
+    /**
+     *
+     * Sets an option value, adding to a value array for multi-values.
+     *
+     * @param StdClass $option The option struct.
+     *
+     * @param mixed $value The option value.
+     *
+     * @return null
+     *
+     */
+    protected function setValue($option, $value)
+    {
+        if ($option->multi) {
+            $this->addMultiValue($option, $value);
+        } else {
+            $this->setSingleValue($option, $value);
+        }
+    }
+
+    /**
+     *
+     * Adds to an array of multi-values for the option.
+     *
+     * @param StdClass $option The option struct.
+     *
+     * @param mixed $value The value to add to the array of multi-values.
+     *
+     * @return null
+     *
+     */
+    protected function addMultiValue($option, $value)
+    {
+        $this->values[$option->name][] = $value;
+        if ($option->alias) {
+            $this->values[$option->alias][] = $value;
+        }
+    }
+
+    /**
+     *
+     * Sets the single value for an option.
+     *
+     * @param StdClass $option The option struct.
+     *
+     * @param mixed $value The value to set.
+     *
+     * @return null
+     *
+     */
+    protected function setSingleValue($option, $value)
+    {
+        $this->values[$option->name] = $value;
+        if ($option->alias) {
+            $this->values[$option->alias] = $value;
+        }
+    }
+
+    /**
+     *
+     * Returns the defined options.
+     *
+     * @return array
+     *
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     *
+     * Returns the parsed values of named options and sequential arguments.
+     *
+     * @return array
+     *
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    /**
+     *
+     * Returns the parsing errors.
+     *
+     * @return array
+     *
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Context/OptionFactory.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Context/OptionFactory.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Context;
+
+/**
+ *
+ * A factory for option objects.
+ *
+ * @package Aura.Cli
+ *
+ */
+class OptionFactory
+{
+    /**
+     *
+     * Returns a new option struct from an option definition string and
+     * description.
+     *
+     * @param string $string The option definition string.
+     *
+     * @param string $descr The option description.
+     *
+     * @return StdClass
+     *
+     */
+    public function newInstance($string, $descr = null)
+    {
+        if (is_int($string)) {
+            $string = $descr;
+            $descr = null;
+        }
+
+        $string = trim($string);
+
+        $option = (object) array(
+            'name'  => null,
+            'alias' => null,
+            'multi' => false,
+            'param' => 'rejected',
+            'descr' => $descr,
+        );
+
+        if (substr($string, 0, 1) == '#') {
+            $this->setArgument($option, $string);
+            return $option;
+        }
+
+        $this->setNewOptionMulti($option, $string);
+        $this->setNewOptionParam($option, $string);
+        $this->setNewOptionMulti($option, $string);
+        $this->setNewOptionNameAlias($option, $string);
+        return $option;
+    }
+
+    /**
+     *
+     * Sets an option as an argument, to be ignored when parsing options.
+     *
+     * @param StdClass $option The option struct.
+     *
+     * @param string $string The argument name.
+     *
+     * @return null
+     *
+     */
+    protected function setArgument($option, $string)
+    {
+        $string = ltrim($string, '# -');
+
+        $option->param = 'argument-required';
+        if (substr($string, -1) == '?') {
+            $option->param = 'argument-optional';
+            $string = rtrim($string, '? -');
+        }
+
+        $option->alias = $string;
+    }
+
+    /**
+     *
+     * Given an undefined option name, returns a default option struct for it.
+     *
+     * @param string $name The undefined option name.
+     *
+     * @return StdClass An option struct.
+     *
+     */
+    public function newUndefined($name)
+    {
+        if (strlen($name) == 1) {
+            return $this->newInstance($name);
+        }
+
+        return $this->newInstance("{$name}::");
+    }
+
+    /**
+     *
+     * Sets the $param property on a new option struct.
+     *
+     * @param StdClass $option The option struct.
+     *
+     * @param $string The option definition string.
+     *
+     * @return null
+     *
+     */
+    protected function setNewOptionParam($option, &$string)
+    {
+        if (substr($string, -2) == '::') {
+            $option->param = 'optional';
+            $string = substr($string, 0, -2);
+        } elseif (substr($string, -1) == ':') {
+            $option->param = 'required';
+            $string = substr($string, 0, -1);
+        }
+
+        $string = rtrim($string, ':');
+    }
+
+    /**
+     *
+     * Sets the $multi property on a new option struct.
+     *
+     * @param StdClass $option The option struct.
+     *
+     * @param $string The option definition string.
+     *
+     * @return null
+     *
+     */
+    protected function setNewOptionMulti($option, &$string)
+    {
+        if (substr($string, -1) == '*') {
+            $option->multi = true;
+            $string = substr($string, 0, -1);
+        }
+    }
+
+    /**
+     *
+     * Sets the $name and $alias properties on a new option struct.
+     *
+     * @param StdClass $option The option struct.
+     *
+     * @param $string The option definition string.
+     *
+     * @return null
+     *
+     */
+    protected function setNewOptionNameAlias($option, &$string)
+    {
+        $names = explode(',', $string);
+        $option->name = $this->fixOptionName($names[0]);
+        if (isset($names[1])) {
+            $option->alias = $this->fixOptionName($names[1]);
+        }
+    }
+
+    /**
+      *
+      * Normalizes the option name.
+      *
+      * @param string $name The option character or long name.
+      *
+      * @return The fixed name with a leading dash or dashes.
+      *
+      */
+    protected function fixOptionName($name)
+    {
+        $name = trim($name, ' -');
+        if (strlen($name) == 1) {
+            return "-$name";
+        }
+        return "--$name";
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Context/Server.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Context/Server.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Context;
+
+/**
+ *
+ * A read-only representation of $_SERVER values.
+ *
+ * @package Aura.Cli
+ *
+ */
+class Server extends AbstractValues
+{
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Exception.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Exception.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli;
+
+/**
+ *
+ * Generic package exception.
+ *
+ * @package Aura.Cli
+ *
+ */
+class Exception extends \Exception
+{
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Exception/ExtensionNotAvailable.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Exception/ExtensionNotAvailable.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Exception;
+
+use EllisLab\ExpressionEngine\Cli\Exception as CliException;
+
+/**
+ *
+ * Trying to use functionality that isn't available.
+ *
+ * @package Aura.Cli
+ *
+ */
+class ExtensionNotAvailable extends CliException
+{
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Exception/FunctionNotAvailable.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Exception/FunctionNotAvailable.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Exception;
+
+use EllisLab\ExpressionEngine\Cli\Exception as CliException;
+
+/**
+ *
+ * Trying to use functionality that isn't available.
+ *
+ * @package Aura.Cli
+ *
+ */
+class FunctionNotAvailable extends CliException
+{
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Exception/OptionNotDefined.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Exception/OptionNotDefined.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Exception;
+
+use EllisLab\ExpressionEngine\Cli\Exception as CliException;
+
+/**
+ *
+ * Asked for an option that is not defined.
+ *
+ * @package Aura.Cli
+ *
+ */
+class OptionNotDefined extends CliException
+{
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Exception/OptionParamRejected.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Exception/OptionParamRejected.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Exception;
+
+use EllisLab\ExpressionEngine\Cli\Exception as CliException;
+
+/**
+ *
+ * The option requires that no parameter be present.
+ *
+ * @package Aura.Cli
+ *
+ */
+class OptionParamRejected extends CliException
+{
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Exception/OptionParamRequired.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Exception/OptionParamRequired.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Exception;
+
+use EllisLab\ExpressionEngine\Cli\Exception as CliException;
+
+/**
+ *
+ * The option requires a non-blank parameter.
+ *
+ * @package Aura.Cli
+ *
+ */
+class OptionParamRequired extends CliException
+{
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Exception/SignalNotCatchable.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Exception/SignalNotCatchable.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Exception;
+
+use EllisLab\ExpressionEngine\Cli\Exception as CliException;
+
+/**
+ *
+ * Trying to catch a signal that isn't catchable or that isn't a signal.
+ *
+ * @package Aura.Cli
+ *
+ */
+class SignalNotCatchable extends CliException
+{
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Help.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Help.php
@@ -1,0 +1,501 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli;
+
+use EllisLab\ExpressionEngine\Cli\Context\OptionFactory;
+
+/**
+ *
+ * Represents the "help" information for a command.
+ *
+ * @package Aura.Cli
+ *
+ */
+class Help
+{
+    /**
+     *
+     * The long-form help text.
+     *
+     * @var string
+     *
+     */
+    protected $descr;
+
+    /**
+     *
+     * A option factory.
+     *
+     * @var OptionFactory
+     *
+     */
+    protected $option_factory;
+
+    /**
+     *
+     * The option definitions.
+     *
+     * @var array
+     *
+     */
+    protected $options = array();
+
+    /**
+     *
+     * A single-line summary for the command.
+     *
+     * @var string
+     *
+     */
+    protected $summary;
+
+    /**
+     *
+     * One or more single-line usage examples.
+     *
+     * @var string|array
+     *
+     */
+    protected $usage;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param OptionFactory $option_factory An option factory.
+     *
+     */
+    public function __construct(OptionFactory $option_factory)
+    {
+        $this->option_factory = $option_factory;
+        $this->init();
+    }
+
+    /**
+     *
+     * Use this to initialize the help object in child classes.
+     *
+     * @return null
+     *
+     */
+    protected function init()
+    {
+        $this->summary = '';
+
+        return $this;
+    }
+
+    /**
+     *
+     * Sets the option definitions.
+     *
+     * @param array $options The option definitions.
+     *
+     * @return null
+     *
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     *
+     * Gets the option definitions.
+     *
+     * @return array
+     *
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     *
+     * Sets the single-line summary.
+     *
+     * @param string $summary The single-line summary.
+     *
+     * @return null
+     *
+     */
+    public function setSummary($summary)
+    {
+        $this->summary = $summary;
+
+        return $this;
+    }
+
+    /**
+     *
+     * Gets the single-line summary.
+     *
+     * @return string
+     *
+     */
+    public function getSummary()
+    {
+        return $this->summary;
+    }
+
+    /**
+     *
+     * Sets the custom usage line(s).
+     *
+     * @param string|array $usage The usage line(s).
+     *
+     * @return null
+     *
+     */
+    public function setUsage($usage)
+    {
+        $this->usage = $usage;
+
+        return $this;
+    }
+
+    /**
+     *
+     * Sets the long-form description.
+     *
+     * @param string $descr The long-form description.
+     *
+     * @return null
+     *
+     */
+    public function setDescr($descr)
+    {
+        $this->descr = $descr;
+
+        return $this;
+    }
+
+    /**
+     *
+     * Gets the formatted help output.
+     *
+     * @param string $name The command name.
+     *
+     * @return string
+     *
+     */
+    public function getHelp($name)
+    {
+        $help = $this->getHelpSummary($name)
+              . $this->getHelpUsage($name)
+              . $this->getHelpDescr()
+              . $this->getHelpArguments()
+              . $this->getHelpOptions()
+        ;
+
+        if (! $help) {
+            $help = "No help available.";
+        }
+
+        return rtrim($help) . PHP_EOL;
+    }
+
+    /**
+     *
+     * Gets the formatted summary output.
+     *
+     * @param string $name The command name.
+     *
+     * @return string
+     *
+     */
+    protected function getHelpSummary($name)
+    {
+        if (! $this->summary) {
+            return;
+        }
+
+        return "<<bold>>SUMMARY<<reset>>" . PHP_EOL
+             . "    <<bold>>{$name}<<reset>> -- " . $this->getSummary()
+             . PHP_EOL . PHP_EOL;
+    }
+
+    /**
+     *
+     * Gets the formatted usage output.
+     *
+     * @param string $name The command name.
+     *
+     * @return string
+     *
+     */
+    protected function getHelpUsage($name)
+    {
+        // hack to maintain back-compat. basically, if there's nothing else,
+        // there shouldn't be automatic usage displayed either.
+        $empty = ! $this->usage
+              && ! $this->options
+              && ! $this->summary
+              && ! $this->descr;
+
+        if ($empty) {
+            return '';
+        }
+
+        $usages = $this->getUsage();
+        if (! $usages) {
+            return;
+        }
+
+        $text = "<<bold>>USAGE<<reset>>" . PHP_EOL;
+        foreach ($usages as $usage) {
+            if ($usage) {
+                $usage = " {$usage}";
+            }
+            $text .= "    <<ul>>$name<<reset>>{$usage}" . PHP_EOL;
+        }
+        return $text . PHP_EOL;
+    }
+
+    /**
+     *
+     * Returns the custom usage line(s), or the default usage line.
+     *
+     * @return array
+     *
+     */
+    protected function getUsage()
+    {
+        $usage = $this->usage;
+        if (! $this->usage) {
+            $usage = $this->getUsageArguments();
+        }
+        return (array) $usage;
+    }
+
+    /**
+     *
+     * Returns the arguments for the default usage line.
+     *
+     * @return string
+     *
+     */
+    protected function getUsageArguments()
+    {
+        $args = array();
+        foreach ($this->options as $string => $descr) {
+            $option = $this->option_factory->newInstance($string, $descr);
+            $this->addUsageArgument($args, $option);
+        }
+        return implode(' ', $args);
+    }
+
+    /**
+     *
+     * Adds a default usage argument.
+     *
+     * @param array $args The default usage arguments.
+     *
+     * @param StdClass $option An option struct.
+     *
+     */
+    protected function addUsageArgument(&$args, $option)
+    {
+        if ($option->name) {
+            // an argument, not an option
+            return;
+        }
+
+        $arg =  '<' . $option->alias . '>';
+
+        if ($option->param == 'argument-optional') {
+            $arg = "[{$arg}]";
+        }
+
+        $args[] = $arg;
+    }
+
+    /**
+     *
+     * Returns the formatted argument descriptions.
+     *
+     * @return string
+     *
+     */
+    protected function getHelpArguments()
+    {
+        $args = array();
+        foreach ($this->options as $string => $descr) {
+            $option = $this->option_factory->newInstance($string, $descr);
+            if (! $option->name) {
+                $args[] = $option;
+            }
+        }
+
+        if (! $args) {
+            return;
+        }
+
+        $text = '';
+        foreach ($args as $arg) {
+            $text .= "    <{$arg->alias}>" . PHP_EOL;
+            if ($arg->descr) {
+                $text .= "        {$arg->descr}";
+            } else {
+                $text .= "        No description.";
+            }
+            $text .= PHP_EOL . PHP_EOL;
+        }
+
+        return "<<bold>>ARGUMENTS<<reset>>" . PHP_EOL
+             . "    " . trim($text) . PHP_EOL . PHP_EOL;
+    }
+
+    /**
+     *
+     * Gets the formatted options output.
+     *
+     * @return string
+     *
+     */
+    protected function getHelpOptions()
+    {
+        if (! $this->options) {
+            return;
+        }
+
+        $text = "<<bold>>OPTIONS<<reset>>" . PHP_EOL;
+        foreach ($this->options as $string => $descr) {
+            $option = $this->option_factory->newInstance($string, $descr);
+            $text .= $this->getHelpOption($option);
+        }
+        return $text;
+    }
+
+    /**
+     *
+     * Gets the formatted output for one option.
+     *
+     * @param \stdClass $option An option structure.
+     *
+     * @return string
+     *
+     */
+    protected function getHelpOption($option)
+    {
+        if (! $option->name) {
+            // it's an argument
+            return '';
+        }
+
+        $text = "    "
+              . $this->getHelpOptionParam($option->name, $option->param, $option->multi)
+              . PHP_EOL;
+
+        if ($option->alias) {
+            $text .= "    "
+                   . $this->getHelpOptionParam($option->alias, $option->param, $option->multi)
+                   . PHP_EOL;
+        }
+
+        if (! $option->descr) {
+            $option->descr = 'No description.';
+        }
+
+        return $text
+             . "        " . trim($option->descr) . PHP_EOL . PHP_EOL;
+    }
+
+    /**
+     *
+     * Gets the formatted output for an option param.
+     *
+     * @param string $name The option name.
+     *
+     * @param string $param The option param flag.
+     *
+     * @param bool $multi The option multi flag.
+     *
+     * @return string
+     *
+     */
+    protected function getHelpOptionParam($name, $param, $multi)
+    {
+        $text = "{$name}";
+        if (strlen($name) == 2) {
+            $text .= $this->getHelpOptionParamShort($param);
+        } else {
+            $text .= $this->getHelpOptionParamLong($param);
+        }
+
+        if ($multi) {
+            $text .= " [$text [...]]";
+        }
+        return $text;
+    }
+
+    /**
+     *
+     * Gets the formatted output for a short option param.
+     *
+     * @param string $param The option param flag.
+     *
+     * @return string
+     *
+     */
+    protected function getHelpOptionParamShort($param)
+    {
+        if ($param == 'required') {
+            return " <value>";
+        }
+
+        if ($param == 'optional') {
+            return " [<value>]";
+        }
+
+        return "";
+    }
+
+    /**
+     *
+     * Gets the formatted output for a long option param.
+     *
+     * @param string $param The option param flag.
+     *
+     * @return string
+     *
+     */
+    protected function getHelpOptionParamLong($param)
+    {
+        if ($param == 'required') {
+            return "=<value>";
+        }
+
+        if ($param == 'optional') {
+            return "[=<value>]";
+        }
+
+        return "";
+    }
+
+    /**
+     *
+     * Gets the formatted output for the long-form description.
+     *
+     * @return string
+     *
+     */
+    public function getHelpDescr()
+    {
+        if (! $this->descr) {
+            return;
+        }
+
+        return "<<bold>>DESCRIPTION<<reset>>" . PHP_EOL
+             . "    " . trim($this->descr) . PHP_EOL . PHP_EOL;
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/StandaloneCli/StandaloneCli.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/StandaloneCli/StandaloneCli.php
@@ -1,0 +1,25 @@
+<?php
+
+// Autoload the CLI
+require SYSPATH . 'ee/EllisLab/ExpressionEngine/Core/Autoloader.php';
+
+EllisLab\ExpressionEngine\Core\Autoloader::getInstance()
+    ->addPrefix('EllisLab', SYSPATH.'ee/EllisLab')
+    ->addPrefix('ExpressionEngine\Addons', SYSPATH.'ee/EllisLab/Addons')
+    ->register();
+
+// Define constants we need
+defined('FILE_READ_MODE') || define('FILE_READ_MODE', 0644);
+defined('FILE_WRITE_MODE') || define('FILE_WRITE_MODE', 0666);
+defined('DIR_READ_MODE') || define('DIR_READ_MODE', 0755);
+defined('DIR_WRITE_MODE') || define('DIR_WRITE_MODE', 0777);
+defined('PATH_CACHE') || define('PATH_CACHE', SYSPATH.'user/cache/');
+
+
+$cli = new EllisLab\ExpressionEngine\Cli\Cli;
+
+$cli->process();
+
+// This will be all we do, so we'll die here.
+// However, the CLI service should handle the completion, this is just a fallback
+die();

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Status.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Status.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli;
+
+/**
+ *
+ * Constants for preferred exit status codes; cf.
+ * <http://www.unix.com/man-page/freebsd/3/sysexits/>.
+ *
+ * @package Aura.Cli
+ *
+ */
+class Status
+{
+    /**
+     * Success
+     */
+    const SUCCESS       = 0;
+
+    /**
+     * Failure
+     */
+    const FAILURE       = 1;
+
+    /**
+     * The command was used incorrectly, e.g., with the wrong number of
+     * arguments, a bad flag, a bad syntax in a parameter, or whatever.
+     */
+    const USAGE         = 64;
+
+    /**
+     * The input data was incorrect in some way. This should only be used for
+     * user’s data and not system files.
+     */
+    const DATAERR       = 65;
+
+    /**
+     * An input file (not a system file) did not exist or was not readable.
+     * This could also include errors like "No message" to a mailer (if it
+     * cared to catch it).
+     */
+    const NOINPUT       = 66;
+
+    /**
+     * The user specified did not exist. This might be used for mail addresses
+     * or remote logins.
+     */
+    const NOUSER        = 67;
+
+    /**
+     * The host specified did not exist. This is used in mail addresses or
+     * network requests.
+     */
+    const NOHOST        = 68;
+
+    /**
+     * A service is unavailable. This can occur if a support program or file
+     * does not exist. This can also be used as a catchall message when
+     * something you wanted to do does not work, but you do not know why.
+     */
+    const UNAVAILABLE   = 69;
+
+    /**
+     * An internal software error has been detected. This should be limited
+     * to non-operating system related errors as possible.
+     */
+    const SOFTWARE      = 70;
+
+    /**
+     * An operating system error has been detected. This is intended to be
+     * used for such things as "cannot fork", "cannot create pipe", or the
+     * like. It includes things like getuid returning a user that does not
+     * exist in the passwd file.
+     */
+    const OSERR         = 71;
+
+    /**
+     * Some system file (e.g., /etc/passwd, /var/run/utmp, etc.) does not
+     * exist, cannot be opened, or has some sort of error (e.g., syntax
+     * error).
+     */
+    const OSFILE        = 72;
+
+    /**
+     * A (user specified) output file cannot be created.
+     */
+    const CANTCREAT     = 73;
+
+    /**
+     * An error occurred while doing I/O on some file.
+     */
+    const IOERR         = 74;
+
+    /**
+     * Temporary failure, indicating something that is not really an error.
+     * In sendmail, this means that a mailer (e.g.) could not create a
+     * connection, and the request should be reattempted later.
+     */
+    const TEMPFAIL      = 75;
+
+    /**
+     * The remote system returned something that was "not possible" during a
+     * protocol exchange.
+     */
+    const PROTOCOL      = 76;
+
+    /**
+     * You did not have sufficient permission to perform the operation. This
+     * is not intended for file system problems, which should use NOINPUT
+     * or CANTCREAT, but rather for higher level permissions.
+     */
+    const NOPERM        = 77;
+
+    /**
+     * Something was found in an unconfigured or misconfigured state.
+     */
+    const CONFIG        = 78;
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Stdio.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Stdio.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli;
+
+use EllisLab\ExpressionEngine\Cli\Stdio\Handle;
+use EllisLab\ExpressionEngine\Cli\Stdio\Formatter;
+
+/**
+ *
+ * Provides a wrapper for standard input/output streams.
+ *
+ * @package Aura.Cli
+ *
+ */
+class Stdio
+{
+    /**
+     *
+     * A Handle object for standard input.
+     *
+     * @var Handle
+     *
+     */
+    protected $stdin;
+
+    /**
+     *
+     * A Handle object for standard output.
+     *
+     * @var Handle
+     *
+     */
+    protected $stdout;
+
+    /**
+     *
+     * A Handle object for standard error.
+     *
+     * @var Handle
+     *
+     */
+    protected $stderr;
+
+    /**
+     *
+     * A Formatter object to format output.
+     *
+     * @var Formatter
+     *
+     */
+    protected $formatter;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param Handle $stdin A Handle object for standard input.
+     *
+     * @param Handle $stdout A Handle object for standard output.
+     *
+     * @param Handle $stderr A Handle object for standard error.
+     *
+     * @param Formatter $formatter A VT100 formatting object.
+     *
+     */
+    public function __construct(
+        Handle $stdin,
+        Handle $stdout,
+        Handle $stderr,
+        Formatter $formatter
+    ) {
+        $this->stdin  = $stdin;
+        $this->stdout = $stdout;
+        $this->stderr = $stderr;
+        $this->formatter  = $formatter;
+    }
+
+    /**
+     *
+     * Returns the standard input Handle object.
+     *
+     * @return Handle
+     *
+     */
+    public function getStdin()
+    {
+        return $this->stdin;
+    }
+
+    /**
+     *
+     * Returns the standard output Handle object.
+     *
+     * @return Handle
+     *
+     */
+    public function getStdout()
+    {
+        return $this->stdout;
+    }
+
+    /**
+     *
+     * Returns the standard error Handle object.
+     *
+     * @return Handle
+     *
+     */
+    public function getStderr()
+    {
+        return $this->stderr;
+    }
+
+    /**
+     *
+     * Gets user input from the command line and trims the end-of-line.
+     *
+     * @return string
+     *
+     */
+    public function in()
+    {
+        return rtrim($this->stdin->fgets(), PHP_EOL);
+    }
+
+    /**
+     *
+     * Gets user input from the command line and leaves the end-of-line in
+     * place.
+     *
+     * @return string
+     *
+     */
+    public function inln()
+    {
+        return $this->stdin->fgets();
+    }
+
+    /**
+     *
+     * Prints formatted text to standard output **without** a trailing newline.
+     *
+     * @param string $string The text to print to standard output.
+     *
+     * @return null
+     *
+     */
+    public function out($string = null)
+    {
+        $string = $this->formatter->format($string, $this->stdout->isPosix());
+        $this->stdout->fwrite($string);
+    }
+
+    /**
+     *
+     * Prints formatted text to standard output **with** a trailing newline.
+     *
+     * @param string $string The text to print to standard output.
+     *
+     * @return null
+     *
+     */
+    public function outln($string = null)
+    {
+        $this->out($string . PHP_EOL);
+    }
+
+    /**
+     *
+     * Prints formatted text to standard error **without** a trailing newline.
+     *
+     * @param string $string The text to print to standard error.
+     *
+     * @return null
+     *
+     */
+    public function err($string = null)
+    {
+        $string = $this->formatter->format($string, $this->stderr->isPosix());
+        $this->stderr->fwrite($string);
+    }
+
+    /**
+     *
+     * Prints formatted text to standard error **with** a trailing newline.
+     *
+     * @param string $string The text to print to standard error.
+     *
+     * @return null
+     *
+     */
+    public function errln($string = null)
+    {
+        $this->err($string . PHP_EOL);
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Stdio/Formatter.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Stdio/Formatter.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Stdio;
+
+/**
+ *
+ * Converts <<markup>> to VT100 display control codes for POSIX, or strips
+ * the <<markup>> entirely for non-POSIX.
+ *
+ * @package Aura.Cli
+ *
+ * @author Paul M. Jones <pmjones@paul-m-jones.com>
+ *
+ */
+class Formatter
+{
+    /**
+     *
+     * Array of <<markup>> names to control code numbers.
+     *
+     * Based on the `ANSI/VT100 Terminal Control reference` at
+     * <http://www.termsys.demon.co.uk/vtansi.htm>.
+     *
+     * @var array
+     *
+     */
+    protected $codes = array(
+        'reset'       => '0',
+        'bold'        => '1',
+        'dim'         => '2',
+        'ul'          => '4',
+        'blink'       => '5',
+        'reverse'     => '7',
+        'black'       => '30',
+        'red'         => '31',
+        'green'       => '32',
+        'yellow'      => '33',
+        'blue'        => '34',
+        'magenta'     => '35',
+        'cyan'        => '36',
+        'white'       => '37',
+        'blackbg'     => '40',
+        'redbg'       => '41',
+        'greenbg'     => '42',
+        'yellowbg'    => '43',
+        'bluebg'      => '44',
+        'magentabg'   => '45',
+        'cyanbg'      => '46',
+        'whitebg'     => '47',
+    );
+
+    /**
+     *
+     * A regex for fomatting codes.
+     *
+     * @var string
+     *
+     */
+    protected $regex;
+
+    /**
+     *
+     * Constructor.
+     *
+     */
+    public function __construct()
+    {
+        $this->regex = '<<\s*((('
+                     . implode('|', array_keys($this->codes))
+                     . ')(\s*))+)>>';
+    }
+
+
+    /**
+     *
+     * Converts <<markup>> in text to VT100 control codes for POSIX, or
+     * strips them for non-POSIX.
+     *
+     * @param string $string The text to format.
+     *
+     * @param bool $posix Is the destination a POSIX terminal?
+     *
+     * @return string The coverted string.
+     *
+     */
+    public function format($string, $posix)
+    {
+        if ($posix) {
+            return preg_replace_callback(
+                "/{$this->regex}/Umsi",
+                array($this, 'formatCallback'),
+                $string
+            );
+        } else {
+            return preg_replace("/{$this->regex}/Umsi", '', $string);
+        }
+    }
+
+    /**
+     *
+     * The callback to format <<markup>> for POSIX.
+     *
+     * @param array $matches The matched <<markup>>.
+     *
+     * @return string
+     *
+     */
+    protected function formatCallback(array $matches)
+    {
+        $str = preg_replace('/(\s+)/msi', ';', $matches[1]);
+        return chr(27) . '[' . strtr($str, $this->codes) . 'm';
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Cli/Stdio/Handle.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Stdio/Handle.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ *
+ * This file is part of Aura for PHP.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php BSD
+ *
+ */
+namespace EllisLab\ExpressionEngine\Cli\Stdio;
+
+/**
+ *
+ * An object-oriented wrapper for file/stream resources.
+ *
+ * @package Aura.Cli
+ *
+ */
+class Handle
+{
+    /**
+     *
+     * The resource represented by the handle.
+     *
+     * @var resource
+     *
+     */
+    protected $resource;
+
+    /**
+     *
+     * The resource name, typically a file or stream name.
+     *
+     * @var string
+     *
+     */
+    protected $name;
+
+    /**
+     *
+     * The mode under which the resource was opened.
+     *
+     * @var string
+     *
+     */
+    protected $mode;
+
+    /**
+     *
+     * What is the current OS? (Used for POSIX checks.)
+     *
+     * @var string
+     *
+     */
+    protected $php_os;
+
+    /**
+     *
+     * Is this a POSIX terminal?
+     *
+     * @var bool
+     *
+     */
+    protected $posix;
+
+    /**
+     *
+     * Constructor.
+     *
+     * @param string $name The resource to open, typically a PHP stream
+     * like "php://stdout".
+     *
+     * @param string $mode Open the resource in this mode; e.g., "w+".
+     *
+     * @param string $php_os Force this PHP OS value; generally for testing.
+     *
+     * @param bool $posix Force this POSIX flag; generally for testing.
+     *
+     */
+    public function __construct($name, $mode, $php_os = null, $posix = null)
+    {
+        $this->name = $name;
+        $this->mode = $mode;
+        $this->resource = fopen($this->name, $this->mode);
+        $this->setPhpOs($php_os);
+        $this->setPosix($posix);
+    }
+
+    /**
+     *
+     * Sets `$php_os`.
+     *
+     * @param string $php_os The operating system; if empty, uses the value of
+     * the PHP_OS constant.
+     *
+     * @return null
+     *
+     */
+    protected function setPhpOs($php_os)
+    {
+        $this->php_os = $php_os;
+        if (! $this->php_os) {
+            $this->php_os = PHP_OS;
+        }
+    }
+
+    /**
+     *
+     * Sets `$posix`.
+     *
+     * @param mixed $posix If boolean, forces the $posix value; otherwise,
+     * checks the `$php_os` value and `posix_isatty()` to auto-determine the
+     * value.
+     *
+     * @return null
+     *
+     */
+    protected function setPosix($posix)
+    {
+        // forcing it off or on?
+        if (is_bool($posix)) {
+            $this->posix = $posix;
+            return;
+        }
+
+        // windows?
+        if (strtolower(substr($this->php_os, 0, 3)) == 'win') {
+            // windows is not posix
+            $this->posix = false;
+            return;
+        }
+
+        // auto-determine; silence posix_isatty() errors regarding
+        // non-standard resources, e.g. php://memory
+        if (function_exists('posix_isatty')) {
+            $level = error_reporting(0);
+            $this->posix = posix_isatty($this->resource);
+            error_reporting($level);
+        }
+    }
+
+    /**
+     *
+     * Destructor; closes the resource if it is not already closed.
+     *
+     * @return null
+     *
+     */
+    public function __destruct()
+    {
+        if ($this->resource) {
+            fclose($this->resource);
+        }
+    }
+
+    /**
+     *
+     * Returns the resource name.
+     *
+     * @return string
+     *
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     *
+     * Returns the resource mode.
+     *
+     * @return string
+     *
+     */
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
+    /**
+     *
+     * Reads 8192 bytes from the resource.
+     *
+     * @return mixed The string read on success, or boolean false on failure.
+     *
+     */
+    public function fread()
+    {
+        return fread($this->resource, 8192);
+    }
+
+    /**
+     *
+     * Writes a string to the resource.
+     *
+     * @param string $string
+     *
+     * @return int The number of bytes written on success, or boolean false on
+     * failure.
+     *
+     */
+    public function fwrite($string)
+    {
+        return fwrite($this->resource, $string);
+    }
+
+    /**
+     *
+     * Rewinds the resource pointer.
+     *
+     * @return bool
+     *
+     */
+    public function rewind()
+    {
+        return rewind($this->resource);
+    }
+
+    /**
+     *
+     * Reads a line from the resource.
+     *
+     * @return string The line on success, or boolean false on failure.
+     *
+     */
+    public function fgets()
+    {
+        return fgets($this->resource);
+    }
+
+    /**
+     *
+     * Does the resource represent an interactive terminal?
+     *
+     * @return bool
+     *
+     */
+    public function isPosix()
+    {
+        return $this->posix;
+    }
+}

--- a/system/ee/EllisLab/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Addons/Addons.php
@@ -23,6 +23,11 @@ class Addons extends CP_Controller {
 	var $params			= array();
 	var $base_url;
 
+	private $addonProviders = [
+		'EllisLab',
+		'Packet Tide',
+	];
+
 	public $assigned_modules = array();
 
 	/**
@@ -482,9 +487,14 @@ class Addons extends CP_Controller {
 					$addon['manual_external'] = TRUE;
 				}
 
-				$party = ($addon['developer'] == 'EllisLab') ? 'first' : 'third';
+				$party = (in_array($addon['developer'], $this->addonProviders))
+							? 'first'
+							: 'third';
+				
 				$addons[$party][$name] = $addon;
+
 			}
+
 		}
 
 		return $addons;

--- a/system/ee/EllisLab/ExpressionEngine/Core/Core.php
+++ b/system/ee/EllisLab/ExpressionEngine/Core/Core.php
@@ -13,6 +13,7 @@ namespace EllisLab\ExpressionEngine\Core;
 use EllisLab\ExpressionEngine\Legacy\App as LegacyApp;
 use EllisLab\ExpressionEngine\Service\Dependency\InjectionContainer;
 use EllisLab\ExpressionEngine\Error\FileNotFound;
+use EllisLab\ExpressionEngine\Cli\Cli;
 
 /**
  * Core Abstract
@@ -101,6 +102,13 @@ abstract class Core {
 		}
 
 		$routing = $this->getRouting($request);
+
+		if(defined('REQ') && REQ === 'CLI') {
+
+			$this->bootCli();
+
+		}
+
 		$routing = $this->loadController($routing);
 		$routing = $this->validateRequest($routing);
 
@@ -110,6 +118,25 @@ abstract class Core {
 		$this->runController($routing);
 
 		return $application->getResponse();
+	}
+
+	/**
+	 * Loads EE CLI
+	 * @return void
+	 */
+	protected function bootCli()
+	{
+
+		$this->legacy->includeBaseController();
+
+		$cli = new Cli;
+
+		$cli->process();
+
+		// This will be all we do, so we'll die here.
+		// However, the CLI service should handle the completion, this is just a fallback
+		die();
+
 	}
 
 	/**

--- a/system/ee/EllisLab/ExpressionEngine/Library/Filesystem/Filesystem.php
+++ b/system/ee/EllisLab/ExpressionEngine/Library/Filesystem/Filesystem.php
@@ -668,6 +668,51 @@ class Filesystem {
 	}
 
 	/**
+	 * Finds string and replaces it
+	 * @param  string $file
+	 * @param  string $search
+	 * @param  string $replace
+	 * @return void
+	 */
+	public function findAndReplace($file, $search, $replace)
+	{
+
+		if ($this->exists($file)) {
+
+		    return;
+
+		}
+
+		// If we're given a directory iterate over the files and recursively call findAndReplace()
+		if ($this->isDir($file)) {
+
+		    foreach ($this->getDirectoryContents($file) as $file) {
+
+		        $this->findAndReplace($file, $search, $replace);
+
+		    }
+
+		    return;
+
+		}
+
+		$contents = $this->read($file);
+
+		if (strpos($search, '/') === 0) {
+
+		    $contents = preg_replace($search, $replace, $contents);
+
+		} else {
+
+		    $contents = str_replace($search, $replace, $contents);
+
+		}
+
+		$this->write($file, $contents, true);
+
+	}
+
+	/**
 	 * Add EE's default index file to a directory
 	 */
 	protected function addIndexHtml($dir)

--- a/system/ee/EllisLab/ExpressionEngine/Library/Filesystem/Filesystem.php
+++ b/system/ee/EllisLab/ExpressionEngine/Library/Filesystem/Filesystem.php
@@ -17,749 +17,749 @@ use FilesystemIterator;
  */
 class Filesystem {
 
-	/**
-	 * Read a file from disk
-	 *
-	 * @param String $path File to read
-	 * @return String File contents
-	 */
-	public function read($path)
-	{
-		if ( ! $this->exists($path))
-		{
-			throw new FilesystemException("File not found: {$path}");
-		}
-		elseif ( ! $this->isFile($path))
-		{
-			throw new FilesystemException("Not a file: {$path}");
-		}
-		elseif ( ! $this->isReadable($path))
-		{
-			throw new FilesystemException("Cannot read file: {$path}");
-		}
-
-		return file_get_contents($this->normalize($path));
-	}
-
-	/**
-	 * Read a file from disk line-by-line, good for large text files
-	 *
-	 * @param String $path File to read
-	 * @param Callable Callback to call for each line of the file, accepts one parameter
-	 */
-	public function readLineByLine($path, Callable $callback)
-	{
-		if ( ! $this->exists($path))
-		{
-			throw new FilesystemException("File not found: {$path}");
-		}
-		elseif ( ! $this->isFile($path))
-		{
-			throw new FilesystemException("Not a file: {$path}");
-		}
-		elseif ( ! $this->isReadable($path))
-		{
-			throw new FilesystemException("Cannot read file: {$path}");
-		}
-
-		$pointer = fopen($path, 'r');
-
-		while ( ! feof($pointer))
-		{
-			$callback(fgets($pointer));
-		}
-
-		fclose($pointer);
-	}
-
-	/**
-	 * Write a file to disk
-	 *
-	 * @param String $path File to write to
-	 * @param String $data Data to write
-	 * @param bool $overwrite Overwrite existing files?
-	 * @param bool $append Append to existing file?
-	 */
-	public function write($path, $data, $overwrite = FALSE, $append = FALSE)
-	{
-		$path = $this->normalize($path);
-
-		if ($this->isDir($path))
-		{
-			throw new FilesystemException("Cannot write file, path is a directory: {$path}");
-		}
-		elseif ($this->isFile($path) && $overwrite == FALSE && $append == FALSE)
-		{
-			throw new FilesystemException("File already exists: {$path}");
-		}
-
-		$flags = LOCK_EX;
-		if ($overwrite == FALSE && $append == TRUE)
-		{
-			$flags = FILE_APPEND | LOCK_EX;
-		}
-
-		file_put_contents($path, $data, $flags);
-
-		$this->ensureCorrectAccessMode($path);
-	}
-
-	/**
-	 * Append to an existing file
-	 *
-	 * @param String $path File to write to
-	 * @param String $data Data to write
-	 */
-	public function append($path, $data)
-	{
-		$this->write($path, $data, FALSE, TRUE);
-	}
-
-	/**
-	 * Make a new directory
-	 *
-	 * @param String $path Directory to create
-	 * @param bool $with_index Add EE's default index.html file in the new dir?
-	 * @return bool Success or failure of mkdir()
-	 */
-	public function mkDir($path, $with_index = TRUE)
-	{
-		$path = $this->normalize($path);
-
-		$old_umask = umask(0);
-		$result = @mkdir($path, DIR_WRITE_MODE, TRUE);
-		umask($old_umask);
-
-		if ( ! $result)
-		{
-			return FALSE;
-		}
-
-		if ($with_index)
-		{
-			$this->addIndexHtml($path);
-		}
-
-		$this->ensureCorrectAccessMode($path);
-
-		return TRUE;
-	}
-
-	/**
-	 * Delete a file or directory
-	 *
-	 * @param String $path File or directory to delete
-	 */
-	public function delete($path)
-	{
-		if ($this->isDir($path))
-		{
-			return $this->deleteDir($path);
-		}
-
-		return $this->deleteFile($path);
-	}
-
-	/**
-	 * Delete a file
-	 *
-	 * @param String $path File to delete
-	 */
-	public function deleteFile($path)
-	{
-		if ( ! $this->isFile($path))
-		{
-			throw new FilesystemException("File does not exist {$path}");
-		}
-
-		return @unlink($this->normalize($path));
-	}
-
-	/**
-	 * Delete a directory
-	 *
-	 * @param String $path Directory to delete
-	 * @param bool $leave_empty Keep the empty root directory?
-	 */
-	public function deleteDir($path, $leave_empty = FALSE)
-	{
-		$path = rtrim($path, '/');
-
-		if ( ! $this->isDir($path))
-		{
-			throw new FilesystemException("Directory does not exist {$path}.");
-		}
-
-		if ( ! $leave_empty && $this->attemptFastDelete($path))
-		{
-			return TRUE;
-		}
-
-		$contents = new FilesystemIterator($this->normalize($path));
-
-		foreach ($contents as $item)
-		{
-			if ($item->isDir())
-			{
-				$this->deleteDir($item->getPathname());
-			}
-			else
-			{
-				$this->deleteFile($item->getPathName());
-			}
-		}
-
-		if ( ! $leave_empty)
-		{
-			@rmdir($this->normalize($path));
-		}
-
-		return TRUE;
-	}
-
-	/**
-	 * Gets the contents of a directory as a flat array, with the option of
-	 * returning a recursive listing
-	 *
-	 * @param String $path Directory to search
-	 * @param bool $recursive Whether or not to do a recursive search
-	 * @param array Array of all paths found inside the specified directory
-	 */
-	public function getDirectoryContents($path, $recursive = FALSE)
-	{
-		if ( ! $this->exists($path))
-		{
-			throw new FilesystemException('Cannot get contents of path, the path is invalid: '.$path);
-		}
-
-		if ( ! $this->isDir($path))
-		{
-			throw new FilesystemException('Cannot get contents of path, the path is not a directory: '.$path);
-		}
-
-		$contents = new FilesystemIterator($this->normalize($path));
-		$contents_array = [];
-
-		foreach ($contents as $item)
-		{
-			if ($item->isDir() && $recursive)
-			{
-				$contents_array += $this->getDirectoryContents($item->getPathname(), $recursive);
-			}
-			else
-			{
-				$contents_array[] = $item->getPathName();
-			}
-		}
-
-		return $contents_array;
-	}
-
-	/**
-	 * Empty a directory
-	 *
-	 * @param String $path Directory to empty
-	 * @param bool $add_index Add EE's default index.html file to the directory
-	 */
-	public function emptyDir($path, $add_index = TRUE)
-	{
-		$this->deleteDir($path, TRUE);
-		$this->addIndexHtml($path);
-	}
-
-	/**
-	 * Attempt to delete a file using the OS method
-	 *
-	 * We can't always do this, but it's much, much faster than iterating
-	 * over directories with many children.
-	 *
-	 * @param bool whether or not the fast system delete could be done
-	 */
-	protected function attemptFastDelete($path)
-	{
-		$path = $this->normalize($path);
-
-		$delete_name = sha1($path.'_delete_'.mt_rand());
-		$delete_path = PATH_CACHE.$delete_name;
-		$this->rename($path, $delete_path);
-
-		if ($this->exists($delete_path) && is_dir($delete_path))
-		{
-			$delete_path = escapeshellarg($delete_path);
-
-			if (DIRECTORY_SEPARATOR == '/')
-			{
-				@exec("rm -rf {$delete_path}");
-			}
-			else
-			{
-				@exec("rd /s /q {$delete_path}");
-			}
-
-			return  ! $this->exists($delete_path);
-		}
-
-		return FALSE;
-	}
-
-	/**
-	 * Rename a file or directory
-	 *
-	 * @param String $source File or directory to rename
-	 * @param String $dest New location for the file or directory
-	 */
-	public function rename($source, $dest)
-	{
-		if ( ! $this->exists($source))
-		{
-			throw new FilesystemException("Cannot rename non-existent path: {$source}");
-		}
-		elseif ($this->exists($dest))
-		{
-			throw new FilesystemException("Cannot rename, destination already exists: {$dest}");
-		}
-
-		// Suppressing potential warning when renaming a directory to one that already exists.
-		@rename(
-			$this->normalize($source),
-			$this->normalize($dest)
-		);
-
-		$this->ensureCorrectAccessMode($dest);
-	}
-
-	/**
-	 * Copy a file or directory
-	 *
-	 * @param String $source File or directory to copy
-	 * @param Stirng $dest Path to the duplicate
-	 */
-	public function copy($source, $dest)
-	{
-		if ( ! $this->exists($source))
-		{
-			throw new FilesystemException("Cannot copy non-existent path: {$source}");
-		}
-
-		if ($this->isDir($source))
-		{
-			$this->recursiveCopy($source, $dest);
-		}
-		else
-		{
-			copy(
-				$this->normalize($source),
-				$this->normalize($dest)
-			);
-		}
-
-		$this->ensureCorrectAccessMode($dest);
-	}
-
-	/**
-	 * Copies a directory to another directory by recursively iterating over its files
-	 *
-	 * @param String $source Directory to copy
-	 * @param Stirng $dest Path to the duplicate
-	 */
-	protected function recursiveCopy($source, $dest)
-	{
-		$dir = opendir($source);
-		@mkdir($dest);
-
-		while(false !== ($file = readdir($dir)))
-		{
-			if (($file != '.') && ($file != '..'))
-			{
-				if ($this->isDir($source . '/' . $file))
-				{
-					$this->recursiveCopy($source . '/' . $file, $dest . '/' . $file);
-				}
-				else
-				{
-					copy($source . '/' . $file, $dest . '/' . $file);
-				}
-			}
-		}
-
-		closedir($dir);
-	}
-
-	/**
-	 * Get the path to the parent directory
-	 *
-	 * @param String $path Path to extract dirname from
-	 * @return String Path to the parent directory
-	 */
-	public function dirname($path)
-	{
-		return dirname($this->normalize($path));
-	}
-
-	/**
-	 * Get the filename and extension
-	 *
-	 * @param String $path Path to extract basename from
-	 * @return String Filename with extension
-	 */
-	public function basename($path)
-	{
-		return basename($this->normalize($path));
-	}
-
-	/**
-	 * Get the filename without extension
-	 *
-	 * @param String $path Path to extract filename from
-	 * @return String Filename without extension
-	 */
-	public function filename($path)
-	{
-		return pathinfo($this->normalize($path), PATHINFO_FILENAME);
-	}
-
-	/**
-	 * Get the extension
-	 *
-	 * @param String $path Path to extract extension from
-	 * @return String Extension
-	 */
-	public function extension($path)
-	{
-		return pathinfo($this->normalize($path), PATHINFO_EXTENSION);
-	}
-
-	/**
-	 * Check if a path exists
-	 *
-	 * @param String $path Path to check
-	 * @return bool Path exists?
-	 */
-	public function exists($path)
-	{
-		if ($path = $this->normalize($path))
-		{
-			return file_exists($path);
-		}
-
-		return FALSE;
-	}
-
-	/**
-	 * Get the last modified time
-	 *
-	 * @param String $path Path to directory or file
-	 * @return int Last modified time
-	 */
-	public function mtime($path)
-	{
-		if ( ! $this->exists($path))
-		{
-			throw new FilesystemException("File does not exist: {$path}");
-		}
-
-		return filemtime($this->normalize($path));
-	}
-
-	/**
-	 * Touch a file or directory
-	 *
-	 * @param String $path File/directory to touch
-	 * @param int Set the last modified time [optional]
-	 */
-	public function touch($path, $time = NULL)
-	{
-		if ( ! $this->exists($path))
-		{
-			throw new FilesystemException("Touching non-existent files is not supported: {$path}");
-		}
-
-		if (isset($time))
-		{
-			touch($this->normalize($path), $time);
-		}
-		else
-		{
-			touch($this->normalize($path));
-		}
-	}
-
-	/**
-	 * Check if a given path is a directory
-	 *
-	 * @param String $path Path to check
-	 * @return bool Is a directory?
-	 */
-	public function isDir($path)
-	{
-		return is_dir($this->normalize($path));
-	}
-
-	/**
-	 * Check if a given path is a file
-	 *
-	 * @param String $path Path to check
-	 * @return bool Is a file?
-	 */
-	public function isFile($path)
-	{
-		return is_file($this->normalize($path));
-	}
-
-	/**
-	 * Check if a path is readable
-	 *
-	 * @param String $path Path to check
-	 * @return bool Is readable?
-	 */
-	public function isReadable($path)
-	{
-		return is_readable($this->normalize($path));
-	}
-
-	/**
-	 * Change the access mode of a file
-	 *
-	 * @param String $path Path to Change
-	 * @param Int Mode, please provide an octal
-	 */
-	public function chmod($path, $mode)
-	{
-		return @chmod($this->normalize($path), $mode);
-	}
-
-	/**
-	 * Check if a file or directory is writable
-	 *
-	 * Does some extra checks for safe_mode windows servers. Yuck.
-	 *
-	 * @param String $path Path to check
-	 * @return bool Is writable?
-	 */
-	public function isWritable($path)
-	{
-		// If we're on a Unix server with safe_mode off we call is_writable
-		if (DIRECTORY_SEPARATOR == '/')
-		{
-			return is_writable($this->normalize($path));
-		}
-
-		// For windows servers and safe_mode "on" installations we'll actually
-		// write a file then read it.  Bah...
-		if ($this->isDir($path))
-		{
-			$path = rtrim($this->normalize($path), '/').'/'.md5(mt_rand(1,100).mt_rand(1,100));
-
-			if (($fp = @fopen($path, FOPEN_WRITE_CREATE)) === FALSE)
-			{
-				return FALSE;
-			}
-
-			fclose($fp);
-			@chmod($path, DIR_WRITE_MODE);
-			@unlink($path);
-			return TRUE;
-		}
-		elseif (($fp = @fopen($path, FOPEN_WRITE_CREATE)) === FALSE)
-		{
-			return FALSE;
-		}
-
-		fclose($fp);
-		return TRUE;
-	}
-
-	/**
-	 * Returns a hash for a given file and hashing algorithm
-	 *
-	 * @param String $algo PHP hashing algorithm, as specified in hash_algos()
-	 * @param String $path Path to check
-	 * @return String Hash of file
-	 */
-	public function hashFile($algo, $filename)
-	{
-		if ( ! $this->exists($filename))
-		{
-			throw new FilesystemException("File does not exist: {$filename}");
-		}
-
-		return hash_file($algo, $filename);
-	}
-
-	/**
-	 * Returns the amount of free bytes at a given path
-	 *
-	 * @param	String	$path	Path to check
-	 * @return	Mixed	Number of bytes as a float, or FALSE on failure
-	 */
-	public function getFreeDiskSpace($path = '/')
-	{
-		return @disk_free_space($path);
-	}
-
-	/**
-	 * include() a file
-	 *
-	 * @param	string	$filename	Full path to file to include
-	 */
-	public function include_file($filename)
-	{
-		include_once($filename);
-	}
-
-	/**
-	 * Given a path this returns a unique filename by appending "_n" (where "n"
-	 * is a number) if a file by the same name already exists, i.e. "image002_1.jpg".
-	 *
-	 * @param String $path Path to make unique
-	 * @return string The path to the file.
-	 */
-	public function getUniqueFilename($path)
-	{
-		$path = $this->normalize($path);
-
-		// The path is good! We're done here.
-		if ( ! $this->exists($path))
-		{
-			return $path;
-		}
-
-		$i = 0;
-		$extension = $this->extension($path);
-		$filename  = $this->dirname($path) . '/' . $this->filename($path);
-
-		$files = glob($filename . '_*'. $extension);
-
-		if ( ! empty($files))
-		{
-			// Try to figure out if we already have a file we've renamed, then
-			// we can pick up where we left off, and reduce the guessing.
-			if (version_compare(PHP_VERSION, '5.4.0') < 0)
-			{
-				rsort($files); // SORT_NATURAL was introduced in 5.4.0 :(
-			}
-			else
-			{
-				rsort($files, SORT_NATURAL);
-			}
-
-			foreach ($files as $file)
-			{
-				$number = str_replace(array($filename, $extension), '', $file);
-				if (substr_count($number, '_') == 1 && strpos($number, '_') === 0)
-				{
-					$number = str_replace('_', '', $number);
-					if (is_numeric($number))
-					{
-						$i = (int) $number;
-						break;
-					}
-				}
-			}
-		}
-
-		do
-		{
-			$i++;
-			$path = $filename . '_' . $i . '.' . $extension;
-		} while (in_array($path, $files));
-
-		return $path;
-	}
-
-	/**
-	 * Finds string and replaces it
-	 * @param  string $file
-	 * @param  string $search
-	 * @param  string $replace
-	 * @return void
-	 */
-	public function findAndReplace($file, $search, $replace)
-	{
-
-		if ($this->exists($file)) {
-
-		    return;
-
-		}
-
-		// If we're given a directory iterate over the files and recursively call findAndReplace()
-		if ($this->isDir($file)) {
-
-		    foreach ($this->getDirectoryContents($file) as $file) {
-
-		        $this->findAndReplace($file, $search, $replace);
-
-		    }
-
-		    return;
-
-		}
-
-		$contents = $this->read($file);
-
-		if (strpos($search, '/') === 0) {
-
-		    $contents = preg_replace($search, $replace, $contents);
-
-		} else {
-
-		    $contents = str_replace($search, $replace, $contents);
-
-		}
-
-		$this->write($file, $contents, true);
-
-	}
-
-	/**
-	 * Add EE's default index file to a directory
-	 */
-	protected function addIndexHtml($dir)
-	{
-		$dir = rtrim($dir, '/');
-
-		if ( ! $this->isDir($dir))
-		{
-			throw new FilesystemException("Cannot add index file to non-existant directory: {$dir}");
-		}
-
-		if ( ! $this->isFile($dir.'/index.html'))
-		{
-			$this->write($dir.'/index.html', 'Directory access is forbidden.');
-		}
-	}
-
-	/**
-	 * Writing files and directories should respect the write modes
-	 * specified. Otherwise on some crudy hosts you end up unable
-	 * to change those files via FTP.
-	 *
-	 * @param String $path Path to ensure access to
-	 */
-	protected function ensureCorrectAccessMode($path)
-	{
-		if ($this->isDir($path))
-		{
-			$this->chmod($path, DIR_WRITE_MODE);
-		}
-		else
-		{
-			$this->chmod($path, FILE_WRITE_MODE);
-		}
-	}
-
-	/**
-	 * Normalize the path for a native function call
-	 *
-	 * This is used by classes that extend this one to, for example, root
-	 * the filesystem in a specific location. It can also be used for sanity
-	 * checks, but beware that it is slow.
-	 */
-	protected function normalize($path)
-	{
-		return $path;
-	}
+    /**
+     * Read a file from disk
+     *
+     * @param String $path File to read
+     * @return String File contents
+     */
+    public function read($path)
+    {
+        if ( ! $this->exists($path))
+        {
+            throw new FilesystemException("File not found: {$path}");
+        }
+        elseif ( ! $this->isFile($path))
+        {
+            throw new FilesystemException("Not a file: {$path}");
+        }
+        elseif ( ! $this->isReadable($path))
+        {
+            throw new FilesystemException("Cannot read file: {$path}");
+        }
+
+        return file_get_contents($this->normalize($path));
+    }
+
+    /**
+     * Read a file from disk line-by-line, good for large text files
+     *
+     * @param String $path File to read
+     * @param Callable Callback to call for each line of the file, accepts one parameter
+     */
+    public function readLineByLine($path, Callable $callback)
+    {
+        if ( ! $this->exists($path))
+        {
+            throw new FilesystemException("File not found: {$path}");
+        }
+        elseif ( ! $this->isFile($path))
+        {
+            throw new FilesystemException("Not a file: {$path}");
+        }
+        elseif ( ! $this->isReadable($path))
+        {
+            throw new FilesystemException("Cannot read file: {$path}");
+        }
+
+        $pointer = fopen($path, 'r');
+
+        while ( ! feof($pointer))
+        {
+            $callback(fgets($pointer));
+        }
+
+        fclose($pointer);
+    }
+
+    /**
+     * Write a file to disk
+     *
+     * @param String $path File to write to
+     * @param String $data Data to write
+     * @param bool $overwrite Overwrite existing files?
+     * @param bool $append Append to existing file?
+     */
+    public function write($path, $data, $overwrite = FALSE, $append = FALSE)
+    {
+        $path = $this->normalize($path);
+
+        if ($this->isDir($path))
+        {
+            throw new FilesystemException("Cannot write file, path is a directory: {$path}");
+        }
+        elseif ($this->isFile($path) && $overwrite == FALSE && $append == FALSE)
+        {
+            throw new FilesystemException("File already exists: {$path}");
+        }
+
+        $flags = LOCK_EX;
+        if ($overwrite == FALSE && $append == TRUE)
+        {
+            $flags = FILE_APPEND | LOCK_EX;
+        }
+
+        file_put_contents($path, $data, $flags);
+
+        $this->ensureCorrectAccessMode($path);
+    }
+
+    /**
+     * Append to an existing file
+     *
+     * @param String $path File to write to
+     * @param String $data Data to write
+     */
+    public function append($path, $data)
+    {
+        $this->write($path, $data, FALSE, TRUE);
+    }
+
+    /**
+     * Make a new directory
+     *
+     * @param String $path Directory to create
+     * @param bool $with_index Add EE's default index.html file in the new dir?
+     * @return bool Success or failure of mkdir()
+     */
+    public function mkDir($path, $with_index = TRUE)
+    {
+        $path = $this->normalize($path);
+
+        $old_umask = umask(0);
+        $result = @mkdir($path, DIR_WRITE_MODE, TRUE);
+        umask($old_umask);
+
+        if ( ! $result)
+        {
+            return FALSE;
+        }
+
+        if ($with_index)
+        {
+            $this->addIndexHtml($path);
+        }
+
+        $this->ensureCorrectAccessMode($path);
+
+        return TRUE;
+    }
+
+    /**
+     * Delete a file or directory
+     *
+     * @param String $path File or directory to delete
+     */
+    public function delete($path)
+    {
+        if ($this->isDir($path))
+        {
+            return $this->deleteDir($path);
+        }
+
+        return $this->deleteFile($path);
+    }
+
+    /**
+     * Delete a file
+     *
+     * @param String $path File to delete
+     */
+    public function deleteFile($path)
+    {
+        if ( ! $this->isFile($path))
+        {
+            throw new FilesystemException("File does not exist {$path}");
+        }
+
+        return @unlink($this->normalize($path));
+    }
+
+    /**
+     * Delete a directory
+     *
+     * @param String $path Directory to delete
+     * @param bool $leave_empty Keep the empty root directory?
+     */
+    public function deleteDir($path, $leave_empty = FALSE)
+    {
+        $path = rtrim($path, '/');
+
+        if ( ! $this->isDir($path))
+        {
+            throw new FilesystemException("Directory does not exist {$path}.");
+        }
+
+        if ( ! $leave_empty && $this->attemptFastDelete($path))
+        {
+            return TRUE;
+        }
+
+        $contents = new FilesystemIterator($this->normalize($path));
+
+        foreach ($contents as $item)
+        {
+            if ($item->isDir())
+            {
+                $this->deleteDir($item->getPathname());
+            }
+            else
+            {
+                $this->deleteFile($item->getPathName());
+            }
+        }
+
+        if ( ! $leave_empty)
+        {
+            @rmdir($this->normalize($path));
+        }
+
+        return TRUE;
+    }
+
+    /**
+     * Gets the contents of a directory as a flat array, with the option of
+     * returning a recursive listing
+     *
+     * @param String $path Directory to search
+     * @param bool $recursive Whether or not to do a recursive search
+     * @param array Array of all paths found inside the specified directory
+     */
+    public function getDirectoryContents($path, $recursive = FALSE)
+    {
+        if ( ! $this->exists($path))
+        {
+            throw new FilesystemException('Cannot get contents of path, the path is invalid: '.$path);
+        }
+
+        if ( ! $this->isDir($path))
+        {
+            throw new FilesystemException('Cannot get contents of path, the path is not a directory: '.$path);
+        }
+
+        $contents = new FilesystemIterator($this->normalize($path));
+        $contents_array = [];
+
+        foreach ($contents as $item)
+        {
+            if ($item->isDir() && $recursive)
+            {
+                $contents_array += $this->getDirectoryContents($item->getPathname(), $recursive);
+            }
+            else
+            {
+                $contents_array[] = $item->getPathName();
+            }
+        }
+
+        return $contents_array;
+    }
+
+    /**
+     * Empty a directory
+     *
+     * @param String $path Directory to empty
+     * @param bool $add_index Add EE's default index.html file to the directory
+     */
+    public function emptyDir($path, $add_index = TRUE)
+    {
+        $this->deleteDir($path, TRUE);
+        $this->addIndexHtml($path);
+    }
+
+    /**
+     * Attempt to delete a file using the OS method
+     *
+     * We can't always do this, but it's much, much faster than iterating
+     * over directories with many children.
+     *
+     * @param bool whether or not the fast system delete could be done
+     */
+    protected function attemptFastDelete($path)
+    {
+        $path = $this->normalize($path);
+
+        $delete_name = sha1($path.'_delete_'.mt_rand());
+        $delete_path = PATH_CACHE.$delete_name;
+        $this->rename($path, $delete_path);
+
+        if ($this->exists($delete_path) && is_dir($delete_path))
+        {
+            $delete_path = escapeshellarg($delete_path);
+
+            if (DIRECTORY_SEPARATOR == '/')
+            {
+                @exec("rm -rf {$delete_path}");
+            }
+            else
+            {
+                @exec("rd /s /q {$delete_path}");
+            }
+
+            return  ! $this->exists($delete_path);
+        }
+
+        return FALSE;
+    }
+
+    /**
+     * Rename a file or directory
+     *
+     * @param String $source File or directory to rename
+     * @param String $dest New location for the file or directory
+     */
+    public function rename($source, $dest)
+    {
+        if ( ! $this->exists($source))
+        {
+            throw new FilesystemException("Cannot rename non-existent path: {$source}");
+        }
+        elseif ($this->exists($dest))
+        {
+            throw new FilesystemException("Cannot rename, destination already exists: {$dest}");
+        }
+
+        // Suppressing potential warning when renaming a directory to one that already exists.
+        @rename(
+            $this->normalize($source),
+            $this->normalize($dest)
+        );
+
+        $this->ensureCorrectAccessMode($dest);
+    }
+
+    /**
+     * Copy a file or directory
+     *
+     * @param String $source File or directory to copy
+     * @param Stirng $dest Path to the duplicate
+     */
+    public function copy($source, $dest)
+    {
+        if ( ! $this->exists($source))
+        {
+            throw new FilesystemException("Cannot copy non-existent path: {$source}");
+        }
+
+        if ($this->isDir($source))
+        {
+            $this->recursiveCopy($source, $dest);
+        }
+        else
+        {
+            copy(
+                $this->normalize($source),
+                $this->normalize($dest)
+            );
+        }
+
+        $this->ensureCorrectAccessMode($dest);
+    }
+
+    /**
+     * Copies a directory to another directory by recursively iterating over its files
+     *
+     * @param String $source Directory to copy
+     * @param Stirng $dest Path to the duplicate
+     */
+    protected function recursiveCopy($source, $dest)
+    {
+        $dir = opendir($source);
+        @mkdir($dest);
+
+        while(false !== ($file = readdir($dir)))
+        {
+            if (($file != '.') && ($file != '..'))
+            {
+                if ($this->isDir($source . '/' . $file))
+                {
+                    $this->recursiveCopy($source . '/' . $file, $dest . '/' . $file);
+                }
+                else
+                {
+                    copy($source . '/' . $file, $dest . '/' . $file);
+                }
+            }
+        }
+
+        closedir($dir);
+    }
+
+    /**
+     * Get the path to the parent directory
+     *
+     * @param String $path Path to extract dirname from
+     * @return String Path to the parent directory
+     */
+    public function dirname($path)
+    {
+        return dirname($this->normalize($path));
+    }
+
+    /**
+     * Get the filename and extension
+     *
+     * @param String $path Path to extract basename from
+     * @return String Filename with extension
+     */
+    public function basename($path)
+    {
+        return basename($this->normalize($path));
+    }
+
+    /**
+     * Get the filename without extension
+     *
+     * @param String $path Path to extract filename from
+     * @return String Filename without extension
+     */
+    public function filename($path)
+    {
+        return pathinfo($this->normalize($path), PATHINFO_FILENAME);
+    }
+
+    /**
+     * Get the extension
+     *
+     * @param String $path Path to extract extension from
+     * @return String Extension
+     */
+    public function extension($path)
+    {
+        return pathinfo($this->normalize($path), PATHINFO_EXTENSION);
+    }
+
+    /**
+     * Check if a path exists
+     *
+     * @param String $path Path to check
+     * @return bool Path exists?
+     */
+    public function exists($path)
+    {
+        if ($path = $this->normalize($path))
+        {
+            return file_exists($path);
+        }
+
+        return FALSE;
+    }
+
+    /**
+     * Get the last modified time
+     *
+     * @param String $path Path to directory or file
+     * @return int Last modified time
+     */
+    public function mtime($path)
+    {
+        if ( ! $this->exists($path))
+        {
+            throw new FilesystemException("File does not exist: {$path}");
+        }
+
+        return filemtime($this->normalize($path));
+    }
+
+    /**
+     * Touch a file or directory
+     *
+     * @param String $path File/directory to touch
+     * @param int Set the last modified time [optional]
+     */
+    public function touch($path, $time = NULL)
+    {
+        if ( ! $this->exists($path))
+        {
+            throw new FilesystemException("Touching non-existent files is not supported: {$path}");
+        }
+
+        if (isset($time))
+        {
+            touch($this->normalize($path), $time);
+        }
+        else
+        {
+            touch($this->normalize($path));
+        }
+    }
+
+    /**
+     * Check if a given path is a directory
+     *
+     * @param String $path Path to check
+     * @return bool Is a directory?
+     */
+    public function isDir($path)
+    {
+        return is_dir($this->normalize($path));
+    }
+
+    /**
+     * Check if a given path is a file
+     *
+     * @param String $path Path to check
+     * @return bool Is a file?
+     */
+    public function isFile($path)
+    {
+        return is_file($this->normalize($path));
+    }
+
+    /**
+     * Check if a path is readable
+     *
+     * @param String $path Path to check
+     * @return bool Is readable?
+     */
+    public function isReadable($path)
+    {
+        return is_readable($this->normalize($path));
+    }
+
+    /**
+     * Change the access mode of a file
+     *
+     * @param String $path Path to Change
+     * @param Int Mode, please provide an octal
+     */
+    public function chmod($path, $mode)
+    {
+        return @chmod($this->normalize($path), $mode);
+    }
+
+    /**
+     * Check if a file or directory is writable
+     *
+     * Does some extra checks for safe_mode windows servers. Yuck.
+     *
+     * @param String $path Path to check
+     * @return bool Is writable?
+     */
+    public function isWritable($path)
+    {
+        // If we're on a Unix server with safe_mode off we call is_writable
+        if (DIRECTORY_SEPARATOR == '/')
+        {
+            return is_writable($this->normalize($path));
+        }
+
+        // For windows servers and safe_mode "on" installations we'll actually
+        // write a file then read it.  Bah...
+        if ($this->isDir($path))
+        {
+            $path = rtrim($this->normalize($path), '/').'/'.md5(mt_rand(1,100).mt_rand(1,100));
+
+            if (($fp = @fopen($path, FOPEN_WRITE_CREATE)) === FALSE)
+            {
+                return FALSE;
+            }
+
+            fclose($fp);
+            @chmod($path, DIR_WRITE_MODE);
+            @unlink($path);
+            return TRUE;
+        }
+        elseif (($fp = @fopen($path, FOPEN_WRITE_CREATE)) === FALSE)
+        {
+            return FALSE;
+        }
+
+        fclose($fp);
+        return TRUE;
+    }
+
+    /**
+     * Returns a hash for a given file and hashing algorithm
+     *
+     * @param String $algo PHP hashing algorithm, as specified in hash_algos()
+     * @param String $path Path to check
+     * @return String Hash of file
+     */
+    public function hashFile($algo, $filename)
+    {
+        if ( ! $this->exists($filename))
+        {
+            throw new FilesystemException("File does not exist: {$filename}");
+        }
+
+        return hash_file($algo, $filename);
+    }
+
+    /**
+     * Returns the amount of free bytes at a given path
+     *
+     * @param   String  $path   Path to check
+     * @return  Mixed   Number of bytes as a float, or FALSE on failure
+     */
+    public function getFreeDiskSpace($path = '/')
+    {
+        return @disk_free_space($path);
+    }
+
+    /**
+     * include() a file
+     *
+     * @param   string  $filename   Full path to file to include
+     */
+    public function include_file($filename)
+    {
+        include_once($filename);
+    }
+
+    /**
+     * Given a path this returns a unique filename by appending "_n" (where "n"
+     * is a number) if a file by the same name already exists, i.e. "image002_1.jpg".
+     *
+     * @param String $path Path to make unique
+     * @return string The path to the file.
+     */
+    public function getUniqueFilename($path)
+    {
+        $path = $this->normalize($path);
+
+        // The path is good! We're done here.
+        if ( ! $this->exists($path))
+        {
+            return $path;
+        }
+
+        $i = 0;
+        $extension = $this->extension($path);
+        $filename  = $this->dirname($path) . '/' . $this->filename($path);
+
+        $files = glob($filename . '_*'. $extension);
+
+        if ( ! empty($files))
+        {
+            // Try to figure out if we already have a file we've renamed, then
+            // we can pick up where we left off, and reduce the guessing.
+            if (version_compare(PHP_VERSION, '5.4.0') < 0)
+            {
+                rsort($files); // SORT_NATURAL was introduced in 5.4.0 :(
+            }
+            else
+            {
+                rsort($files, SORT_NATURAL);
+            }
+
+            foreach ($files as $file)
+            {
+                $number = str_replace(array($filename, $extension), '', $file);
+                if (substr_count($number, '_') == 1 && strpos($number, '_') === 0)
+                {
+                    $number = str_replace('_', '', $number);
+                    if (is_numeric($number))
+                    {
+                        $i = (int) $number;
+                        break;
+                    }
+                }
+            }
+        }
+
+        do
+        {
+            $i++;
+            $path = $filename . '_' . $i . '.' . $extension;
+        } while (in_array($path, $files));
+
+        return $path;
+    }
+
+    /**
+     * Finds string and replaces it
+     * @param  string $file
+     * @param  string $search
+     * @param  string $replace
+     * @return void
+     */
+    public function findAndReplace($file, $search, $replace)
+    {
+
+        if ($this->exists($file)) {
+
+            return;
+
+        }
+
+        // If we're given a directory iterate over the files and recursively call findAndReplace()
+        if ($this->isDir($file)) {
+
+            foreach ($this->getDirectoryContents($file) as $file) {
+
+                $this->findAndReplace($file, $search, $replace);
+
+            }
+
+            return;
+
+        }
+
+        $contents = $this->read($file);
+
+        if (strpos($search, '/') === 0) {
+
+            $contents = preg_replace($search, $replace, $contents);
+
+        } else {
+
+            $contents = str_replace($search, $replace, $contents);
+
+        }
+
+        $this->write($file, $contents, true);
+
+    }
+
+    /**
+     * Add EE's default index file to a directory
+     */
+    protected function addIndexHtml($dir)
+    {
+        $dir = rtrim($dir, '/');
+
+        if ( ! $this->isDir($dir))
+        {
+            throw new FilesystemException("Cannot add index file to non-existant directory: {$dir}");
+        }
+
+        if ( ! $this->isFile($dir.'/index.html'))
+        {
+            $this->write($dir.'/index.html', 'Directory access is forbidden.');
+        }
+    }
+
+    /**
+     * Writing files and directories should respect the write modes
+     * specified. Otherwise on some crudy hosts you end up unable
+     * to change those files via FTP.
+     *
+     * @param String $path Path to ensure access to
+     */
+    protected function ensureCorrectAccessMode($path)
+    {
+        if ($this->isDir($path))
+        {
+            $this->chmod($path, DIR_WRITE_MODE);
+        }
+        else
+        {
+            $this->chmod($path, FILE_WRITE_MODE);
+        }
+    }
+
+    /**
+     * Normalize the path for a native function call
+     *
+     * This is used by classes that extend this one to, for example, root
+     * the filesystem in a specific location. It can also be used for sanity
+     * checks, but beware that it is slow.
+     */
+    protected function normalize($path)
+    {
+        return $path;
+    }
 }
 
 // EOF

--- a/system/ee/EllisLab/ExpressionEngine/Service/Addon/Addon.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Addon/Addon.php
@@ -312,6 +312,20 @@ class Addon {
 	}
 
 	/**
+	 * Get the *_upgrade class
+	 *
+	 * @return string The fqcn or $class
+	 */
+	public function getUpgraderClass()
+	{
+		$this->requireFile('upgrade');
+
+		$class = ucfirst($this->shortname).'_upgrade';
+
+		return $this->getFullyQualified($class);
+	}
+
+	/**
 	 * Get the *_mcp class
 	 *
 	 * @return string The fqcn or $class
@@ -421,6 +435,16 @@ class Addon {
 	public function hasExtension()
 	{
 		return $this->hasFile('ext');
+	}
+
+	/**
+	 * Has an upd.* file?
+	 *
+	 * @return bool TRUE of it does, FALSE if not
+	 */
+	public function hasUpgrader()
+	{
+		return $this->hasFile('upgrade');
 	}
 
 	/**

--- a/system/ee/EllisLab/ExpressionEngine/Service/Updater/Logger.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Updater/Logger.php
@@ -30,12 +30,28 @@ class Logger extends File {
 	{
 		if (REQ == 'CLI' && CLI_VERBOSE)
 		{
-			stdout($message);
+			$this->stdout($message);
 		}
 
 		$message = '['.date('Y-M-d H:i:s O').'] ' . $message;
 
 		parent::log($message);
+	}
+
+	private function stdout($message) {
+		$text_color = '[1;37m';
+
+		$arrow_color = '[0;34m';
+		$text_color = '[1;37m';
+
+		if (REQ == 'CLI' && ! empty($message))
+		{
+			$message = "\033".$arrow_color."==> \033" . $text_color . strip_tags($message) . "\033[0m\n";
+
+			$stdout = fopen('php://stdout', 'w');
+			fwrite($stdout, $message);
+			fclose($stdout);
+		}
 	}
 }
 

--- a/system/ee/EllisLab/ExpressionEngine/Service/Updater/Runner.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Updater/Runner.php
@@ -91,7 +91,7 @@ class Runner {
 	{
 		if (REQ == 'CLI')
 		{
-			stdout($this->getLanguageForStep($step).'...', CLI_STDOUT_BOLD);
+			$this->stdout($this->getLanguageForStep($step).'...');
 		}
 
 		try
@@ -125,5 +125,22 @@ class Runner {
 		ee()->lang->loadfile('updater');
 		return lang($step.'_step');
 	}
+
+	private function stdout($message) {
+		$text_color = '[1;37m';
+
+		$arrow_color = '[0;34m';
+		$text_color = '[1;37m';
+
+		if (REQ == 'CLI' && ! empty($message))
+		{
+			$message = "\033".$arrow_color."==> \033" . $text_color . strip_tags($message) . "\033[0m\n";
+
+			$stdout = fopen('php://stdout', 'w');
+			fwrite($stdout, $message);
+			fclose($stdout);
+		}
+	}
+
 }
 // EOF

--- a/system/ee/installer/controllers/wizard.php
+++ b/system/ee/installer/controllers/wizard.php
@@ -36,8 +36,8 @@ class Wizard extends CI_Controller {
 	private $current_step 			= 1;
 	private $steps        			= 3;
 	private $addon_step   			= FALSE;
-	private $shouldBackupDatabase	= false;
-	private $shouldUpgradeAddons 	= false;
+	private $shouldBackupDatabase	= FALSE;
+	private $shouldUpgradeAddons 	= FALSE;
 
 	public $now;
 	public $year;

--- a/system/ee/installer/language/english/installer_lang.php
+++ b/system/ee/installer/language/english/installer_lang.php
@@ -56,6 +56,8 @@ $lang = array(
 	'start_update'   => 'Update',
 	'update_note'    => '<b>Please</b> read <a href="'.DOC_URL.'installation/update.html" rel="external">Updating ExpressionEngine</a> <strong>before</strong> starting.',
 	'update_backup'  => 'Please <b>back up</b> your database before updating ExpressionEngine',
+	'update_should_get_database_backup' => 'Backup database before upgrade',
+	'update_should_update_addons'		=> 'Allow addons to upgrade (advanced)',
 	'updating_title' => "Updating ExpressionEngine to %s",
 	'running_updates' => "Running updates for %s",
 	'updating'       => 'Updating ExpressionEngine',

--- a/system/ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/AddonUpdater.php
+++ b/system/ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/AddonUpdater.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2019, EllisLab Corp. (https://ellislab.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace EllisLab\ExpressionEngine\Updater\Service\Updater;
+
+use EllisLab\ExpressionEngine\Updater\Service\Updater\SteppableTrait;
+
+/**
+ * Database updater for one-click updater
+ *
+ * Runs the ud_x_xx_xx.php files needed to complete the update
+ */
+class AddonUpdater {
+
+	use SteppableTrait;
+
+	protected $from_version;
+
+	/**
+	 * Construct class
+	 *
+	 * @param	string		$from_version	Version we are updating from
+	 * @return  void
+	 */
+	public function __construct($from_version)
+	{
+		$this->from_version = $from_version;
+	}
+
+	/**
+	 * runs upgrader for each installed addon
+	 * @return array
+	 */
+	public function updateAddons()
+	{
+
+		$addons = ee('Addon')->all();
+
+		$results = [];
+
+		foreach ($addons as $name => $info)
+		{
+			$info = ee('Addon')->get($name);
+
+			// If it's built in, we'll skip it
+			if ($info->get('built_in')) {
+				continue;
+			}
+
+			// If it doesn't have an upgrader, there's nothing to do
+			if( ! $info->hasUpgrader() ) {
+				continue;
+			}
+
+			try {
+
+				$success = $this->processAddon($name, $info);
+
+			} catch (\Exception $e) {
+
+				$success = false;
+
+			}
+
+			$results[$name] = $success;
+
+		}
+
+		return $results;
+
+	}
+
+	// PRIVATE FUNCTIONS
+	/**
+	 * runs the upgrader class for an addon
+	 * @param  string $name [name of addon]
+	 * @param  stdClass $info [info on class of addon]
+	 * @return mixed
+	 */
+	private function processAddon($name, $info)
+	{
+
+		$upgrader = $info->getUpgraderClass();
+
+		$result = (new $upgrader)->upgrade($this->from_version);
+
+		// If we are updating from the CLI, we can ensure that all addons get updated at each step
+		// This is a great deal slower, but makes life easier
+		if(defined('CLI_UPDATE_FORCE_ADDON_UPDATE') && CLI_UPDATE_FORCE_ADDON_UPDATE) {
+
+			$updater = $info->getInstallerClass();
+
+			$updater->update($this->from_version);
+
+		}
+
+		return $result;
+
+	}
+
+}

--- a/system/ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/AddonUpgrader.php
+++ b/system/ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/AddonUpgrader.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2019, EllisLab Corp. (https://ellislab.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace EllisLab\ExpressionEngine\Updater\Service\Updater;
+
+use EllisLab\ExpressionEngine\Library\Filesystem\Filesystem;
+use EllisLab\ExpressionEngine\Updater\Service\Updater\SteppableTrait;
+use Exception;
+
+/**
+ * Database updater for one-click updater
+ *
+ * Runs the ud_x_xx_xx.php files needed to complete the update
+ */
+class AddonUpgrader {
+
+	protected $filesystem;
+
+	protected $error;
+
+	private $basepath;
+
+	private $removeFunctions = [
+		'__construct',
+	];
+
+	public function __construct($basepath)
+	{
+
+		$this->basepath = $basepath;
+
+		$this->filesystem = new Filesystem;
+
+	}
+
+	/**
+	 * runs all appropriate methods to upgrade an addon
+	 * @return bool
+	 */
+	public function run()
+	{
+
+		$functions = get_class_methods($this);
+
+		foreach ($functions as $fxn) {
+
+			if( ! in_array($fxn, $this->removeFunctions)) {
+
+				$result = $this->{$fxn}();
+
+				if( ! $result ) {
+					throw new Exception('Upgrader failed');
+				}
+
+			}
+
+		}
+
+		return true;
+
+	}
+
+	// PROTECTED FUNCTIONS
+	// These are the ones that update all of the things in the addon.
+	protected function convertThisEEGetInstanceToNull()
+	{
+
+		if($this->filesystem->isDir($this->basepath)) {
+
+			$contents = $this->filesystem->getDirectoryContents($this->basepath, true);
+
+			foreach ($contents as $file) {
+
+				$fileContents = $this->filesystem->read($file);
+
+				$newFileContents = str_replace('$this->EE =& get_instance();', '', $fileContents);
+
+				try {
+
+					$this->filesystem->write($file, $newFileContents, true);
+
+				} catch(Exception $e) {
+
+					$this->error = "{$e->getMessage()}\n\n\n{$e->getTraceAsString()}";
+
+					return false;
+
+				}
+
+			}
+
+		}
+
+	}
+
+	protected function convertThisEEToEEFunction()
+	{
+
+		if($this->filesystem->isDir($this->basepath)) {
+
+			$contents = $this->filesystem->getDirectoryContents($this->basepath, true);
+
+			foreach ($contents as $file) {
+
+				$fileContents = $this->filesystem->read($file);
+
+				$newFileContents = str_replace('$this->EE', 'ee()', $fileContents);
+
+				try {
+
+					$this->filesystem->write($file, $newFileContents, true);
+
+				} catch(Exception $e) {
+
+					$this->error = "{$e->getMessage()}\n\n\n{$e->getTraceAsString()}";
+
+					return false;
+
+				}
+
+			}
+
+		}
+
+		return true;
+
+	}
+
+}

--- a/system/ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/Runner.php
+++ b/system/ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/Runner.php
@@ -31,7 +31,8 @@ class Runner {
 			'updateFiles',
 			'checkForDbUpdates',
 			'backupDatabase',
-			'updateDatabase'
+			'updateDatabase',
+			'updateAddons'
 		]);
 
 		$this->logger = $this->makeLoggerService();
@@ -255,6 +256,11 @@ class Runner {
 		}
 	}
 
+	public function updateAddons()
+	{
+		$this->makeAddonUpdaterService()->updateAddons();
+	}
+
 	/**
 	 * Overrides SteppableTrait's runStep to be a catch-all for exceptions
 	 */
@@ -344,6 +350,17 @@ class Runner {
 			$filesystem,
 			$verifier,
 			$this->logger
+		);
+	}
+
+	/**
+	 * Makes AddonUpgrade service
+	 */
+	protected function makeAddonUpdaterService()
+	{
+
+		return new Service\Updater\AddonUpdater(
+			ee()->config->item('app_version')
 		);
 	}
 

--- a/system/ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/SteppableTrait.php
+++ b/system/ee/installer/updater/EllisLab/ExpressionEngine/Updater/Service/Updater/SteppableTrait.php
@@ -16,9 +16,27 @@ namespace EllisLab\ExpressionEngine\Updater\Service\Updater;
  */
 trait SteppableTrait {
 
+	/**
+	 * Set the steps (method names) to run through
+	 *
+	 * @param	array	$steps	Method names
+	 */
 	public function setSteps(Array $steps)
 	{
 		$this->steps = $steps;
+	}
+
+	/**
+	 * Runs an individual step
+	 */
+	public function runStep($step)
+	{
+		$this->currentStep = $step;
+		$this->nextStep = NULL;
+
+		list($step, $parameters) = $this->parseStepString($step);
+
+		call_user_func_array([$this, $step], $parameters);
 	}
 
 }

--- a/system/ee/installer/updater/boot.php
+++ b/system/ee/installer/updater/boot.php
@@ -19,12 +19,12 @@ else
 {
 	if ( ! defined('BASEPATH'))
 	{
-		define('BASEPATH', SYSPATH.'ee/legacy/');
-		define('PATH_CACHE',  SYSPATH . 'user/cache/');
-		define('FILE_READ_MODE', 0644);
-		define('FILE_WRITE_MODE', 0666);
-		define('DIR_READ_MODE', 0755);
-		define('DIR_WRITE_MODE', 0777);
+		defined('BASEPATH') || define('BASEPATH', SYSPATH.'ee/legacy/');
+		defined('PATH_CACHE') || define('PATH_CACHE',  SYSPATH . 'user/cache/');
+		defined('FILE_READ_MODE') || define('FILE_READ_MODE', 0644);
+		defined('FILE_WRITE_MODE') || define('FILE_WRITE_MODE', 0666);
+		defined('DIR_READ_MODE') || define('DIR_READ_MODE', 0755);
+		defined('DIR_WRITE_MODE') || define('DIR_WRITE_MODE', 0777);
 
 		require __DIR__.'/EllisLab/ExpressionEngine/Updater/Boot/boot.common.php';
 	}
@@ -34,9 +34,7 @@ else
 $constants = require SYSPATH.'ee/EllisLab/ExpressionEngine/Config/constants.php';
 
 foreach ($constants as $k => $v) {
-	if ( ! defined($k)) {
-		define($k, $v);
-	}
+	defined($k) || define($k, $v);
 }
 
 /*

--- a/system/ee/installer/updates/ud_2_00_01.php
+++ b/system/ee/installer/updates/ud_2_00_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_0_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_00_02.php
+++ b/system/ee/installer/updates/ud_2_00_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_0_2;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_01_00.php
+++ b/system/ee/installer/updates/ud_2_01_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_1_0;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_01_01.php
+++ b/system/ee/installer/updates/ud_2_01_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_1_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_01_02.php
+++ b/system/ee/installer/updates/ud_2_01_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_1_2;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_01_03.php
+++ b/system/ee/installer/updates/ud_2_01_03.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_1_3;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_01_04.php
+++ b/system/ee/installer/updates/ud_2_01_04.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_1_4;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_01_05.php
+++ b/system/ee/installer/updates/ud_2_01_05.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_1_5;
+
 /**
  * Update
  */
@@ -52,7 +54,7 @@ class Updater {
 		// Add a MySQL index or three to help performance
 		$steps[] = '_do_add_indexes';
 
-		$steps = new ProgressIterator($steps);
+		$steps = new \ProgressIterator($steps);
 
 		foreach ($steps as $k => $v)
 		{

--- a/system/ee/installer/updates/ud_2_02_00.php
+++ b/system/ee/installer/updates/ud_2_02_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_2_0;
+
 /**
  * Update
  */
@@ -22,7 +24,7 @@ class Updater {
 	 */
 	public function do_update()
 	{
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_update_session_table',
 				'_update_password_lockout_table',

--- a/system/ee/installer/updates/ud_2_02_01.php
+++ b/system/ee/installer/updates/ud_2_02_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_2_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_02_02.php
+++ b/system/ee/installer/updates/ud_2_02_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_2_2;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_03_00.php
+++ b/system/ee/installer/updates/ud_2_03_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_3_0;
+
 /**
  * Update
  */
@@ -22,7 +24,7 @@ class Updater {
 	 */
 	public function do_update()
 	{
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_update_session_table',
 				'_fix_emoticon_config',

--- a/system/ee/installer/updates/ud_2_03_01.php
+++ b/system/ee/installer/updates/ud_2_03_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_3_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_04_00.php
+++ b/system/ee/installer/updates/ud_2_04_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_4_0;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_update_watermarks_table',
 				'_update_file_dimensions_table',

--- a/system/ee/installer/updates/ud_2_05_00.php
+++ b/system/ee/installer/updates/ud_2_05_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_5_0;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_05_01.php
+++ b/system/ee/installer/updates/ud_2_05_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_5_1;
+
 /**
  * Update
  */
@@ -22,7 +24,7 @@ class Updater {
 	 */
 	public function do_update()
 	{
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_update_ip_address_length',
 			)

--- a/system/ee/installer/updates/ud_2_05_02.php
+++ b/system/ee/installer/updates/ud_2_05_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_5_2;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_05_03.php
+++ b/system/ee/installer/updates/ud_2_05_03.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_5_3;
+
 /**
  * Update
  */
@@ -22,7 +24,7 @@ class Updater {
 	 */
 	public function do_update()
 	{
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_change_site_preferences_column_type',
 				'_truncate_tables',

--- a/system/ee/installer/updates/ud_2_05_04.php
+++ b/system/ee/installer/updates/ud_2_05_04.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_5_4;
+
 /**
  * Update
  */
@@ -22,7 +24,7 @@ class Updater {
 	 */
 	public function do_update()
 	{
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_change_member_totals_length',
 				'_update_session_table',

--- a/system/ee/installer/updates/ud_2_05_05.php
+++ b/system/ee/installer/updates/ud_2_05_05.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_5_5;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_06_00.php
+++ b/system/ee/installer/updates/ud_2_06_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_6_0;
+
 /**
  * Update
  */
@@ -31,7 +33,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_add_template_name_to_dev_log',
 				'_drop_dst',
@@ -420,13 +422,13 @@ If you do not wish to reset your password, ignore this message. It will expire i
 	{
 		ee()->remove('template');
 		require_once(APPPATH . 'libraries/Template.php');
-		ee()->set('template', new Installer_Template());
+		ee()->set('template', new \Installer_Template());
 
 		// Since we don't have consistent destructors,
 		// we'll keep this here.
 		$installer_config = ee()->config;
 		ee()->remove('config');
-		ee()->set('config', new MSM_Config());
+		ee()->set('config', new \MSM_Config());
 
 		// We need to figure out which template to load.
 		// Need to check the edit date.

--- a/system/ee/installer/updates/ud_2_06_01.php
+++ b/system/ee/installer/updates/ud_2_06_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_6_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_07_00.php
+++ b/system/ee/installer/updates/ud_2_07_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_7_0;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_update_specialty_templates',
 				'_update_actions_table',
@@ -436,19 +438,19 @@ If you do not wish to reset your password, ignore this message. It will expire i
 		// We're gonna need this to be already loaded.
 		ee()->remove('functions');
 		require_once(APPPATH . 'libraries/Functions.php');
-		ee()->set('functions', new Installer_Functions());
+		ee()->set('functions', new \Installer_Functions());
 
 		ee()->remove('extensions');
 		require_once(APPPATH . 'libraries/Extensions.php');
-		ee()->set('extensions', new Installer_Extensions());
+		ee()->set('extensions', new \Installer_Extensions());
 
 		ee()->remove('addons');
 		require_once(APPPATH . 'libraries/Addons.php');
-		ee()->set('addons', new Installer_Addons());
+		ee()->set('addons', new \Installer_Addons());
 
 		$installer_config = ee()->config;
 		ee()->remove('config');
-		ee()->set('config', new MSM_Config());
+		ee()->set('config', new \MSM_Config());
 
 		// We need to figure out which template to load.
 		// Need to check the edit date.
@@ -712,7 +714,7 @@ If you do not wish to reset your password, ignore this message. It will expire i
 			require_once(APPPATH . 'libraries/Template.php');
 		}
 		ee()->remove('template');
-		ee()->set('template', new Installer_Template());
+		ee()->set('template', new \Installer_Template());
 
 		ee()->load->model('snippet_model');
 		$snippets = ee()->snippet_model->fetch();

--- a/system/ee/installer/updates/ud_2_07_01.php
+++ b/system/ee/installer/updates/ud_2_07_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_7_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_07_02.php
+++ b/system/ee/installer/updates/ud_2_07_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_7_2;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_clean_quick_tabs',
 			)

--- a/system/ee/installer/updates/ud_2_07_03.php
+++ b/system/ee/installer/updates/ud_2_07_03.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_7_3;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_update_email_db_columns',
 			)

--- a/system/ee/installer/updates/ud_2_08_00.php
+++ b/system/ee/installer/updates/ud_2_08_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_8_0;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_update_specialty_templates',
 				'_update_extension_quick_tabs',
@@ -285,7 +287,7 @@ If you do not wish to reset your password, ignore this message. It will expire i
 		ee()->config->_update_config(array(), array('secure_forms' => ''));
 
 		// Remove config item from db
-		$msm_config = new MSM_Config();
+		$msm_config = new \MSM_Config();
 		$msm_config->remove_config_item('secure_forms');
 
 		// If it was no, we need to set it as disabled

--- a/system/ee/installer/updates/ud_2_08_01.php
+++ b/system/ee/installer/updates/ud_2_08_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_8_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_09_00.php
+++ b/system/ee/installer/updates/ud_2_09_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_9_0;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_update_template_routes_table',
 				'_set_hidden_template_indicator',
@@ -149,19 +151,19 @@ class Updater {
 		// We're gonna need this to be already loaded.
 		ee()->remove('functions');
 		require_once(APPPATH . 'libraries/Functions.php');
-		ee()->set('functions', new Installer_Functions());
+		ee()->set('functions', new \Installer_Functions());
 
 		ee()->remove('extensions');
 		require_once(APPPATH . 'libraries/Extensions.php');
-		ee()->set('extensions', new Installer_Extensions());
+		ee()->set('extensions', new \Installer_Extensions());
 
 		ee()->remove('addons');
 		require_once(APPPATH . 'libraries/Addons.php');
-		ee()->set('addons', new Installer_Addons());
+		ee()->set('addons', new \Installer_Addons());
 
 		$installer_config = ee()->config;
 		ee()->remove('config');
-		ee()->set('config', new MSM_Config());
+		ee()->set('config', new \MSM_Config());
 
 		// We need to figure out which template to load.
 		// Need to check the edit date.
@@ -272,11 +274,11 @@ class Updater {
 
 		ee()->remove('template');
 		require_once(APPPATH . 'libraries/Template.php');
-		ee()->set('template', new Installer_Template());
+		ee()->set('template', new \Installer_Template());
 
 		$installer_config = ee()->config;
 		ee()->remove('config');
-		ee()->set('config', new MSM_Config());
+		ee()->set('config', new \MSM_Config());
 
 		$templates = ee()->template_model->fetch_last_edit(array(), TRUE);
 

--- a/system/ee/installer/updates/ud_2_09_01.php
+++ b/system/ee/installer/updates/ud_2_09_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_9_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_09_02.php
+++ b/system/ee/installer/updates/ud_2_09_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_9_2;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_09_03.php
+++ b/system/ee/installer/updates/ud_2_09_03.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_9_3;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_extract_cache_driver_config',
 				'_recompile_template_routes',
@@ -124,7 +126,7 @@ class Updater {
 
 		foreach ($query->result() as $template)
 		{
-			$ee_route = new EE_Route($template->route, $template->route_required == 'y');
+			$ee_route = new \EE_Route($template->route, $template->route_required == 'y');
 			$compiled = $ee_route->compile();
 			$data = array('route_parsed' => $compiled);
 			ee()->template_model->update_template_route($template->template_id, $data);
@@ -151,7 +153,7 @@ class Updater {
 
 		// Update the site preferences
 		$sites = ee()->db->select('site_id')->get('sites');
-		$msm_config = new MSM_Config();
+		$msm_config = new \MSM_Config();
 
 		if ($sites->num_rows() > 0)
 		{

--- a/system/ee/installer/updates/ud_2_10_00.php
+++ b/system/ee/installer/updates/ud_2_10_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_10_0;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_member_login_state',
 				'_modify_category_data_fields',
@@ -94,7 +96,7 @@ class Updater {
 
 		// Update the site preferences
 		$sites = ee()->db->select('site_id')->get('sites');
-		$msm_config = new MSM_Config();
+		$msm_config = new \MSM_Config();
 
 		if ($sites->num_rows() > 0)
 		{
@@ -144,7 +146,7 @@ class Updater {
 	 */
 	public function _add_new_private_messages_options()
 	{
-		$msm_config = new MSM_Config();
+		$msm_config = new \MSM_Config();
 		$msm_config->update_site_prefs(
 			array(
 				'prv_msg_enabled' => 'y',

--- a/system/ee/installer/updates/ud_2_10_01.php
+++ b/system/ee/installer/updates/ud_2_10_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_10_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_10_02.php
+++ b/system/ee/installer/updates/ud_2_10_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_10_2;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_10_03.php
+++ b/system/ee/installer/updates/ud_2_10_03.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_10_3;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_11_00.php
+++ b/system/ee/installer/updates/ud_2_11_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_11_0;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_11_01.php
+++ b/system/ee/installer/updates/ud_2_11_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_11_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_11_02.php
+++ b/system/ee/installer/updates/ud_2_11_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_11_2;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_11_03.php
+++ b/system/ee/installer/updates/ud_2_11_03.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_11_3;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_11_04.php
+++ b/system/ee/installer/updates/ud_2_11_04.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_11_4;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_11_05.php
+++ b/system/ee/installer/updates/ud_2_11_05.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_11_5;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_11_06.php
+++ b/system/ee/installer/updates/ud_2_11_06.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_11_6;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_11_07.php
+++ b/system/ee/installer/updates/ud_2_11_07.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_11_7;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_11_08.php
+++ b/system/ee/installer/updates/ud_2_11_08.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_11_8;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_2_11_09.php
+++ b/system/ee/installer/updates/ud_2_11_09.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_2_11_9;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_3_00_00.php
+++ b/system/ee/installer/updates/ud_3_00_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_0_0;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_move_database_information',
 				'_update_email_cache_table',
@@ -384,7 +386,7 @@ class Updater {
 		foreach ($sites as $site)
 		{
 			ee()->remove('config');
-			ee()->set('config', new MSM_Config());
+			ee()->set('config', new \MSM_Config());
 
 			ee()->config->site_prefs('', $site['site_id']);
 
@@ -644,7 +646,7 @@ class Updater {
 			$all_site_ids[] = $site->site_id;
 		}
 
-		$msm_config = new MSM_Config();
+		$msm_config = new \MSM_Config();
 
 		foreach ($all_site_ids as $site_id)
 		{
@@ -1266,7 +1268,7 @@ class Updater {
 	 */
 	private function _remove_referrer_module_artifacts()
 	{
-		$msm_config = new MSM_Config();
+		$msm_config = new \MSM_Config();
 		$msm_config->remove_config_item(array('log_referrers', 'max_referrers'));
 
 		ee()->smartforge->drop_table('referrers');
@@ -1332,7 +1334,7 @@ class Updater {
 		ee()->smartforge->drop_table('mailing_list_queue');
 		ee()->smartforge->drop_table('email_cache_ml');
 
-		$msm_config = new MSM_Config();
+		$msm_config = new \MSM_Config();
 		$msm_config->remove_config_item(array(
 			'mailinglist_enabled',
 			'mailinglist_notify',
@@ -1407,7 +1409,7 @@ class Updater {
 	 */
 	private function _remove_cp_theme_config()
 	{
-		$msm_config = new MSM_Config();
+		$msm_config = new \MSM_Config();
 		$msm_config->remove_config_item(array('cp_theme'));
 
 		ee()->smartforge->drop_column('members', 'cp_theme');

--- a/system/ee/installer/updates/ud_3_00_01.php
+++ b/system/ee/installer/updates/ud_3_00_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_0_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_3_00_02.php
+++ b/system/ee/installer/updates/ud_3_00_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_0_2;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_update_member_field_schema',
 			)

--- a/system/ee/installer/updates/ud_3_00_03.php
+++ b/system/ee/installer/updates/ud_3_00_03.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_0_3;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_3_00_04.php
+++ b/system/ee/installer/updates/ud_3_00_04.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_0_4;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_3_00_05.php
+++ b/system/ee/installer/updates/ud_3_00_05.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_0_5;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'install_required_modules',
 			)

--- a/system/ee/installer/updates/ud_3_00_06.php
+++ b/system/ee/installer/updates/ud_3_00_06.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_0_6;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'_comment_formatting'
 			)

--- a/system/ee/installer/updates/ud_3_01_00.php
+++ b/system/ee/installer/updates/ud_3_01_00.php
@@ -8,6 +8,10 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_1_0;
+
+use Exception;
+
 /**
  * Update
  */
@@ -25,7 +29,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'move_avatars',
 				'update_member_data_column_names',

--- a/system/ee/installer/updates/ud_3_01_01.php
+++ b/system/ee/installer/updates/ud_3_01_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_1_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_3_01_02.php
+++ b/system/ee/installer/updates/ud_3_01_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_1_2;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_3_01_03.php
+++ b/system/ee/installer/updates/ud_3_01_03.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_1_3;
+
 /**
  * Update
  */
@@ -24,7 +26,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'update_memberlist_order_by',
 				'update_site_ids_for_categories'
@@ -46,7 +48,7 @@ class Updater {
 	 */
 	private function update_memberlist_order_by()
 	{
-		$msm_config = new MSM_Config();
+		$msm_config = new \MSM_Config();
 		$msm_config->update_site_prefs(array('memberlist_order_by' => 'member_id'), 'all');
 	}
 

--- a/system/ee/installer/updates/ud_3_01_04.php
+++ b/system/ee/installer/updates/ud_3_01_04.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_1_4;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_3_02_00.php
+++ b/system/ee/installer/updates/ud_3_02_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_2_0;
+
 /**
  * Update
  */
@@ -25,7 +27,7 @@ class Updater {
 	{
 		ee()->load->dbforge();
 
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'drop_cp_search_table',
 				'add_url_field',

--- a/system/ee/installer/updates/ud_3_02_01.php
+++ b/system/ee/installer/updates/ud_3_02_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_2_1;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_3_02_02.php
+++ b/system/ee/installer/updates/ud_3_02_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_2_2;
+
 /**
  * Update
  */
@@ -22,7 +24,7 @@ class Updater {
 	 */
 	public function do_update()
 	{
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'install_required_fieldtypes',
 			)

--- a/system/ee/installer/updates/ud_3_03_00.php
+++ b/system/ee/installer/updates/ud_3_03_00.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_3_0;
+
 /**
  * Update
  */
@@ -22,7 +24,7 @@ class Updater {
 	 */
 	public function do_update()
 	{
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'add_can_debug_column',
 				'use_site_default_localization_settings',
@@ -111,7 +113,7 @@ class Updater {
 			->get('sites')
 			->result_array();
 		$site_1 = array_shift($sites);
-		$msm_config = new MSM_Config();
+		$msm_config = new \MSM_Config();
 
 		$msm_config->site_prefs('', 1);
 		$same = TRUE;

--- a/system/ee/installer/updates/ud_3_03_01.php
+++ b/system/ee/installer/updates/ud_3_03_01.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_3_1;
+
 /**
  * Update
  */
@@ -22,10 +24,11 @@ class Updater {
 	 */
 	public function do_update()
 	{
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'use_site_default_localization_settings',
-				'set_encryption_key'
+				'set_encryption_key',
+				'fixCategoryFields'
 			)
 		);
 
@@ -96,6 +99,26 @@ class Updater {
 		}
 	}
 
+	// Adds category fields
+	private function fixCategoryFields()
+	{
+
+		if ( ! ee()->db->field_exists('legacy_field_data', 'category_fields'))
+		{
+			ee()->smartforge->add_column(
+				'category_fields',
+				array(
+					'legacy_field_data' => array(
+						'type'    => 'CHAR(1)',
+						'null'    => FALSE,
+						'default' => 'n'
+					)
+				)
+			);
+			ee()->db->update('category_fields', array('legacy_field_data' => 'y'));
+		}
+
+	}
 
 }
 

--- a/system/ee/installer/updates/ud_3_03_02.php
+++ b/system/ee/installer/updates/ud_3_03_02.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_3_2;
+
 /**
  * Update
  */
@@ -22,7 +24,7 @@ class Updater {
 	 */
 	public function do_update()
 	{
-		$steps = new ProgressIterator(
+		$steps = new \ProgressIterator(
 			array(
 				'update_superadmin_permissions'
 			)
@@ -141,6 +143,7 @@ class Updater {
 		ee()->db->where('group_id', 1)
 			->update('member_groups', $permissions);
 	}
+
 }
 
 // EOF

--- a/system/ee/installer/updates/ud_3_03_03.php
+++ b/system/ee/installer/updates/ud_3_03_03.php
@@ -8,124 +8,124 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_3_3;
+
 /**
  * Update
  */
-class Updater {
+class Updater
+{
+    public $version_suffix = '';
 
-	var $version_suffix = '';
+    /**
+     * Do Update
+     *
+     * @return TRUE
+     */
+    public function do_update()
+    {
+        $steps = new \ProgressIterator(
+            array(
+                'addFieldSettingsColumns',
+                'update_category_fields',
+                'alter_is_locked',
+                'update_status_highlight'
+            )
+        );
 
-	/**
-	 * Do Update
-	 *
-	 * @return TRUE
-	 */
-	public function do_update()
-	{
-		$steps = new ProgressIterator(
-			array(
-				'addFieldSettingsColumns',
-				'update_category_fields',
-				'alter_is_locked',
-				'update_status_highlight'
-			)
-		);
+        foreach ($steps as $k => $v) {
+            $this->$v();
+        }
 
-		foreach ($steps as $k => $v)
-		{
-			$this->$v();
-		}
+        return true;
+    }
 
-		return TRUE;
-	}
+    /**
+     * This column isn't needed until 3.5.1, but needs adding before we access
+     * the CategoryField models below
+     *
+     * @return void
+     */
+    private function addFieldSettingsColumns()
+    {
+        ee()->smartforge->add_column(
+            'category_fields',
+            array(
+                'field_settings' => array(
+                    'type' => 'text',
+                    'null' => true
+                )
+            )
+        );
+    }
 
-	/**
-	 * This column isn't needed until 3.5.1, but needs adding before we access
-	 * the CategoryField models below
-	 *
-	 * @return void
-	 */
-	private function addFieldSettingsColumns()
-	{
-		ee()->smartforge->add_column(
-			'category_fields',
-			array(
-				'field_settings' => array(
-					'type' => 'text',
-					'null' => TRUE
-				)
-			)
-		);
-	}
+    /**
+     * Update category fields so their formatting is properly set
+     *
+     * @return void
+     */
+    private function update_category_fields()
+    {
+        $category_fields = ee('Model')->get('CategoryField')
+            ->all()
+            ->indexBy('field_id');
 
-	/**
-	 * Update category fields so their formatting is properly set
-	 *
-	 * @return void
-	 */
-	private function update_category_fields()
-	{
-		$category_fields = ee()->db->select('field_id', 'field_default_fmt')
-			->get('category_fields')
-			->result_array();
+        foreach ($category_fields as $id => $field) {
+            ee()->db->update(
+                'category_field_data',
+                array('field_ft_'.$id => $field->field_default_fmt),
+                array('field_ft_'.$id => null)
+            );
+        }
+    }
 
-		foreach ($category_fields as $row)
-		{
-			ee()->db->update(
-				'category_field_data',
-				array('field_ft_'.$row['field_id'] => $row['field_default_fmt']),
-				array('field_ft_'.$row['field_id'] => NULL)
-			);
-		}
-	}
+    /**
+     * Update is_locked in exp_member_groups to default to unlocked
+     *
+     * @return void
+     */
+    private function alter_is_locked()
+    {
+        // ALTER TABLE `exp_member_groups` CHANGE COLUMN `is_locked` `is_locked` char(1) NOT NULL DEFAULT 'n';
+        ee()->smartforge->modify_column(
+            'member_groups',
+            array(
+                'is_locked' => array(
+                    'name'			=> 'is_locked',
+                    'type'			=> 'char',
+                    'constraint'	=> 1,
+                    'default'		=> 'n',
+                    'null'			=> false
+                )
+            )
+        );
+    }
 
-	/**
-	 * Update is_locked in exp_member_groups to default to unlocked
-	 *
-	 * @return void
-	 */
-	private function alter_is_locked()
-	{
-		// ALTER TABLE `exp_member_groups` CHANGE COLUMN `is_locked` `is_locked` char(1) NOT NULL DEFAULT 'n';
-		ee()->smartforge->modify_column(
-			'member_groups',
-			array(
-				'is_locked' => array(
-					'name'			=> 'is_locked',
-					'type'			=> 'char',
-					'constraint'	=> 1,
-					'default'		=> 'n',
-					'null'			=> FALSE
-				)
-			)
-		);
-	}
+    /**
+     * Update status highlight field to have a default
+     *
+     * @return void
+     */
+    private function update_status_highlight()
+    {
+        // ALTER TABLE `exp_statuses` CHANGE COLUMN `highlight` `highlight` varchar(30) NOT NULL DEFAULT '000000';
+        ee()->smartforge->modify_column(
+            'statuses',
+            array(
+                'highlight' => array(
+                    'name'			=> 'highlight',
+                    'type'			=> 'varchar',
+                    'constraint'	=> 30,
+                    'default'		=> '000000',
+                    'null'			=> false
+                )
+            )
+        );
 
-	/**
-	 * Update status highlight field to have a default
-	 *
-	 * @return void
-	 */
-	private function update_status_highlight()
-	{
-		// ALTER TABLE `exp_statuses` CHANGE COLUMN `highlight` `highlight` varchar(30) NOT NULL DEFAULT '000000';
-		ee()->smartforge->modify_column(
-			'statuses',
-			array(
-				'highlight' => array(
-					'name'			=> 'highlight',
-					'type'			=> 'varchar',
-					'constraint'	=> 30,
-					'default'		=> '000000',
-					'null'			=> FALSE
-				)
-			)
-		);
-
-		// Update existing
-		ee()->db->where('highlight', '')
-			->update('statuses', array('highlight' => '000000'));
-	}
+        // Update existing
+        ee()->db->where('highlight', '')
+            ->update('statuses', array('highlight' => '000000'));
+    }
 }
 
 // EOF

--- a/system/ee/installer/updates/ud_3_03_04.php
+++ b/system/ee/installer/updates/ud_3_03_04.php
@@ -8,6 +8,8 @@
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
 
+namespace EllisLab\ExpressionEngine\Updater\Version_3_3_4;
+
 /**
  * Update
  */

--- a/system/ee/installer/updates/ud_3_05_16.php
+++ b/system/ee/installer/updates/ud_3_05_16.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2019, EllisLab Corp. (https://ellislab.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace EllisLab\ExpressionEngine\Updater\Version_3_5_16;
+
+/**
+ * Update
+ */
+class Updater {
+
+	var $version_suffix = '';
+
+	/**
+	 * Do Update
+	 *
+	 * @return TRUE
+	 */
+	public function do_update()
+	{
+		return TRUE;
+	}
+}
+
+// EOF

--- a/system/ee/installer/updates/ud_3_05_17.php
+++ b/system/ee/installer/updates/ud_3_05_17.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2019, EllisLab Corp. (https://ellislab.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace EllisLab\ExpressionEngine\Updater\Version_3_5_17;
+
+/**
+ * Update
+ */
+class Updater {
+
+	var $version_suffix = '';
+
+	/**
+	 * Do Update
+	 *
+	 * @return TRUE
+	 */
+	public function do_update()
+	{
+		return TRUE;
+	}
+}
+
+// EOF

--- a/system/ee/installer/updates/ud_4_00_00.php
+++ b/system/ee/installer/updates/ud_4_00_00.php
@@ -57,10 +57,6 @@ class Updater {
 
 	private function emancipateTheFields()
 	{
-		if (ee()->db->table_exists('channels_channel_field_groups'))
-		{
-			return;
-		}
 
 		// Fields can span Sites and do not need Groups
 		ee()->smartforge->modify_column('channel_fields', array(
@@ -86,62 +82,68 @@ class Updater {
 		));
 
 		// Add the Many-to-Many tables
-		ee()->dbforge->add_field(
-			array(
-				'channel_id' => array(
-					'type'       => 'int',
-					'constraint' => 4,
-					'unsigned'   => TRUE,
-					'null'       => FALSE
-				),
-				'group_id' => array(
-					'type'       => 'int',
-					'constraint' => 4,
-					'unsigned'   => TRUE,
-					'null'       => FALSE
+		if ( ! ee()->db->table_exists('channels_channel_field_groups')) {
+			ee()->dbforge->add_field(
+				array(
+					'channel_id' => array(
+						'type'       => 'int',
+						'constraint' => 4,
+						'unsigned'   => TRUE,
+						'null'       => FALSE
+					),
+					'group_id' => array(
+						'type'       => 'int',
+						'constraint' => 4,
+						'unsigned'   => TRUE,
+						'null'       => FALSE
+					)
 				)
-			)
-		);
-		ee()->dbforge->add_key(array('channel_id', 'group_id'), TRUE);
-		ee()->smartforge->create_table('channels_channel_field_groups');
+			);
+			ee()->dbforge->add_key(array('channel_id', 'group_id'), TRUE);
+			ee()->smartforge->create_table('channels_channel_field_groups');
+		}
 
-		ee()->dbforge->add_field(
-			array(
-				'channel_id' => array(
-					'type'       => 'int',
-					'constraint' => 4,
-					'unsigned'   => TRUE,
-					'null'       => FALSE
-				),
-				'field_id' => array(
-					'type'       => 'int',
-					'constraint' => 6,
-					'unsigned'   => TRUE,
-					'null'       => FALSE
+		if ( ! ee()->db->table_exists('channels_channel_fields')) {
+			ee()->dbforge->add_field(
+				array(
+					'channel_id' => array(
+						'type'       => 'int',
+						'constraint' => 4,
+						'unsigned'   => TRUE,
+						'null'       => FALSE
+					),
+					'field_id' => array(
+						'type'       => 'int',
+						'constraint' => 6,
+						'unsigned'   => TRUE,
+						'null'       => FALSE
+					)
 				)
-			)
-		);
-		ee()->dbforge->add_key(array('channel_id', 'field_id'), TRUE);
-		ee()->smartforge->create_table('channels_channel_fields');
+			);
+			ee()->dbforge->add_key(array('channel_id', 'field_id'), TRUE);
+			ee()->smartforge->create_table('channels_channel_fields');
+		}
 
-		ee()->dbforge->add_field(
-			array(
-				'field_id' => array(
-					'type'       => 'int',
-					'constraint' => 6,
-					'unsigned'   => TRUE,
-					'null'       => FALSE
-				),
-				'group_id' => array(
-					'type'       => 'int',
-					'constraint' => 4,
-					'unsigned'   => TRUE,
-					'null'       => FALSE
+		if ( ! ee()->db->table_exists('channel_field_groups_fields')) {
+			ee()->dbforge->add_field(
+				array(
+					'field_id' => array(
+						'type'       => 'int',
+						'constraint' => 6,
+						'unsigned'   => TRUE,
+						'null'       => FALSE
+					),
+					'group_id' => array(
+						'type'       => 'int',
+						'constraint' => 4,
+						'unsigned'   => TRUE,
+						'null'       => FALSE
+					)
 				)
-			)
-		);
-		ee()->dbforge->add_key(array('field_id', 'group_id'), TRUE);
-		ee()->smartforge->create_table('channel_field_groups_fields');
+			);
+			ee()->dbforge->add_key(array('field_id', 'group_id'), TRUE);
+			ee()->smartforge->create_table('channel_field_groups_fields');
+		}
 
 		// Convert the one-to-one channel to field group assignment to the
 		// many-to-many structure

--- a/system/ee/installer/updates/ud_4_03_00.php
+++ b/system/ee/installer/updates/ud_4_03_00.php
@@ -271,6 +271,11 @@ class Updater {
 
 	private function installConsentModule()
 	{
+
+		if(REQ == 'CLI') {
+			return;
+		}
+
 		$addon = ee('Addon')->get('consent');
 
 		if ( ! $addon OR ! $addon->isInstalled())

--- a/system/ee/installer/updates/ud_4_03_07.php
+++ b/system/ee/installer/updates/ud_4_03_07.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2019, EllisLab Corp. (https://ellislab.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace EllisLab\ExpressionEngine\Updater\Version_4_3_7;
+
+/**
+ * Update
+ */
+class Updater {
+
+	var $version_suffix = '';
+
+	/**
+	 * Do Update
+	 *
+	 * @return TRUE
+	 */
+	public function do_update()
+	{
+		return TRUE;
+	}
+}
+
+// EOF

--- a/system/ee/installer/updates/ud_4_03_08.php
+++ b/system/ee/installer/updates/ud_4_03_08.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2019, EllisLab Corp. (https://ellislab.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace EllisLab\ExpressionEngine\Updater\Version_4_3_8;
+
+/**
+ * Update
+ */
+class Updater {
+
+	var $version_suffix = '';
+
+	/**
+	 * Do Update
+	 *
+	 * @return TRUE
+	 */
+	public function do_update()
+	{
+		return TRUE;
+	}
+}
+
+// EOF

--- a/system/ee/installer/updates/ud_5_04_00.php
+++ b/system/ee/installer/updates/ud_5_04_00.php
@@ -1,0 +1,32 @@
+<?php
+/**
+* This source file is part of the open source project
+* ExpressionEngine (https://expressionengine.com)
+*
+* @link      https://expressionengine.com/
+* @copyright Copyright (c) 2003-2020, Packet Tide, LLC (https://packettide.com)
+* @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+*/
+
+namespace EllisLab\ExpressionEngine\Updater\Version_5_4_0;
+
+/**
+* Update
+*/
+class Updater {
+
+	var $version_suffix = '';
+
+	/**
+	* Do Update
+	*
+	* @return TRUE
+	*/
+	public function do_update()
+	{
+		return TRUE;
+	}
+
+}
+
+// EOF

--- a/system/ee/installer/views/update_form.php
+++ b/system/ee/installer/views/update_form.php
@@ -10,6 +10,14 @@
 		</div>
 	</div>
 	<form action="<?=$action?>" method="post">
+		<?php if($show_advanced): ?>
+			<fieldset class="form-ctrls">
+				<label><input type="checkbox" name="database_backup" value="1"> <?=lang('update_should_get_database_backup')?></label>
+			</fieldset>
+			<fieldset class="form-ctrls">
+				<label><input type="checkbox" name="update_addons" value="1"> <?=lang('update_should_update_addons')?></label>
+			</fieldset>
+		<?php endif; ?>
 		<fieldset class="form-ctrls">
 			<input class="btn" type="submit" value="<?=lang('start_update')?>">
 		</fieldset>

--- a/system/ee/legacy/helpers/cli_helper.php
+++ b/system/ee/legacy/helpers/cli_helper.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Sends a message to stdout if we're in the CLI
+ *
+ * @param	string	$message	Message to display
+ * @param	const	$status		Status of message, affects appearance
+ */
+
+defined('CLI_STDOUT_NORMAL') || define('CLI_STDOUT_NORMAL', 1);
+defined('CLI_STDOUT_BOLD') || define('CLI_STDOUT_BOLD', 2);
+defined('CLI_STDOUT_SUCCESS') || define('CLI_STDOUT_SUCCESS', 3);
+defined('CLI_STDOUT_FAILURE') || define('CLI_STDOUT_FAILURE', 4);
+
+if( ! function_exists('stdout') ) {
+
+	function stdout($message, $status = CLI_STDOUT_NORMAL)
+	{
+		$text_color = '[1;37m';
+
+		switch ($status) {
+			case CLI_STDOUT_BOLD:
+				$arrow_color = '[0;34m';
+				$text_color = '[1;37m';
+				break;
+			case CLI_STDOUT_SUCCESS:
+				$arrow_color = '[0;32m';
+				break;
+			case CLI_STDOUT_FAILURE:
+				$arrow_color = '[0;31m';
+				break;
+			default:
+				$arrow_color = $text_color = '[0m';
+				break;
+		}
+
+		if (REQ == 'CLI' && ! empty($message))
+		{
+
+			$message = "\033".$arrow_color."==> \033" . $text_color . strip_tags($message) . "\033[0m\n";
+
+			$stdout = fopen('php://stdout', 'w');
+
+			fwrite($stdout, $message);
+
+			fclose($stdout);
+
+		}
+
+	}
+
+}

--- a/system/ee/legacy/language/english/updater_lang.php
+++ b/system/ee/legacy/language/english/updater_lang.php
@@ -47,6 +47,9 @@ $lang = array(
 'updateFiles_step' =>
 'Updating files',
 
+'updateAddons_step' =>
+'Checking addons for automatic updates',
+
 'files_not_writable' =>
 'The following paths are not writable:
 


### PR DESCRIPTION
## Overview

Per discussion, this PR adds two thing:
1. Upgrade Fixes: This adds
- namespacing to EE2 updates so that they can be run in the EE upgrade process via the CLI (see below) or UI.
- Add-on upgrading during the EE core upgrading process via available add-on hooks
- Database backup as part of the EE core upgrade process.

2. CLI Feature. This allows for creation of commands for use in the command line. Documentation available on docs PR [https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/90](https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/90).

In addition, the CLI feature adds:
- CLI upgrading from EE2 to EE5
- ability to move file structure from EE2 to EE5 similar structure, with a good amount of control, via `prepare-upgrade` command.

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [X] 🚀 Implements a new feature
- [X] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/90