### PR TITLE
make sure field names are valid

### DIFF
--- a/system/ee/EllisLab/ExpressionEngine/Controller/Fields/Fields.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Fields/Fields.php
@@ -466,7 +466,7 @@ class Fields extends AbstractFieldsController {
 		$field->field_order = ($field->field_order) ?: 0;
 		$field->site_id = (int) $field->site_id ?: 0;
 
-		$field->set($_POST);
+		$field->set(ee()->security->xss_clean($_POST));
 
 		if ($field->field_pre_populate)
 		{


### PR DESCRIPTION
Make sure a valid field name is submitted when creating a new field. 