### PR TITLE
improve handling CP alerts

### DIFF
--- a/changelogs/minor.md
+++ b/changelogs/minor.md
@@ -6,6 +6,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 
 - Adds namespacing to v2 upgrades for ease of upgrading from v2 to v5
 - Adds CLI feature
+- Improved XSS filtering for CP clerts
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/EllisLab/ExpressionEngine/Service/Alert/Alert.php
+++ b/system/ee/EllisLab/ExpressionEngine/Service/Alert/Alert.php
@@ -129,9 +129,10 @@ class Alert {
 	 * @param string|array $item The item to display. If it's an array it will
 	 *  be rendred as a list.
 	 * @param string $class An optional CSS class to add to the item
+	 * @param string $xss_filter Apply XSS filtering to the message
 	 * @return self This returns a reference to itself
 	 */
-	public function addToBody($item, $class = NULL)
+	public function addToBody($item, $class = NULL, $xss_filter = true)
 	{
 		if ($class)
 		{
@@ -150,13 +151,13 @@ class Alert {
 			$this->body .= '<ul>';
 			foreach ($item as $i)
 			{
-				$this->body .= '<li>' . ee()->security->xss_clean($i) . '</li>';
+				$this->body .= '<li>' . ($xss_filter ? ee('Security/XSS')->clean($i) : $i) . '</li>';
 			}
 			$this->body .= '</ul>';
 		}
 		else
 		{
-			$this->body .= '<p' . $class . '>' . ee()->security->xss_clean($item) . '</p>';
+			$this->body .= '<p' . $class . '>' . ($xss_filter ? ee('Security/XSS')->clean($item) : $item) . '</p>';
 		}
 		return $this;
 	}

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -416,7 +416,7 @@ class Cp {
 				$button .= '<input class="btn submit" type="submit" value="' . lang('checksum_changed_accept') . '">';
 				$button .= form_close();
 
-				$alert->addToBody($button);
+				$alert->addToBody($button, '', false);
 
 				return $alert->now();
 			}


### PR DESCRIPTION
## Overview

Added 3rd parameter (`bool`) for `addToBody` function in CP/Alert that allows disabling filtering for particular message

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
