### PR TITLE
Remove CSS styling which sets status to uppercase

### DIFF
--- a/changelogs/major.md
+++ b/changelogs/major.md
@@ -56,6 +56,7 @@ Developers
 
 - Forgot Password emails will now respect your "Mail Format" preference (essentially enabling the ability to use HTML in Forgot Password emails).
 - Fixed a bug where table bulk selections can be saved by the browser on page reload, but don't show in the UI.
+- Control panel status column in entry list displays status text casing which matches the actual casing as entered into the system on creation. 
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/cp-styles/app/styles/legacy/_status-tag.scss
+++ b/cp-styles/app/styles/legacy/_status-tag.scss
@@ -9,7 +9,7 @@
 	border: 1px solid transparent;
 	font-size: 75%;
   font-weight: 500;
-  text-transform: uppercase;
+  text-transform: none;
   letter-spacing: 1px;
 	border-radius: $border-radius-xsmall;
 


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

The status column in the list of entries shows the status items in
uppercase. This is caused by a text-transform property in the CSS for
the "status-tag" class.

The status column is useful as a reference to be used in channel entry
tags, but the CSS obscures the actual casing being used.

Change the text-transform property from uppercase to "none." This change
affects status items being used elsewhere, creating the same issue in
each of these instances.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#246 ](https://github.com/ExpressionEngine/ExpressionEngine/issues/246).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
No documentation needed.

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
