### PR TITLE
Restrict textarea resize to vertical

### DIFF
--- a/changelogs/major.md
+++ b/changelogs/major.md
@@ -45,6 +45,7 @@ Bullet list below, e.g.
 - Changed sidebar copyright company name
 - Default avatars have been removed
 - The system avatar settings "Allow avatar uploads?" and "Allow avatars?" have been removed
+- Fixed bug #996 where resizing textareas beyond the parent element was breaking other children of that parent.
 
 Developers
 - Updated CodeMirror to version 5.48

--- a/cp-styles/app/styles/base/_inputs.scss
+++ b/cp-styles/app/styles/base/_inputs.scss
@@ -12,6 +12,7 @@ textarea {
 	min-width: 100%;
 	height: auto;
 	line-height: $line-height-normal;
+  resize: vertical;
 
   &.tall {
     height: 115px;


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

The current textarea size is set to a min and max of 100%. Because the
textarea is always set to the max width of the parent element, then it
shouldn't need to be resized horizontally. Resizing is an automatic
feature in some browsers and may be overridden.

In some cases, resizing the textarea outside the parent element creates
issues with other child elements which share the same parent. As an
example, the issue this change is meant to address is that a resized
text area is pushing "delete" controls for text inputs off the screen.
The user would then have to refresh the page to get those controls
back.

Note that the user is unable to make the textarea smaller because of
other styling rules. With both max and min width set to 100%, the user
can only make the textarea larger. Though this would be an alternative
for fixing this issue, it's reasonable to assume that we should be
constraining the size to the max width of the parent.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#996 ](https://github.com/ExpressionEngine/ExpressionEngine/issues/996).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
No documentation required.

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
