### PR TITLE
Fix/910 date picker

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -5,23 +5,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 ## Patch Release
 
 Bullet list below, e.g.
-   - Added <new feature>
-   - Fixed a bug (#<linked issue number>) where <bug behavior>.
-
-   - Fixed a bug that prevented the instal wizard from auto-renaming the installer folder after install.
-   - Fixed install exception when using MySQL 8 with unsuported authentication type.
-   - Fixed PSR-12 lint error for SELF constant by adding and swapping it out for new EESELF constant.
-   - Fixed "Select Dropdown" "Populate the menu from another channel field" not showing any field options.
-   - Fixed an 'Invalid parameter count' error message, switching in a more friendly permission message on the publish edit page.
-   - Fixed a bug ([#687](https://github.com/ExpressionEngine/ExpressionEngine/issues/687) where no valid channels were available in the channel field on the publish page.
-   - Fixed several missing language variables in the control panel.
-   - Fixed template HTTP Authentication not recognizing Super Admin.
-   - Added CLI command file
-   - Fixed a bug with user lang translations in the CP.
-   - Fix addon icon for png and svg
-   - Fix bug in the Template Profiler when it attempts to parse an empty array
-   - Fixed issue with super admins seeing unauthorized message when accessing empty entry manager
-   - Changed how permission check for members with CP access is handled
+   - Fixed a bug (#910) where date picker wasn't following the last day of the month when switching.
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/themes/ee/asset/javascript/src/cp/date_picker.js
+++ b/themes/ee/asset/javascript/src/cp/date_picker.js
@@ -183,9 +183,9 @@ EE.cp.datePicker = {
 
 					if ($(that.element).val()) {
 						var d = new Date($(that.element).data('timestamp') * 1000);
-						d.setYear(that.year);
-						d.setMonth(that.month);
-						d.setDate($(this).text());
+						var lastDayOfCurrentMonth = new Date(that.year, that.month + 1, 0).getDate()
+						var dateToSet = lastDayOfCurrentMonth <= $(this).text() ? lastDayOfCurrentMonth : $(this).text()
+						d = new Date(that.year, that.month, dateToSet)
 					} else {
 						var d = new Date(that.year, that.month, $(this).text());
 					}


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Addresses #910, where date picker was adding an extra month when clicking on the last day of the month of months with more days than the next or previous.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#910](https://github.com/ExpressionEngine/ExpressionEngine/issues/910).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No