### PR TITLE
Fix bug where the color picker fields would not init in the grid field settings page

### DIFF
--- a/themes/ee/cp/js/build/components/colorpicker.js
+++ b/themes/ee/cp/js/build/components/colorpicker.js
@@ -249,6 +249,9 @@ $(document).ready(function () {
         ColorPicker.renderFields();
     });
 });
+Grid.bind('colorpicker', 'displaySettings', function (el) {
+    ColorPicker.renderFields(el[0]);
+});
 Grid.bind('colorpicker', 'display', function (cell) {
     ColorPicker.renderFields(cell[0]);
 });

--- a/themes/ee/cp/js/src/components/colorpicker.tsx
+++ b/themes/ee/cp/js/src/components/colorpicker.tsx
@@ -349,6 +349,10 @@ $(document).ready(function () {
     })
 })
 
+Grid.bind('colorpicker', 'displaySettings', (el) => {
+    ColorPicker.renderFields(el[0])
+})
+
 Grid.bind('colorpicker', 'display', function(cell) {
     ColorPicker.renderFields(cell[0])
 });


### PR DESCRIPTION
This fixes the bug where when you create a new grid field, then add a color picker fieldtype column, the color picker settings fields would not initialize their color picker. 

Fixes #714