### PR TITLE
Remove visibility from const for php 5.6 compatibility

### DIFF
--- a/system/ee/ExpressionEngine/Addons/filepicker/Service/FilePicker/FilePicker.php
+++ b/system/ee/ExpressionEngine/Addons/filepicker/Service/FilePicker/FilePicker.php
@@ -18,7 +18,7 @@ use ExpressionEngine\Model\File\File;
  */
 class FilePicker
 {
-    public const CONTROLLER = 'addons/settings/filepicker/modal';
+    const CONTROLLER = 'addons/settings/filepicker/modal';
 
     protected $url;
     protected $active;

--- a/system/ee/ExpressionEngine/Cli/Status.php
+++ b/system/ee/ExpressionEngine/Cli/Status.php
@@ -22,56 +22,56 @@ class Status
     /**
      * Success
      */
-    public const SUCCESS = 0;
+    const SUCCESS = 0;
 
     /**
      * Failure
      */
-    public const FAILURE = 1;
+    const FAILURE = 1;
 
     /**
      * The command was used incorrectly, e.g., with the wrong number of
      * arguments, a bad flag, a bad syntax in a parameter, or whatever.
      */
-    public const USAGE = 64;
+    const USAGE = 64;
 
     /**
      * The input data was incorrect in some way. This should only be used for
      * user’s data and not system files.
      */
-    public const DATAERR = 65;
+    const DATAERR = 65;
 
     /**
      * An input file (not a system file) did not exist or was not readable.
      * This could also include errors like "No message" to a mailer (if it
      * cared to catch it).
      */
-    public const NOINPUT = 66;
+    const NOINPUT = 66;
 
     /**
      * The user specified did not exist. This might be used for mail addresses
      * or remote logins.
      */
-    public const NOUSER = 67;
+    const NOUSER = 67;
 
     /**
      * The host specified did not exist. This is used in mail addresses or
      * network requests.
      */
-    public const NOHOST = 68;
+    const NOHOST = 68;
 
     /**
      * A service is unavailable. This can occur if a support program or file
      * does not exist. This can also be used as a catchall message when
      * something you wanted to do does not work, but you do not know why.
      */
-    public const UNAVAILABLE = 69;
+    const UNAVAILABLE = 69;
 
     /**
      * An internal software error has been detected. This should be limited
      * to non-operating system related errors as possible.
      */
-    public const SOFTWARE = 70;
+    const SOFTWARE = 70;
 
     /**
      * An operating system error has been detected. This is intended to be
@@ -79,47 +79,47 @@ class Status
      * like. It includes things like getuid returning a user that does not
      * exist in the passwd file.
      */
-    public const OSERR = 71;
+    const OSERR = 71;
 
     /**
      * Some system file (e.g., /etc/passwd, /var/run/utmp, etc.) does not
      * exist, cannot be opened, or has some sort of error (e.g., syntax
      * error).
      */
-    public const OSFILE = 72;
+    const OSFILE = 72;
 
     /**
      * A (user specified) output file cannot be created.
      */
-    public const CANTCREAT = 73;
+    const CANTCREAT = 73;
 
     /**
      * An error occurred while doing I/O on some file.
      */
-    public const IOERR = 74;
+    const IOERR = 74;
 
     /**
      * Temporary failure, indicating something that is not really an error.
      * In sendmail, this means that a mailer (e.g.) could not create a
      * connection, and the request should be reattempted later.
      */
-    public const TEMPFAIL = 75;
+    const TEMPFAIL = 75;
 
     /**
      * The remote system returned something that was "not possible" during a
      * protocol exchange.
      */
-    public const PROTOCOL = 76;
+    const PROTOCOL = 76;
 
     /**
      * You did not have sufficient permission to perform the operation. This
      * is not intended for file system problems, which should use NOINPUT
      * or CANTCREAT, but rather for higher level permissions.
      */
-    public const NOPERM = 77;
+    const NOPERM = 77;
 
     /**
      * Something was found in an unconfigured or misconfigured state.
      */
-    public const CONFIG = 78;
+    const CONFIG = 78;
 }

--- a/system/ee/ExpressionEngine/Controller/Utilities/ExportEmailAddresses.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/ExportEmailAddresses.php
@@ -15,8 +15,8 @@ namespace ExpressionEngine\Controller\Utilities;
  */
 class ExportEmailAddresses extends Utilities
 {
-    public const CACHE_TTL = 300; // 5 mins
-    public const PREFIX = 'exprt';
+    const CACHE_TTL = 300; // 5 mins
+    const PREFIX = 'exprt';
 
     protected $batch_size = 10;
     protected $validated_batch_size = 5;

--- a/system/ee/ExpressionEngine/Controller/Utilities/Reindex.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/Reindex.php
@@ -16,7 +16,7 @@ use ExpressionEngine\Service\Model\Collection;
  */
 class Reindex extends Utilities
 {
-    public const CACHE_KEY = '/search/reindex';
+    const CACHE_KEY = '/search/reindex';
 
     protected $field_ids = [];
     protected $entry_ids = [];

--- a/system/ee/ExpressionEngine/Library/CP/Table.php
+++ b/system/ee/ExpressionEngine/Library/CP/Table.php
@@ -15,13 +15,13 @@ namespace ExpressionEngine\Library\CP;
  */
 class Table
 {
-    public const COL_TEXT = 1;
-    public const COL_CHECKBOX = 2;
-    public const COL_STATUS = 3;
-    public const COL_TOOLBAR = 4;
-    public const COL_ID = 5;
-    public const COL_SMALL = 6;
-    public const COL_INFO = 7;
+    const COL_TEXT = 1;
+    const COL_CHECKBOX = 2;
+    const COL_STATUS = 3;
+    const COL_TOOLBAR = 4;
+    const COL_ID = 5;
+    const COL_SMALL = 6;
+    const COL_INFO = 7;
 
     public $config = array();
     protected $columns = array();

--- a/system/ee/ExpressionEngine/Library/Parser/Conditional/BooleanExpression.php
+++ b/system/ee/ExpressionEngine/Library/Parser/Conditional/BooleanExpression.php
@@ -17,9 +17,9 @@ use ExpressionEngine\Library\Parser\Conditional\Exception\BooleanExpressionExcep
  */
 class BooleanExpression
 {
-    public const NON_ASSOC = 0;
-    public const LEFT_ASSOC = 1;
-    public const RIGHT_ASSOC = 2;
+    const NON_ASSOC = 0;
+    const LEFT_ASSOC = 1;
+    const RIGHT_ASSOC = 2;
 
     private $tokens;
     private $unary_operators;

--- a/system/ee/ExpressionEngine/Library/Parser/Conditional/Lexer.php
+++ b/system/ee/ExpressionEngine/Library/Parser/Conditional/Lexer.php
@@ -65,7 +65,7 @@ class Lexer extends AbstractLexer
      */
     private $tag_depth = 0;
 
-    public const COMMENT_PATTERN = "
+    const COMMENT_PATTERN = "
 		\{!--		# open tag
 		(.*?)		# anything inbetween
 		--\}		# closing tag
@@ -74,7 +74,7 @@ class Lexer extends AbstractLexer
     /**
      * Regex for boolean values
      */
-    public const BOOL_PATTERN = "
+    const BOOL_PATTERN = "
 		\b					# must be its own word
 		(true|false)		# The pattern is case insensitive
 		(?!(-+)?\w)			# simulate \b with -
@@ -83,7 +83,7 @@ class Lexer extends AbstractLexer
     /**
      * Regex for variables
      */
-    public const VARIABLE_PATTERN = "
+    const VARIABLE_PATTERN = "
 		\w*(								# word characters on both ends are ok
 			[a-zA-Z]([\w:-]+\w)?			# we need at least one alpha in there
 			|								# to avoid things like 5-5, and it can't
@@ -94,7 +94,7 @@ class Lexer extends AbstractLexer
     /**
      * Regex for numbers
      */
-    public const NUMBER_PATTERN = "
+    const NUMBER_PATTERN = "
 		(
 			[0-9]*\.[0-9]+					# You must have a number either
 			|								# before or after the dot. The other

--- a/system/ee/ExpressionEngine/Model/Session/Session.php
+++ b/system/ee/ExpressionEngine/Model/Session/Session.php
@@ -45,7 +45,7 @@ class Session extends Model
     /**
      * Manage sudo-like timeout for "trust but verify" actions
      */
-    public const AUTH_TIMEOUT = '+15 minutes';
+    const AUTH_TIMEOUT = '+15 minutes';
     public function resetAuthTimeout()
     {
         $this->setProperty('auth_timeout', ee()->localize->string_to_timestamp(self::AUTH_TIMEOUT));

--- a/system/ee/ExpressionEngine/Service/Consent/Consent.php
+++ b/system/ee/ExpressionEngine/Service/Consent/Consent.php
@@ -21,7 +21,7 @@ use InvalidArgumentException;
  */
 class Consent
 {
-    public const COOKIE_NAME = 'visitor_consents';
+    const COOKIE_NAME = 'visitor_consents';
 
     /**
      * @var array Cookie data, for visitors

--- a/system/ee/ExpressionEngine/Service/Consent/CookieRegistry.php
+++ b/system/ee/ExpressionEngine/Service/Consent/CookieRegistry.php
@@ -18,22 +18,22 @@ class CookieRegistry
     /**
      * @var int Value to indicate Necessary cookies
      */
-    public const NECESSARY = 0;
+    const NECESSARY = 0;
 
     /**
      * @var int Value to indicate Functionality cookies
      */
-    public const FUNCTIONALITY = 1;
+    const FUNCTIONALITY = 1;
 
     /**
      * @var int Value to indicate Performance cookies
      */
-    public const PERFORMANCE = 2;
+    const PERFORMANCE = 2;
 
     /**
      * @var int Value to indicate Targeting cookies
      */
-    public const TARGETING = 4;
+    const TARGETING = 4;
 
     /**
      * @var array Registered cookies

--- a/system/ee/ExpressionEngine/Service/Database/Backup/Query.php
+++ b/system/ee/ExpressionEngine/Service/Database/Backup/Query.php
@@ -17,9 +17,9 @@ namespace ExpressionEngine\Service\Database\Backup;
  */
 class Query
 {
-    public const BINARY_TYPE = 1;
-    public const STRING_TYPE = 2;
-    public const NUMBER_TYPE = 3;
+    const BINARY_TYPE = 1;
+    const STRING_TYPE = 2;
+    const NUMBER_TYPE = 3;
 
     /**
      * @var Database\Query Database Query object

--- a/system/ee/ExpressionEngine/Service/Dependency/InjectionContainer.php
+++ b/system/ee/ExpressionEngine/Service/Dependency/InjectionContainer.php
@@ -24,7 +24,7 @@ class InjectionContainer implements ServiceProvider
     /**
      * @var string Native prefix
      */
-    public const NATIVE_PREFIX = 'ee:';
+    const NATIVE_PREFIX = 'ee:';
 
     /**
      * @var array An associative array of registered dependencies

--- a/system/ee/ExpressionEngine/Service/Model/Query/Delete.php
+++ b/system/ee/ExpressionEngine/Service/Model/Query/Delete.php
@@ -17,7 +17,7 @@ use ExpressionEngine\Service\Model\Relation\BelongsTo;
  */
 class Delete extends Query
 {
-    public const DELETE_BATCH_SIZE = 100;
+    const DELETE_BATCH_SIZE = 100;
 
     public function run()
     {

--- a/system/ee/ExpressionEngine/Service/Validation/ValidationRule.php
+++ b/system/ee/ExpressionEngine/Service/Validation/ValidationRule.php
@@ -27,8 +27,8 @@ namespace ExpressionEngine\Service\Validation;
  */
 abstract class ValidationRule
 {
-    public const STOP = 'STOP';
-    public const SKIP = 'SKIP';
+    const STOP = 'STOP';
+    const SKIP = 'SKIP';
 
     /**
      * @var array Rule parameters

--- a/system/ee/Mexitek/PHPColors/Color.php
+++ b/system/ee/Mexitek/PHPColors/Color.php
@@ -35,7 +35,7 @@ class Color
      * Set this to FALSE to adjust automatic shade to be between given color
      * and black (for darken) or white (for lighten)
      */
-    public const DEFAULT_ADJUST = 10;
+    const DEFAULT_ADJUST = 10;
 
     /**
      * Instantiates the class with a HEX value

--- a/system/ee/legacy/core/Security.php
+++ b/system/ee/legacy/core/Security.php
@@ -25,8 +25,8 @@ interface Strict_XID
 class EE_Security
 {
     // Flags for have_valid_xid()
-    public const CSRF_STRICT = 1;	// require single-use token for ajax requests
-    public const CSRF_EXEMPT = 2;	// opt-out of xid checks
+    const CSRF_STRICT = 1;	// require single-use token for ajax requests
+    const CSRF_EXEMPT = 2;	// opt-out of xid checks
 
     /**
      * XSS Clean

--- a/system/ee/legacy/libraries/Auth.php
+++ b/system/ee/legacy/libraries/Auth.php
@@ -59,7 +59,7 @@ class Auth
         32 => 'md5'
     );
 
-    public const BCRYPT_HASH_LENGTH = 60;
+    const BCRYPT_HASH_LENGTH = 60;
 
     /**
      * Constructor

--- a/system/ee/legacy/libraries/Cache/Cache.php
+++ b/system/ee/legacy/libraries/Cache/Cache.php
@@ -19,11 +19,11 @@ class Cache extends EE_Driver_Library
      * current site, or it should be globally accessible by the EE
      * installation across MSM sites
      */
-    public const GLOBAL_SCOPE = 1;	// Scoped to the current site
-    public const LOCAL_SCOPE = 2;	// Scoped to global EE install
+    const GLOBAL_SCOPE = 1;	// Scoped to the current site
+    const LOCAL_SCOPE = 2;	// Scoped to global EE install
 
     // separator character used to separate nested namespace names
-    public const NAMESPACE_SEPARATOR = '/';
+    const NAMESPACE_SEPARATOR = '/';
 
     /**
      * Valid cache drivers

--- a/system/ee/legacy/libraries/Csrf.php
+++ b/system/ee/legacy/libraries/Csrf.php
@@ -20,7 +20,7 @@ class Csrf
     private $request_token;
     private $session_token;
 
-    public const TOKEN_LENGTH = 40; // the token is always the sha1 of a random string
+    const TOKEN_LENGTH = 40; // the token is always the sha1 of a random string
 
     public function __construct()
     {

--- a/system/ee/legacy/libraries/Typography.php
+++ b/system/ee/legacy/libraries/Typography.php
@@ -75,8 +75,8 @@ class EE_Typography
     private $quote_marker = null;
 
     // tag bracket constants for use in Safe HTML / BBcode parsing
-    public const HTML_BRACKETS = 1;
-    public const BBCODE_BRACKETS = 2;
+    const HTML_BRACKETS = 1;
+    const BBCODE_BRACKETS = 2;
 
     /**
      * Constructor

--- a/system/ee/legacy/libraries/csrf/Cookie.php
+++ b/system/ee/legacy/libraries/csrf/Cookie.php
@@ -20,7 +20,7 @@
  */
 class Csrf_cookie implements Csrf_storage_backend
 {
-    public const COOKIE_NAME = 'csrf_token';
+    const COOKIE_NAME = 'csrf_token';
 
     /**
      * Get the expiration value

--- a/system/ee/legacy/libraries/csrf/Database.php
+++ b/system/ee/legacy/libraries/csrf/Database.php
@@ -18,7 +18,7 @@
  */
 class Csrf_database implements Csrf_storage_backend
 {
-    public const GC_PROBABILITY = 5;
+    const GC_PROBABILITY = 5;
 
     public function get_expiration()
     {

--- a/system/ee/legacy/libraries/simplepie/SimplePie/Cache/Base.php
+++ b/system/ee/legacy/libraries/simplepie/SimplePie/Cache/Base.php
@@ -57,14 +57,14 @@ interface SimplePie_Cache_Base
      *
      * @var string
      */
-    public const TYPE_FEED = 'spc';
+    const TYPE_FEED = 'spc';
 
     /**
      * Image cache type
      *
      * @var string
      */
-    public const TYPE_IMAGE = 'spi';
+    const TYPE_IMAGE = 'spi';
 
     /**
      * Create a new cache object

--- a/system/ee/legacy/libraries/typography/Markdown/Michelf/Markdown.php
+++ b/system/ee/legacy/libraries/typography/Markdown/Michelf/Markdown.php
@@ -22,7 +22,7 @@ class Markdown implements MarkdownInterface
 {
     ### Version ###
 
-    public const  MARKDOWNLIB_VERSION = "1.6.0";
+    const  MARKDOWNLIB_VERSION = "1.6.0";
 
     ### Simple Function Interface ###
 
@@ -291,7 +291,7 @@ class Markdown implements MarkdownInterface
 			  |
 				\'[^\']*\'	# text inside single quotes (tolerate ">")
 			  )*
-			)?	
+			)?
 			';
         $content =
             str_repeat('
@@ -309,7 +309,7 @@ class Markdown implements MarkdownInterface
                 '
 					  </\2\s*>	# closing nested tag
 					)
-				  |				
+				  |
 					<(?!/\2\s*>	# other tags with a different name
 				  )
 				)*',
@@ -337,9 +337,9 @@ class Markdown implements MarkdownInterface
 			)
 			(						# save in $1
 
-			  # Match from `\n<tag>` to `</tag>\n`, handling nested tags 
+			  # Match from `\n<tag>` to `</tag>\n`, handling nested tags
 			  # in between.
-					
+
 						[ ]{0,' . $less_than_tab . '}
 						<(' . $block_tags_b_re . ')# start tag = $2
 						' . $attr . '>			# attributes followed by > and \n
@@ -357,28 +357,28 @@ class Markdown implements MarkdownInterface
 						</\3>				# the matching end tag
 						[ ]*				# trailing spaces/tabs
 						(?=\n+|\Z)	# followed by a newline or end of document
-					
-			| # Special case just for <hr />. It was easier to make a special 
+
+			| # Special case just for <hr />. It was easier to make a special
 			  # case than to make the other regex more complicated.
-			
+
 						[ ]{0,' . $less_than_tab . '}
 						<(hr)				# start tag = $2
 						' . $attr . '			# attributes
 						/?>					# the matching end tag
 						[ ]*
 						(?=\n{2,}|\Z)		# followed by a blank line or end of document
-			
+
 			| # Special case for standalone HTML comments:
-			
+
 					[ ]{0,' . $less_than_tab . '}
 					(?s:
 						<!-- .*? -->
 					)
 					[ ]*
 					(?=\n{2,}|\Z)		# followed by a blank line or end of document
-			
+
 			| # PHP and ASP-style processor instructions (<? and <%)
-			
+
 					[ ]{0,' . $less_than_tab . '}
 					(?s:
 						<([?%])			# $2
@@ -387,7 +387,7 @@ class Markdown implements MarkdownInterface
 					)
 					[ ]*
 					(?=\n{2,}|\Z)		# followed by a blank line or end of document
-					
+
 			)
 			)}Sxmi',
             array($this, '_hashHTMLBlocks_callback'),

--- a/system/ee/legacy/models/file_category_model.php
+++ b/system/ee/legacy/models/file_category_model.php
@@ -13,7 +13,7 @@
  */
 class File_category_model extends CI_Model
 {
-    public const TABLE_NAME = 'file_categories';
+    const TABLE_NAME = 'file_categories';
 
     /**
      * Set the file category

--- a/system/ee/legacy/models/relationship_model.php
+++ b/system/ee/legacy/models/relationship_model.php
@@ -13,10 +13,10 @@
  */
 class Relationship_model extends CI_Model
 {
-    public const CHILD = 1;
-    public const PARENT = 2;
-    public const SIBLING = 3;
-    public const GRID = 4;
+    const CHILD = 1;
+    const PARENT = 2;
+    const SIBLING = 3;
+    const GRID = 4;
 
     protected $_table = 'relationships';
 


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Declaring a visibility for const is part of the PSR-12 spec, but not supported by PHP 5.6. This removes the visibility to maintain support for PHP 5.6.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
