### PR TITLE
Reverted previous change and fixed checking hasAny permissions for both superadmins and members

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -20,6 +20,8 @@ Bullet list below, e.g.
    - Fixed a bug with user lang translations in the CP.
    - Fix addon icon for png and svg
    - Fix bug in the Template Profiler when it attempts to parse an empty array
+   - Fixed issue with super admins seeing unauthorized message when accessing empty entry manager
+   - Changed how permission check for members with CP access is handled
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/ExpressionEngine/Controller/Publish/Edit.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Edit.php
@@ -40,7 +40,7 @@ class Edit extends AbstractPublishController
         }
 
         $this->permissions['all'] = array_merge($this->permissions['others'], $this->permissions['self']);
-        
+
         if (! ee('Permission')->hasAny($this->permissions['all'])) {
             show_error(lang('unauthorized_access'), 403);
         }

--- a/system/ee/ExpressionEngine/Controller/Publish/Edit.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Edit.php
@@ -40,8 +40,8 @@ class Edit extends AbstractPublishController
         }
 
         $this->permissions['all'] = array_merge($this->permissions['others'], $this->permissions['self']);
-
-        if (empty($this->permissions['all']) or ! ee('Permission')->hasAny($this->permissions['all'])) {
+        
+        if (! ee('Permission')->hasAny($this->permissions['all'])) {
             show_error(lang('unauthorized_access'), 403);
         }
     }

--- a/system/ee/ExpressionEngine/Service/Permission/Permission.php
+++ b/system/ee/ExpressionEngine/Service/Permission/Permission.php
@@ -175,11 +175,18 @@ class Permission
         if ($this->isSuperAdmin()) {
             return true;
         }
+        
+        // Check to see that something was passed, even if it's an empty array (mostly a gut-check for add-on devs).
+        if (empty(func_get_args())) {
+            throw new \BadMethodCallException('Invalid parameter count, 1 or more arguments required.');
+        }
 
         $which = $this->prepareArguments(func_get_args());
 
+        // Check to see if an empty array of values was passed. We want to check to see if the user has
+        // any of the requested permissions, but if it's empty, they obviously do not have permission.
         if (! count($which)) {
-            throw new \BadMethodCallException('Invalid parameter count, 1 or more arguments required.');
+            return false;
         }
 
         foreach ($which as $w) {

--- a/system/ee/ExpressionEngine/Service/Permission/Permission.php
+++ b/system/ee/ExpressionEngine/Service/Permission/Permission.php
@@ -175,7 +175,7 @@ class Permission
         if ($this->isSuperAdmin()) {
             return true;
         }
-        
+
         // Check to see that something was passed, even if it's an empty array (mostly a gut-check for add-on devs).
         if (empty(func_get_args())) {
             throw new \BadMethodCallException('Invalid parameter count, 1 or more arguments required.');
@@ -224,7 +224,7 @@ class Permission
         if ($this->isSuperAdmin()) {
             return true;
         }
-        
+
         //legacy permission support
         if (in_array($which, ['can_create_entries', 'can_edit_other_entries', 'can_edit_self_entries', 'can_delete_self_entries', 'can_delete_all_entries', 'can_assign_post_authors'])) {
             $member = ee()->session->getMember();


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Fixes a regression issue where Super Admins get an unauthorized message when accessing the Entry Manager if no channels exist (blank slate).

Changes how the `hasAny` permission check for Members with CP access but not Entry Manager access is handled.

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [X] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->