### PR TITLE
only save current fieldtype setting when swiching fieldtype

### DIFF
--- a/system/ee/ExpressionEngine/Model/Channel/ChannelField.php
+++ b/system/ee/ExpressionEngine/Model/Channel/ChannelField.php
@@ -138,9 +138,15 @@ class ChannelField extends FieldModel
     public function set(array $data = array())
     {
         parent::set($data);
-        $old_field_type = $this->getBackup('field_type');
 
-        $field = $this->getField($this->getSettingsValues());
+        $old_field_type = $this->getBackup('field_type');
+        if (! empty($old_field_type) && $old_field_type != $this->getFieldType()) {
+            $field_settings = array();
+        } else {
+            $field_settings =$this->getSettingsValues();
+        }
+
+        $field = $this->getField($field_settings);
         $this->setProperty('field_settings', $field->saveSettingsForm($data));
 
         return $this;


### PR DESCRIPTION
fixes #995

Improves https://github.com/ExpressionEngine/ExpressionEngine/commit/5e493118feab3a5d12c6254874c85fbbe0225c3d

EECORE-1094

Related PR: #1061