### PR TITLE
Fix HTTP Auth not recognizing super admin

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -15,6 +15,7 @@ Bullet list below, e.g.
    - Fixed an 'Invalid parameter count' error message, switching in a more friendly permission message on the publish edit page.
    - Fixed a bug ([#687](https://github.com/ExpressionEngine/ExpressionEngine/issues/687) where no valid channels were available in the channel field on the publish page.
    - Fixed several missing language variables in the control panel.
+   - Fixed template HTTP Authentication not recognizing Super Admin.
    - Added CLI command file
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/legacy/libraries/Auth.php
+++ b/system/ee/legacy/libraries/Auth.php
@@ -129,7 +129,7 @@ class Auth {
 			foreach ($member->getAllRoles()->pluck('role_id') as $role_id)
 			{
 				// If they have even a single Role that is allowed, then they are allowed
-				if ( ! in_array($role_id, $not_allowed_groups))
+				if ( ! in_array($role_id, $not_allowed_groups) OR $role_id == 1)
 				{
 					$authed = TRUE;
 					break;


### PR DESCRIPTION
Super admin credentials weren't accepted by template HTTP Auth.