### PR TITLE
Fluid Field Post-Save Bug Fix

### DIFF
--- a/system/ee/EllisLab/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/EllisLab/Addons/fluid_field/ft.fluid_field.php
@@ -250,8 +250,6 @@ class Fluid_field_ft extends EE_Fieldtype {
 
 		$values['field_id_' . $field->getId()] = $field->getData();
 
-		$field->postSave();
-
 		$format = $field->getFormat();
 
 		if ( ! is_null($format))
@@ -280,6 +278,8 @@ class Fluid_field_ft extends EE_Fieldtype {
 		$query->set($values);
 		$query->where('id', $fluid_field->field_data_id);
 		$query->update($fluid_field->ChannelField->getTableName());
+
+		$fluid_field->getField()->postSave();
 	}
 
 	private function addField($order, $field_id, array $values)
@@ -307,6 +307,8 @@ class Fluid_field_ft extends EE_Fieldtype {
 
 		$fluid_field->field_data_id = $id;
 		$fluid_field->save();
+
+		$fluid_field->getField()->postSave();
 	}
 
 	private function removeField($fluid_field)

--- a/system/ee/legacy/controllers/cp/login.php
+++ b/system/ee/legacy/controllers/cp/login.php
@@ -210,6 +210,16 @@ class Login extends CP_Controller {
 		}
 
 		$incoming->start_session(TRUE);
+		
+		
+		/* -------------------------------------------
+		/* 'cp_member_login_success' hook.
+		 */
+		ee()->extensions->call('cp_member_login_success', $member_id);
+		/*
+	    /* -------------------------------------------*/
+		
+		
 
 		// Redirect the user to the CP home page
 		// ----------------------------------------------------------------


### PR DESCRIPTION
## Overview

Currently, the [`fluid_field`](https://docs.expressionengine.com/latest/fieldtypes/fluid.html#fluid-fieldtype) field type calls the [`EE_Fieldtype::post_save($data)`](https://docs.expressionengine.com/latest/development/fieldtypes.html#ee_fieldtypepost_savedata) method before the `field_data_id` value on the `fluid_field_data` table is updated.

**Background**: I am making a custom field type. Using the [`EE_Fieldtype::settings_modify_column($data)`](https://docs.expressionengine.com/latest/development/fieldtypes.html#ee_fieldtypesettings_modify_columndata) method, I have added some additional columns to the standard `channel_data_field_[field_id]` database table. To make updates to these new table columns, I need the `field_data_id` which corresponds to [`$this->settings['fluid_field_data_id']`](https://docs.expressionengine.com/latest/development/fieldtypes.html#grid-fieldtype-settings-class-property). Currently, when [`post_save($data)`](https://docs.expressionengine.com/latest/development/fieldtypes.html#ee_fieldtypepost_savedata) is called from the ft.fluid_field.php class, the `field_data_id` value in the `fluid_field_data` table is 0.

**Solution**: Call `postSave()` after the `fluid_field_data` db table has been appropriately updated with the corresponding `field_data_id`.

**PS**
I think `$fluid_field->getField()->postSave()` is appropriate to use. Someone may want to double check this.


## Nature of This Change

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security

## Is this backwards compatible?

- [ ] Yes
- [ ] No
- [x] I don't know, but probably...