### PR TITLE
Bug/6.x/fix template profile array check error

### DIFF
--- a/system/ee/ExpressionEngine/Service/Profiler/Section/Template.php
+++ b/system/ee/ExpressionEngine/Service/Profiler/Section/Template.php
@@ -62,7 +62,12 @@ class Template extends ProfilerSection
     public function setData($log)
     {
         $last = end($log);
-        $this->template_memory = $last['memory'];
+
+        if ($last !== false) {
+            $this->template_memory = $last['memory'];
+        } else {
+            $this->template_memory = 0;
+        }
 
         foreach ($log as &$entry) {
             // convert human friendly megabytes into bytes for maths


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fixes a bug where an array in the template profiler was not being checked as empty first and threw an error.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
