### PR TITLE
IMPORTANT Update to ft.fluid_field.php

### DIFF
--- a/system/ee/EllisLab/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/EllisLab/Addons/fluid_field/ft.fluid_field.php
@@ -250,8 +250,6 @@ class Fluid_field_ft extends EE_Fieldtype {
 
 		$values['field_id_' . $field->getId()] = $field->getData();
 
-		$field->postSave();
-
 		$format = $field->getFormat();
 
 		if ( ! is_null($format))
@@ -307,6 +305,8 @@ class Fluid_field_ft extends EE_Fieldtype {
 
 		$fluid_field->field_data_id = $id;
 		$fluid_field->save();
+
+		$fluid_field->getField()->postSave();
 	}
 
 	private function removeField($fluid_field)


### PR DESCRIPTION
Currently, postSave() is called before the field_data_id is updated. I have moved this method call until after the fluid_field_data table is appropriately updated.

**Background**
I am making a custom field type. Instead of making/maintaining my own database tables, I have chosen to utilize the install() method. This allows me to add new columns to the standard 'channel_data_field_[field_id]' table.

**Problem**
The method post_save($data) in my custom field type class needs to make such changes to the new table columns. In order for this to happen, I need to know the field_data_id from the fluid_field_data table which corresponds to the $this->settings['fluid_field_data_id']. 

Currently, when the post_save($data) method is called, this value is '0'.

**Solution**
I moved the postSave() call to the field on the Facade until after the fluid_field_data table has been updated accordingly. This is how it should be.