### PR TITLE
Changing a custom field type now resets the field settings.

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -8,6 +8,7 @@ Bullet list below, e.g.
 - Added <new feature>
 - Fixed the consent form's return behavior.
 - Fixed "Select Dropdown" "Populate the menu from another channel field" not showing any field options.
+- Changing a custom field type now resets the field settings.  Having the wrong settings for a field was causing display issues for some addons.
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelField.php
+++ b/system/ee/EllisLab/ExpressionEngine/Model/Channel/ChannelField.php
@@ -139,8 +139,17 @@ class ChannelField extends FieldModel {
 	{
 		parent::set($data);
 
-		$field = $this->getField($this->getSettingsValues());
-		$this->setProperty('field_settings', $field->saveSettingsForm($data));
+		$old_field_type = $this->getBackup('field_type');
+
+		if ( ! empty($old_field_type) && $old_field_type != $this->getFieldType())
+		{
+			$this->setProperty('field_settings', array());
+		}
+		else
+		{
+			$field = $this->getField($this->getSettingsValues());
+			$this->setProperty('field_settings', $field->saveSettingsForm($data));
+		}
 
 		return $this;
 	}


### PR DESCRIPTION
Before, it just left the settings, which really shouldn’t have mattered.  But it was causing Asset fields to continue to display as Asset fields on publish, even after changing to File fields.  The setting fields also didn’t display on the file field’d edit page. Fixes https://github.com/ExpressionEngine/ExpressionEngine/issues/618

Cleaning them out on save just makes sense.



- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
