### PR TITLE
Replace deprecated Redis delete calls with del

### DIFF
--- a/system/ee/legacy/libraries/Cache/drivers/Cache_redis.php
+++ b/system/ee/legacy/libraries/Cache/drivers/Cache_redis.php
@@ -69,7 +69,7 @@ class EE_Cache_redis extends CI_Driver
     {
         // Delete namespace contents
         if (strrpos($key, Cache::NAMESPACE_SEPARATOR, strlen($key) - 1) !== false) {
-            return ($this->_redis->delete(
+            return ($this->_redis->del(
                 $this->_redis->keys($this->unique_key($key, $scope) . '*')
             ) === 1);
         }
@@ -91,7 +91,7 @@ class EE_Cache_redis extends CI_Driver
      */
     public function clean($scope = Cache::LOCAL_SCOPE)
     {
-        return ($this->_redis->delete(
+        return ($this->_redis->del(
             $this->_redis->keys($this->unique_key('', $scope) . '*')
         ) === 1);
     }


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

This small fix updates the Cache_redis.php driver so that it uses the current 'del' command to delete cache items.

Fix for ---> https://github.com/ExpressionEngine/ExpressionEngine/issues/323

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#323](https://github.com/ExpressionEngine/ExpressionEngine/issues/323).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
