### PR TITLE
Modified legacy boot file to auto-correct boot path. Changed legacy f…

### DIFF
--- a/system/ee/installer/files/ee5/EllisLab/ExpressionEngine/Boot/boot.php
+++ b/system/ee/installer/files/ee5/EllisLab/ExpressionEngine/Boot/boot.php
@@ -4,4 +4,12 @@ if (!defined('EESELF') && defined('SELF')) {
     define('EESELF', SELF);
 }
 
+// Check to see if we have write access to the file.
+if (!empty($_SERVER['SCRIPT_FILENAME']) && is_file(realpath($_SERVER['SCRIPT_FILENAME'])) && is_writable(realpath($_SERVER['SCRIPT_FILENAME']))) {
+    $contents = file_get_contents(realpath($_SERVER['SCRIPT_FILENAME']));
+    $contents = str_replace('ee/EllisLab/ExpressionEngine/Boot/boot.php', 'ee/ExpressionEngine/Boot/boot.php', $contents);
+    file_put_contents(realpath($_SERVER['SCRIPT_FILENAME']), $contents);
+    header("Refresh:1");
+}
+
 require_once SYSPATH . '/ee/ExpressionEngine/Boot/boot.php';

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -365,12 +365,16 @@ class Cp
             );
         }
 
-        if (ee('Filesystem')->exists(SYSPATH . 'ee/EllisLab')) {
-            $notices[] = sprintf(
-                lang('el_folder_present'),
-                SYSDIR . '/ee/EllisLab',
-                DOC_URL . 'installation/updating.html#if-updating-from-expressionengine-3-or-higher'
-            );
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+        foreach ($backtrace as $trace) {
+            if (!empty($trace['file']) && strpos($trace['file'], 'ee/EllisLab/ExpressionEngine/Boot/boot.php') !== false) {
+                $notices[] = sprintf(
+                    lang('el_folder_present'),
+                    SYSDIR . '/ee/EllisLab',
+                    DOC_URL . 'installation/updating.html#if-updating-from-expressionengine-3-or-higher'
+                );
+                break;
+            }
         }
 
         if (! empty($notices)) {


### PR DESCRIPTION
…older present check to look in backtrace for EllisLab boot file.

<!-- What's in this pull request? -->
## Overview
Modifies calling file (index.php or admin.php) to remove legacy EllisLab from boot path then refreshes page to prevent false-positive warning message.

It also changes the warning message to look in the backtrace for the EllisLab boot file instead of the presence of the boot file itself.

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [X] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security
