### PR TITLE
updated template sync to public function and removed template model f…

### DIFF
--- a/system/ee/EllisLab/ExpressionEngine/Controller/Design/Template.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Design/Template.php
@@ -252,7 +252,7 @@ class Template extends AbstractDesignController {
     			{
     				$template->save();
     				// Save a new revision
-    				$template->saveNewTemplateRevision($template);
+    				$template->saveNewTemplateRevision();
 
     				ee('CP/Alert')->makeInline('shared-form')
     					->asSuccess()

--- a/system/ee/EllisLab/ExpressionEngine/Model/Template/Template.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Template/Template.php
@@ -238,7 +238,7 @@ class Template extends FileSyncedModel {
 	 *
 	 * @param	Template	$template	Saved template model object
 	 */
-	protected function saveNewTemplateRevision()
+	public function saveNewTemplateRevision()
 	{
 		if ( ! bool_config_item('save_tmpl_revisions'))
 		{

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -4549,7 +4549,7 @@ class EE_Template {
 
 					// do it!
 					$template_model = ee('Model')->make('Template', $data)->save();
-					$template_model->saveNewTemplateRevision($template_model);
+					$template_model->saveNewTemplateRevision();
 
 					// add to existing array so we don't try to create this template again
 					$existing[$group][] = $template_name;
@@ -4569,7 +4569,7 @@ class EE_Template {
 					 );
 
 					$template_model = ee('Model')->make('Template', $data)->save();
-					$template_model->saveNewTemplateRevision($template_model);
+					$template_model->saveNewTemplateRevision();
 				}
 
 				unset($existing[$group]);


### PR DESCRIPTION
…rom being passed in as it's not on the model

Updated template sync calls to use model.. no longer have to pass template name as the sync function is on the model that's saving it.   Hat tip @intoeetive 