### PR TITLE
Added missing fields from model retrieval (used by getAllCustomFields)

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -7,7 +7,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 Bullet list below, e.g.
 - Added <new feature>
 - Fixed the consent form's return behavior.
-
+- Fixed "Select Dropdown" "Populate the menu from another channel field" not showing any field options.
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/legacy/fieldtypes/EE_Fieldtype.php
+++ b/system/ee/legacy/fieldtypes/EE_Fieldtype.php
@@ -1089,7 +1089,7 @@ abstract class EE_Fieldtype {
 
 		$channels = ee('Model')->get('Channel as C')
 			->with('CustomFields as CF')
-			->fields('C.channel_title', 'C.channel_id', 'CF.field_id', 'CF.field_label')
+			->fields('C.channel_title', 'C.channel_id', 'CF.field_id', 'CF.field_label', 'CF.field_name', 'CF.field_type')
 			->filter('site_id', ee()->config->item('site_id'))
 			->order('channel_title', 'asc')
 			->all();


### PR DESCRIPTION
## Overview

Fixes an issue with the Channel Field "Select Dropdown" option to "Populate the menu from another channel field". The `->fields()` call on the model retrieval was missing the `CF.field_name` (used by the later `$channel->getAllCustomFields()` and `CF.field_type` (used to check compatibility) fields causing no options to show up for this setting.

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security

## Is this backwards compatible?

- [X] Yes
- [ ] No