### PR TITLE
EECORE-1083 Fixes #927 updated language for File Field default field description

### DIFF
--- a/system/ee/language/english/fieldtypes_lang.php
+++ b/system/ee/language/english/fieldtypes_lang.php
@@ -93,7 +93,7 @@ $lang = array(
     /* File */
     'file_ft_allowed_dirs' => 'Allowed Directory',
 
-    'file_ft_allowed_dirs_desc' => 'Default directory to store files uploaded with this field.',
+    'file_ft_allowed_dirs_desc' => 'Directory used by this field for storing and retrieving files.',
 
     'file_ft_cannot_find_file' => '<b>File not found.</b> We could not locate %s on the server.',
 


### PR DESCRIPTION
## Overview
updated language for File Field default field description

Resolves [#927](https://github.com/ExpressionEngine/ExpressionEngine/issues/927).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

