### PR TITLE
Removing commands for 5.4

### DIFF
--- a/system/ee/EllisLab/ExpressionEngine/Cli/Cli.php
+++ b/system/ee/EllisLab/ExpressionEngine/Cli/Cli.php
@@ -47,10 +47,12 @@ class Cli
     public $internalCommands = [
         'hello'           => Commands\CommandHelloWorld::class,
         'list'            => Commands\CommandListCommands::class,
-        'update'          => Commands\CommandUpdate::class,
-        'prepare-upgrade' => Commands\CommandPrepareUpgrade::class,
-        'run-update-hook' => Commands\CommandRunUpdateHook::class,
         'cache:clear'     => Commands\CommandClearCaches::class,
+        // These commands are removed from 5.4 and working in 6.0. 
+        // Don't use these.
+        // 'update'          => Commands\CommandUpdate::class,
+        // 'prepare-upgrade' => Commands\CommandPrepareUpgrade::class,
+        // 'run-update-hook' => Commands\CommandRunUpdateHook::class,
     ];
 
     /**


### PR DESCRIPTION
## Overview

Removes commands for 6.0 for inclusion in 5.4

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [X] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No