### PR TITLE
fix system not saving online/offline preference 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           repository: ExpressionEngine/ExpressionEngine-User-Guide
           token: ${{ secrets.ORG_ACCESS_TOKEN }}
           path: ExpressionEngine-User-Guide
+          ref: 6.x
 
       - name: Setup asdf
         uses: asdf-vm/actions/setup@v1

--- a/system/ee/ExpressionEngine/Controller/Settings/Config.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Config.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2020, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Controller\Settings;
+
+use CP_Controller;
+
+/**
+ * This is hidden controller that lets SuperAdmins save any config value to the config file
+ */
+class Config extends Settings
+{
+
+    public function index()
+    {
+        if (! ee('Permission')->isSuperAdmin()) {
+            show_error(lang('unauthorized_access'));
+        }
+
+        $fields = [];
+        foreach (ee()->config->divineAll() as $key) {
+            if (ee()->input->post($key) != '') {
+                $fields[$key] = ee()->input->post($key);
+            }
+        }
+        
+        $config_update = ee()->config->update_site_prefs($fields);
+
+        if (!empty($config_update)) {
+            ee()->load->helper('html_helper');
+            ee()->view->set_message('issue', lang('cp_message_issue'), ul($config_update), true);
+
+            ee()->view->set_message('issue', lang('settings_save_error'), lang('settings_save_error_desc'));
+        } else {
+            ee()->view->set_message('success', lang('preferences_updated'), lang('preferences_updated_desc'), true);
+        }
+
+        ee()->functions->redirect(ee('CP/URL')->make('settings'));
+    }
+}
+// END CLASS
+
+// EOF

--- a/system/ee/ExpressionEngine/Service/Updater/Runner.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Runner.php
@@ -139,7 +139,7 @@ class Runner
     private function turnSystemOff()
     {
         $config = ee('Config')->getFile();
-        $config->set('is_system_on_before_updater', $config->get('is_system_on', 'y'));
+        $config->set('is_system_on_before_updater', $config->get('is_system_on', 'y'), true);
         $config->set('is_system_on', 'n', true);
     }
 }

--- a/system/ee/installer/files/ee5/EllisLab/ExpressionEngine/Boot/boot.php
+++ b/system/ee/installer/files/ee5/EllisLab/ExpressionEngine/Boot/boot.php
@@ -4,4 +4,12 @@ if (!defined('EESELF') && defined('SELF')) {
     define('EESELF', SELF);
 }
 
+// Check to see if we have write access to the file.
+if (!empty($_SERVER['SCRIPT_FILENAME']) && is_file(realpath($_SERVER['SCRIPT_FILENAME'])) && is_writable(realpath($_SERVER['SCRIPT_FILENAME']))) {
+    $contents = file_get_contents(realpath($_SERVER['SCRIPT_FILENAME']));
+    $contents = str_replace('ee/EllisLab/ExpressionEngine/Boot/boot.php', 'ee/ExpressionEngine/Boot/boot.php', $contents);
+    file_put_contents(realpath($_SERVER['SCRIPT_FILENAME']), $contents);
+    header("Refresh:1");
+}
+
 require_once SYSPATH . '/ee/ExpressionEngine/Boot/boot.php';

--- a/system/ee/installer/files/ee5/EllisLab/ExpressionEngine/Boot/boot.php
+++ b/system/ee/installer/files/ee5/EllisLab/ExpressionEngine/Boot/boot.php
@@ -7,9 +7,14 @@ if (!defined('EESELF') && defined('SELF')) {
 // Check to see if we have write access to the file.
 if (!empty($_SERVER['SCRIPT_FILENAME']) && is_file(realpath($_SERVER['SCRIPT_FILENAME'])) && is_writable(realpath($_SERVER['SCRIPT_FILENAME']))) {
     $contents = file_get_contents(realpath($_SERVER['SCRIPT_FILENAME']));
-    $contents = str_replace('ee/EllisLab/ExpressionEngine/Boot/boot.php', 'ee/ExpressionEngine/Boot/boot.php', $contents);
-    file_put_contents(realpath($_SERVER['SCRIPT_FILENAME']), $contents);
-    header("Refresh:1");
+    if ($contents !== false) {
+        $contents = str_replace('ee/EllisLab/ExpressionEngine/Boot/boot.php', 'ee/ExpressionEngine/Boot/boot.php', $contents);
+        $fileWritten = file_put_contents(realpath($_SERVER['SCRIPT_FILENAME']), $contents);
+    }
+}
+
+if (!isset($fileWritten) || $fileWritten === false) {
+    define('ELLISLAB_STILL_HERE', true);
 }
 
 require_once SYSPATH . '/ee/ExpressionEngine/Boot/boot.php';

--- a/system/ee/installer/schema/mysql_schema.php
+++ b/system/ee/installer/schema/mysql_schema.php
@@ -789,6 +789,7 @@ class EE_Schema
 			cat_order int(4) unsigned NOT NULL,
 			PRIMARY KEY `cat_id` (`cat_id`),
 			KEY `group_id` (`group_id`),
+			KEY `parent_id` (`parent_id`),
 			KEY `cat_name` (`cat_name`),
 			KEY `site_id` (`site_id`)
 		)";

--- a/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/Runner.php
+++ b/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/Runner.php
@@ -208,13 +208,8 @@ class Runner
      */
     public function selfDestruct($rollback = null)
     {
-        $is_system_on_before_updater = 'y';
-        $checkConfigQuery = ee('db')->select('value')->from('config')->where('key', 'is_system_on')->order_by('site_id', 'asc')->get();
-        if ($checkConfigQuery->num_rows() > 0) {
-            $is_system_on_before_updater = $checkConfigQuery->row('value');
-        }
         $config = ee('Config')->getFile();
-        $config->set('is_system_on', $config->get('is_system_on_before_updater', $is_system_on_before_updater), true);
+        $config->set('is_system_on', $config->get('is_system_on_before_updater', 'y'), true);
         $config->set('app_version', APP_VER, true);
 
         // Legacy logger lib to log to update_log table

--- a/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/Runner.php
+++ b/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/Runner.php
@@ -208,8 +208,13 @@ class Runner
      */
     public function selfDestruct($rollback = null)
     {
+        $is_system_on_before_updater = 'y';
+        $checkConfigQuery = ee('db')->select('value')->from('config')->where('key', 'is_system_on')->order_by('site_id', 'asc')->get();
+        if ($checkConfigQuery->num_rows() > 0) {
+            $is_system_on_before_updater = $checkConfigQuery->row('value');
+        }
         $config = ee('Config')->getFile();
-        $config->set('is_system_on', $config->get('is_system_on_before_updater', 'y'), true);
+        $config->set('is_system_on', $config->get('is_system_on_before_updater', $is_system_on_before_updater), true);
         $config->set('app_version', APP_VER, true);
 
         // Legacy logger lib to log to update_log table

--- a/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/Runner.php
+++ b/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/Runner.php
@@ -244,22 +244,35 @@ class Runner
         ee()->lang->loadfile('updater');
         ee()->load->library('session');
 
+        // show banner with system online info if we don't know the prev online state
+        // of if they update from latest 5.x - there's chance they did not notice the banner there
+        $showSystemOnlineBanner = $prevSystemOnlineStateUnknown || version_compare(ee()->config->item('app_version'), '5.4', '>=');
+
         if (empty($rollback)) {
             ee()->session->set_flashdata('update:completed', true);
-            ee()->session->set_flashdata('update:show_status_switch', $prevSystemOnlineStateUnknown);
+            ee()->session->set_flashdata('update:show_status_switch', $showSystemOnlineBanner);
         } else {
-            ee('CP/Alert')->makeBanner('warning_system_status')
-                ->asAttention()
-                ->canClose()
-                ->withTitle(lang('update_version_warning'))
-                ->addToBody(sprintf(
-                    lang('update_version_warning_desc'),
-                    (ee()->config->item('is_system_on') == 'y') ? lang('online') : lang('offline')
-                ))
-                ->defer();
+            if ($showSystemOnlineBanner) {
+                $update_version_warning = lang('update_version_warning');
+                $update_version_warning_desc = lang('update_version_warning_desc');
+                //in EE 5.4, these strings are not available
+                if ($update_version_warning == 'update_version_warning') {
+                    $update_version_warning = 'Please check system online status';
+                    $update_version_warning_desc = 'Your current system status is set to <b>%s</b>. If you need to change that, please visit System Settings.';
+                }
+                ee('CP/Alert')->makeBanner('warning_system_status')
+                    ->asAttention()
+                    ->canClose()
+                    ->withTitle($update_version_warning)
+                    ->addToBody(sprintf(
+                        $update_version_warning_desc,
+                        (ee()->config->item('is_system_on') == 'y') ? lang('online') : lang('offline')
+                    ))
+                    ->defer();
+            }
 
             ee('CP/Alert')->makeBanner('update-rolledback')
-                ->asInfo()
+                ->asTip()
                 ->withTitle(sprintf(lang('update_rolledback'), APP_VER))
                 ->addToBody(sprintf(
                     lang('update_rolledback_desc'),

--- a/system/ee/installer/updates/ud_6_00_00.php
+++ b/system/ee/installer/updates/ud_6_00_00.php
@@ -45,7 +45,7 @@ class Updater
     protected function addPostInstallMessageTemplate()
     {
         $sites = ee('Model')->get('Site')->all();
-        require_once SYSPATH . 'ee/language/' . ee()->config->item('deft_lang') ?: 'english' . '/email_data.php';
+        require_once SYSPATH . 'ee/language/' . (ee()->config->item('deft_lang') ?: 'english') . '/email_data.php';
 
         foreach ($sites as $site) {
             ee('Model')->make('SpecialtyTemplate')

--- a/system/ee/installer/updates/ud_6_00_00.php
+++ b/system/ee/installer/updates/ud_6_00_00.php
@@ -45,7 +45,7 @@ class Updater
     protected function addPostInstallMessageTemplate()
     {
         $sites = ee('Model')->get('Site')->all();
-        require_once SYSPATH . 'ee/language/' . ee()->config->item('language') . '/email_data.php';
+        require_once SYSPATH . 'ee/language/' . ee()->config->item('deft_lang') ?: 'english' . '/email_data.php';
 
         foreach ($sites as $site) {
             ee('Model')->make('SpecialtyTemplate')

--- a/system/ee/installer/updates/ud_6_00_02.php
+++ b/system/ee/installer/updates/ud_6_00_02.php
@@ -27,6 +27,7 @@ class Updater
     {
         $steps = new \ProgressIterator([
             'ensureSuperAdminLocked',
+            'addCategoryParentKey',
         ]);
 
         foreach ($steps as $k => $v) {
@@ -44,6 +45,11 @@ class Updater
                 'is_locked' => 'y'
             ]
         );
+    }
+
+    private function addCategoryParentKey()
+    {
+        ee()->smartforge->add_key('categories', 'parent_id');
     }
 
 }

--- a/system/ee/language/english/core_lang.php
+++ b/system/ee/language/english/core_lang.php
@@ -99,6 +99,12 @@ If you made these changes, please accept the modifications on the control panel 
 
     'checksum_email_subject' => 'A core file was modified on your site.',
 
+    'warning_system_status_title' => 'Please check system online status',
+
+    'warning_system_status_message' => 'Your current system status is set to <b>%s</b>. If you need to change that, please visit <a href="%s">System Settings</a> or press the button below.',
+
+    'warning_system_status_button' => 'Set System %s',
+
     'csrf_token_expired' => 'This form has expired. Please refresh and try again.',
 
     'current_password_incorrect' => 'Your current password was not submitted correctly.',

--- a/system/ee/language/english/cp_lang.php
+++ b/system/ee/language/english/cp_lang.php
@@ -65,6 +65,10 @@ $lang = array(
 
     'build' => 'Build:',
 
+    'offline' => 'Offline',
+
+    'online' => 'Online',
+
     'captcha_explanation' => 'A CAPTCHA is an image containing a security code that users have to submit. Please consult the user guide for more info.',
 
     'categories' => 'Categories',

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -82,10 +82,6 @@ $lang = array(
 
     'manual' => 'Manual',
 
-    'offline' => 'Offline',
-
-    'online' => 'Online',
-
     'show_ee_news' => 'Show ExpressionEngine news?',
 
     'show_ee_news_desc' => 'When enabled, the latest news about ExpressionEngine will appear on the control panel\'s homepage.',

--- a/system/ee/language/english/updater_lang.php
+++ b/system/ee/language/english/updater_lang.php
@@ -128,6 +128,10 @@ Please make sure you have the latest version of each file in place and then try 
     'update_rolledback_desc' =>
     'Contact support if you continue having trouble updating, or you can <a href=\'%s\' rel=\'external\'>manually update</a>.',
 
+    'update_version_warning' => 'Please check system online status',
+
+    'update_version_warning_desc' => 'Your current system status is set to <b>%s</b>. If you need to change that, please visit System Settings.',
+
     '' => ''
 );
 

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -463,7 +463,7 @@ class EE_Core
         });
 
         //show them post-update checks, again
-        if (ee()->input->get('after') == 'update') {
+        if (ee()->input->get('after') == 'update' || ee()->session->flashdata('update:completed')) {
             $advisor = new \ExpressionEngine\Library\Advisor\Advisor();
             $messages = $advisor->postUpdateChecks();
             if (!empty($messages)) {

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -172,15 +172,14 @@ class Cp
         ));
 
         if (ee()->session->flashdata('update:completed')) {
-            ee()->javascript->set_global('cp.updateCompleted', true);
 
             $updateCompletedScript = <<<JSC
-                /*$(document).ready(function() {
+                $(document).ready(function() {
                     document.getElementsByClassName('js-about')[0].click();
                     $('html, body').animate({
                         scrollTop: $('.app-about').offset().top
                     }, 500);
-                });*/
+                });
             JSC;
             ee()->javascript->output($updateCompletedScript);
         }

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -173,6 +173,42 @@ class Cp
 
         if (ee()->session->flashdata('update:completed')) {
             ee()->javascript->set_global('cp.updateCompleted', true);
+
+            $updateCompletedScript = <<<JSC
+                /*$(document).ready(function() {
+                    document.getElementsByClassName('js-about')[0].click();
+                    $('html, body').animate({
+                        scrollTop: $('.app-about').offset().top
+                    }, 500);
+                });*/
+            JSC;
+            ee()->javascript->output($updateCompletedScript);
+        }
+
+        if (ee()->session->flashdata('update:show_status_switch')) {
+            $systemStatusAlert = ee('CP/Alert')->makeBanner('warning_system_status')
+                ->asAttention()
+                ->canClose()
+                ->withTitle(lang('warning_system_status_title'))
+                ->addToBody(sprintf(
+                    lang('warning_system_status_message'),
+                    (ee()->config->item('is_system_on') == 'y') ? lang('online') : lang('offline'),
+                    ee('CP/URL')->make('settings/general')
+                ));
+                
+            $button = form_open(
+                ee('CP/URL')->make('settings/config'),
+                '',
+                array(
+                    'is_system_on' => (ee()->config->item('is_system_on') == 'y') ? 'n' : 'y'
+                )
+            );
+
+            $button .= '<input class="button button--primary" type="submit" value="' . sprintf(lang('warning_system_status_button'), (ee()->config->item('is_system_on') == 'y') ? lang('offline') : lang('online')) . '">';
+            $button .= form_close();
+
+            $systemStatusAlert->addToBody($button, '', false);
+            $systemStatusAlert->now();
         }
 
         // Combo-load the javascript files we need for every request

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -365,12 +365,16 @@ class Cp
             );
         }
 
-        if (ee('Filesystem')->exists(SYSPATH . 'ee/EllisLab')) {
-            $notices[] = sprintf(
-                lang('el_folder_present'),
-                SYSDIR . '/ee/EllisLab',
-                DOC_URL . 'installation/updating.html#if-updating-from-expressionengine-3-or-higher'
-            );
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+        foreach ($backtrace as $trace) {
+            if (!empty($trace['file']) && strpos($trace['file'], 'ee/EllisLab/ExpressionEngine/Boot/boot.php') !== false) {
+                $notices[] = sprintf(
+                    lang('el_folder_present'),
+                    SYSDIR . '/ee/EllisLab',
+                    DOC_URL . 'installation/updating.html#if-updating-from-expressionengine-3-or-higher'
+                );
+                break;
+            }
         }
 
         if (! empty($notices)) {

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -401,16 +401,12 @@ class Cp
             );
         }
 
-        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
-        foreach ($backtrace as $trace) {
-            if (!empty($trace['file']) && strpos($trace['file'], 'ee/EllisLab/ExpressionEngine/Boot/boot.php') !== false) {
-                $notices[] = sprintf(
-                    lang('el_folder_present'),
-                    SYSDIR . '/ee/EllisLab',
-                    DOC_URL . 'installation/updating.html#if-updating-from-expressionengine-3-or-higher'
-                );
-                break;
-            }
+        if (defined('ELLISLAB_STILL_HERE') && ELLISLAB_STILL_HERE == true) {
+            $notices[] = sprintf(
+                lang('el_folder_present'),
+                SYSDIR . '/ee/EllisLab',
+                DOC_URL . 'installation/updating.html#if-updating-from-expressionengine-3-or-higher'
+            );
         }
 
         if (! empty($notices)) {

--- a/tests/cypress/cypress/integration/z_installer/updater.ee6.js
+++ b/tests/cypress/cypress/integration/z_installer/updater.ee6.js
@@ -192,7 +192,7 @@ context('Updater', () => {
       })
     })
 
-    it.only('turns system off if system was off before updating', () => {
+    it('turns system off if system was off before updating', () => {
       cy.task('installer:revert_config').then(()=>{
         cy.task('installer:replace_config', {
           file: config,

--- a/themes/ee/asset/javascript/src/common.js
+++ b/themes/ee/asset/javascript/src/common.js
@@ -485,8 +485,8 @@ $(document).ready(function(){
 
 		$('.js-about').on('click', function(e) {
 			// Trigger an event so that the about popup can check for updates when shown
-			$('.app-about').trigger('display');
 			e.preventDefault();
+			$('.app-about').trigger('display');
 		});
 
 		$('.app-about').on('display', function() {

--- a/themes/ee/asset/javascript/src/cp/global_start.js
+++ b/themes/ee/asset/javascript/src/cp/global_start.js
@@ -231,14 +231,6 @@ $(document).ready(function () {
 	EE.cp.validateLicense();
 });
 
-// Scroll to version popover on successful update
-if (EE.cp.updateCompleted) {
-	$('.app-about-info').show()
-	$('.app-about-info__update').hide()
-	$('html, body').animate({
-		scrollTop: $('.app-about-info').offset().top
-	}, 500)
-}
 
 /**
  * Posts the current EE license to the EE main site for validation purposes.


### PR DESCRIPTION
…when doing 1-click upgrade

Also:

Add parent_id key on exp_categories table. Closes #847
Automaticaly modify index.php and admin.php files when doing 1-click updates

5.4.0 -> 6.0.2
![image](https://user-images.githubusercontent.com/752126/106905869-47152e80-6705-11eb-8c53-8f1de0eb6ac4.png)

5.4.0 -> 6.0.2 attempt -> rollback
![image](https://user-images.githubusercontent.com/752126/106923313-9a43ad00-6716-11eb-9f56-7b2d8c474ac5.png)


