### PR TITLE
EECORE-992 updated ping.expressionengine to use ssl connection

### DIFF
--- a/system/ee/legacy/libraries/El_pings.php
+++ b/system/ee/legacy/libraries/El_pings.php
@@ -214,7 +214,7 @@ class El_pings
     {
         $target = parse_url($url);
 
-        $fp = @fsockopen($target['host'], 80, $errno, $errstr, 3);
+        $fp = @fsockopen('ssl://'.$target['host'], 443, $errno, $errstr, 3);
 
         if (! $fp) {
             return false;


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Updates pings to use SSL.


## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x ] Yes
- [ ] No


