### PR TITLE
ensures we have version info to check against for updates #416

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -28,6 +28,7 @@ Bullet list below, e.g.
 
    - Altered a javascript filename that mod_security tended to object to.
    - Fixed a bug where input data were assumed to be URL encoded, causing certain character sequences to be stripped when cleaned.
+   - Fixed a bug ([#416](https://github.com/ExpressionEngine/ExpressionEngine/issues/416)) PHP error was thrown in some cases during check for available updates.
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/EllisLab/ExpressionEngine/Controller/Settings/General.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Settings/General.php
@@ -271,10 +271,9 @@ class General extends Settings {
 		else
 		{
 			$version_info = ee()->el_pings->getUpgradeInfo();
-			$latest_version = $version_info['version'];
 
 			// New version available
-			if (version_compare(ee()->config->item('app_version'), $latest_version, '<'))
+			if (!empty($version_info) && version_compare(ee()->config->item('app_version'), $version_info['version'], '<'))
 			{
 				if (AJAX_REQUEST)
 				{
@@ -287,7 +286,7 @@ class General extends Settings {
 				$upgrade_url = ee('CP/URL', 'updater')->compile();
 				$instruct_url = ee()->cp->masked_url(DOC_URL.'installation/update.html');
 
-				$desc = sprintf(lang('version_update_inst'), $latest_version, $upgrade_url, $instruct_url);
+				$desc = sprintf(lang('version_update_inst'), $version_info['version'], $upgrade_url, $instruct_url);
 
 				ee('CP/Alert')->makeBanner('version-update-available')
 					->asWarning()


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fixed a bug where PHP error was thrown in some cases during check for available updates.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#416](https://github.com/ExpressionEngine/ExpressionEngine/issues/416).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
