### PR TITLE
Fixed a bug where a file field within a fluid field would populate all other file fields when selecting images (Fixes #922)

### DIFF
--- a/themes/ee/asset/javascript/src/fields/file/file_field_drag_and_drop.es6
+++ b/themes/ee/asset/javascript/src/fields/file/file_field_drag_and_drop.es6
@@ -38,6 +38,15 @@ class FileField extends React.Component {
   }
 
   getFieldContainer() {
+    let fluidContainer = $(this.props.thisField).closest('.fluid__item-field')
+
+    // Is this file field inside of a fluid field? 
+    // If it is, we need to get the fluid item container, 
+    // not the container that holds the entire fluid field
+    if (fluidContainer.length) {
+      return fluidContainer
+    }
+
     return $(this.props.thisField).closest('.grid-file-upload, .field-control')
   }
 

--- a/themes/ee/asset/javascript/src/fields/file/file_field_drag_and_drop.js
+++ b/themes/ee/asset/javascript/src/fields/file/file_field_drag_and_drop.js
@@ -79,6 +79,14 @@ function (_React$Component) {
   }, {
     key: "getFieldContainer",
     value: function getFieldContainer() {
+      var fluidContainer = $(this.props.thisField).closest('.fluid__item-field'); // Is this file field inside of a fluid field? 
+      // If it is, we need to get the fluid item container, 
+      // not the container that holds the entire fluid field
+
+      if (fluidContainer.length) {
+        return fluidContainer;
+      }
+
       return $(this.props.thisField).closest('.grid-file-upload, .field-control');
     }
   }, {


### PR DESCRIPTION
Looks like the file field was targeting the entire fluid field, instead of it's own container.