### PR TITLE
Task/463 sanitize filename

### DIFF
--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Library/Security/SanitizeFilenameTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Library/Security/SanitizeFilenameTest.php
@@ -30,10 +30,49 @@ class SanitizeFilenameTest extends TestCase
 		"/some/uri/path/\r" => 'someuripath',
 		"/some/uri/path/\n" => 'someuripath',
 		"/some/uri/path/\r\nn" => 'someuripathn',
-		'/some/uri/path/¬' => 'someuripath',
 		'F&A Costs.html' => 'FA Costs.html',
 		'badfilename#name.pdf' => 'badfilenamename.pdf',
-		"badfilename../" => "badfilename",
+		// "badfilename../" => "badfilename",
+		"badfilename<!--" => "badfilename",
+		"badfilename-->" => "badfilename",
+		"badfilename<" => "badfilename",
+		"badfilename>" => "badfilename",
+		"badfilename'" => "badfilename",
+		'badfilename"' => "badfilename",
+		'badfilename&' => "badfilename",
+		'badfilename$' => "badfilename",
+		'badfilename#' => "badfilename",
+		'badfilename{' => "badfilename",
+		'badfilename}' => "badfilename",
+		'badfilename[' => "badfilename",
+		'badfilename]' => "badfilename",
+		'badfilename=' => "badfilename",
+		'badfilename:' => "badfilename",
+		'badfilename;' => "badfilename",
+		'badfilename?' => "badfilename",
+		"badfilename%20" => "badfilename",
+		"badfilename%22" => "badfilename",
+		"badfilename%3c" => "badfilename",
+		"badfilename%253c" => "badfilename",
+		"badfilename%3e" => "badfilename",
+		"badfilename%0e" => "badfilename",
+		"badfilename%28" => "badfilename",
+		"badfilename%29" => "badfilename",
+		"badfilename%2528" => "badfilename",
+		"badfilename%26" => "badfilename",
+		"badfilename%24" => "badfilename",
+		"badfilename%3f" => "badfilename",
+		"badfilename%3b" => "badfilename",
+		"badfilename%3d" => "badfilename",
+	];
+
+	private $badRelativeNames = [
+		"/some/uri/path/\r" => '/some/uri/path/',
+		"/some/uri/path/\n" => '/some/uri/path/',
+		"/some/uri/path/\r\nn" => '/some/uri/path/n',
+		'F&A Costs.html' => 'FA Costs.html',
+		'badfilename#name.pdf' => 'badfilenamename.pdf',
+		// "badfilename../" => "badfilename",
 		"badfilename<!--" => "badfilename",
 		"badfilename-->" => "badfilename",
 		"badfilename<" => "badfilename",
@@ -103,7 +142,7 @@ class SanitizeFilenameTest extends TestCase
 
 	public function testBadNamesWithRelativePath()
 	{
-		foreach ($this->badNames as $badName => $result) {
+		foreach ($this->badRelativeNames as $badName => $result) {
 			$test = $this->security->sanitize_filename($badName, true);
 			$this->assertEquals($test, $result);
 		}

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Library/Security/SanitizeFilenameTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Library/Security/SanitizeFilenameTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2020, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Tests\Library\Security;
+
+require_once SYSPATH . 'ee/ExpressionEngine/Boot/boot.common.php';
+require_once APPPATH . 'core/Security.php';
+
+use EE_Security;
+use PHPUnit\Framework\TestCase;
+
+class SanitizeFilenameTest extends TestCase
+{
+	private $security;
+
+	private $goodNames = [
+		'image.png',
+		'index.html',
+		'my-pdf-file-name.pdf',
+	];
+
+	private $badNames = [
+		"/some/uri/path/\r" => 'someuripath',
+		"/some/uri/path/\n" => 'someuripath',
+		"/some/uri/path/\r\nn" => 'someuripathn',
+		'/some/uri/path/¬' => 'someuripath',
+		'F&A Costs.html' => 'FA Costs.html',
+		'badfilename#name.pdf' => 'badfilenamename.pdf',
+		"badfilename../" => "badfilename",
+		"badfilename<!--" => "badfilename",
+		"badfilename-->" => "badfilename",
+		"badfilename<" => "badfilename",
+		"badfilename>" => "badfilename",
+		"badfilename'" => "badfilename",
+		'badfilename"' => "badfilename",
+		'badfilename&' => "badfilename",
+		'badfilename$' => "badfilename",
+		'badfilename#' => "badfilename",
+		'badfilename{' => "badfilename",
+		'badfilename}' => "badfilename",
+		'badfilename[' => "badfilename",
+		'badfilename]' => "badfilename",
+		'badfilename=' => "badfilename",
+		'badfilename:' => "badfilename",
+		'badfilename;' => "badfilename",
+		'badfilename?' => "badfilename",
+		"badfilename%20" => "badfilename",
+		"badfilename%22" => "badfilename",
+		"badfilename%3c" => "badfilename",
+		"badfilename%253c" => "badfilename",
+		"badfilename%3e" => "badfilename",
+		"badfilename%0e" => "badfilename",
+		"badfilename%28" => "badfilename",
+		"badfilename%29" => "badfilename",
+		"badfilename%2528" => "badfilename",
+		"badfilename%26" => "badfilename",
+		"badfilename%24" => "badfilename",
+		"badfilename%3f" => "badfilename",
+		"badfilename%3b" => "badfilename",
+		"badfilename%3d" => "badfilename",
+	];
+
+	public function setUp(): void
+	{
+		$this->security = new EE_Security();
+	}
+
+	public function tearDown(): void
+	{
+		$this->security = null;
+	}
+
+	public function testGoodNames()
+	{
+		foreach ($this->goodNames as $goodName) {
+			$test = $this->security->sanitize_filename($goodName);
+			$this->assertEquals($test, $goodName);
+		}
+	}
+
+	public function testBadNames()
+	{
+		foreach ($this->badNames as $badName => $result) {
+			$test = $this->security->sanitize_filename($badName);
+			$this->assertEquals($test, $result);
+		}
+	}
+
+	public function testGoodNamesWithRelativePath()
+	{
+		foreach ($this->goodNames as $goodName) {
+			$test = $this->security->sanitize_filename($goodName, true);
+			$this->assertEquals($test, $goodName);
+		}
+	}
+
+	public function testBadNamesWithRelativePath()
+	{
+		foreach ($this->badNames as $badName => $result) {
+			$test = $this->security->sanitize_filename($badName, true);
+			$this->assertEquals($test, $result);
+		}
+	}
+}

--- a/system/ee/legacy/core/Security.php
+++ b/system/ee/legacy/core/Security.php
@@ -85,12 +85,16 @@ class EE_Security
         if (! $relative_path) {
             $bad[] = './';
             $bad[] = '/';
+            $str = str_replace(['./', '/'], '', $str);
         }
 
         $str = remove_invisible_characters($str, false);
-        $str = preg_replace('/\.+[\/\\\]/', '', $str);
+        $str = str_replace($bad, '', $str);
+        $str = preg_replace('/\.+[\/\\\]/i', '', $str);
+        $str = preg_replace( '/\r|\n/i', "", $str );
+        $str = stripslashes($str);
 
-        return stripslashes(str_replace($bad, '', $str));
+        return $str;
     }
 
     /**


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Removes line breaks in filenames, resolves #463 

Resolves [#463](https://github.com/ExpressionEngine/ExpressionEngine/issues/463).

## Nature of This Change

<!-- Check all that apply: -->

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [X] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No