### PR TITLE
change login extension hook placement fot CP logins

### DIFF
--- a/system/ee/legacy/libraries/Auth.php
+++ b/system/ee/legacy/libraries/Auth.php
@@ -176,6 +176,21 @@ class Auth
      */
     public function verify()
     {
+        // If this is being called from the CP, use the hook
+        if (REQ == 'CP') {
+            /* -------------------------------------------
+            /* 'login_authenticate_start' hook.
+            /*  - Take control of CP authentication routine
+            /*  - Added EE 1.4.2
+            */
+            ee()->extensions->call('login_authenticate_start');
+            if (ee()->extensions->end_script === true) {
+                return;
+            }
+            /*
+            /* -------------------------------------------*/
+        }
+        
         $username = (string) ee()->input->post('username');
 
         // No username/password?  Bounce them...
@@ -191,21 +206,6 @@ class Auth
             $this->errors[] = 'no_password';
 
             return false;
-        }
-
-        // If this is being called from the CP, use the hook
-        if (REQ == 'CP') {
-            /* -------------------------------------------
-            /* 'login_authenticate_start' hook.
-            /*  - Take control of CP authentication routine
-            /*  - Added EE 1.4.2
-            */
-            ee()->extensions->call('login_authenticate_start');
-            if (ee()->extensions->end_script === true) {
-                return;
-            }
-            /*
-            /* -------------------------------------------*/
         }
 
         // Is IP and User Agent required for login?


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

While working on a small extension to allow users to login from the front-end via their email instead of username, I noticed that unlike in the front-end login form the hook for the CP gets called after the username variable is set, effectively not allowing the hook to be used to its full potential.

For example in system/ee/ExpressionEngine/Addons/member/mod.member_auth.php where the 'member_member_login_start' is called before setting the variables that get checked.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
