### PR TITLE
Implemented different approach to trigger `before_channel_entry_delet…

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -28,6 +28,9 @@ Bullet list below, e.g.
 
    - Altered a javascript filename that mod_security tended to object to.
    - Fixed a bug where input data were assumed to be URL encoded, causing certain character sequences to be stripped when cleaned.
+   - Implemented different approach to trigger `before_channel_entry_delete` extension hook. Fixes a bug ([#487](https://github.com/ExpressionEngine/ExpressionEngine/issues/487)) where custom fields data were not available for extensions when deleting entry.
+
+
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelEntry.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelEntry.php
@@ -479,6 +479,16 @@ class ChannelEntry extends ContentModel {
 
 	public function onBeforeDelete()
 	{
+		/**
+		 * we're placing the hook call here, so it would be called a bit earlier,
+		 * when all data are still present
+		 */
+		if (ee()->extensions->active_hook('before_channel_entry_delete'))
+		{
+			$entry = ee('Model')->get('ChannelEntry', $this->entry_id)->first();
+			ee()->extensions->call('before_channel_entry_delete', $entry, $entry->getValues());
+		}
+
 		$this->getAssociation('Channel')->markForReload();
 		parent::onBeforeDelete();
 

--- a/system/ee/EllisLab/ExpressionEngine/Service/Model/Model.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Model/Model.php
@@ -625,19 +625,22 @@ class Model extends SerializableEntity implements Subscriber, ValidationAware {
 	 */
 	protected function hookShouldTrigger($hook)
 	{
-
 		$process = true;
-
-		if($hook == 'after_channel_entry_save') {
-			
-			if($this->_has_saved) $process = false;
-
-			$this->_has_saved = true;
-			
+		switch ($hook) {
+			case 'before_channel_entry_delete':
+				$process = false;
+				break;
+			case 'after_channel_entry_save':
+				if($this->_has_saved) {
+					$process = false;
+				}
+				$this->_has_saved = true;
+				break;
+			default:
+				$process = true;
+				break;
 		}
-
 		return $process;
-
 	}
 
 	/**


### PR DESCRIPTION
…e` extension hook

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Implemented different approach to trigger `before_channel_entry_delete` extension hook. Resolves ([#487](https://github.com/ExpressionEngine/ExpressionEngine/issues/487)) where custom fields data were not available for extensions when deleting entry.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
