### PR TITLE
Display category group ID

### DIFF
--- a/system/ee/ExpressionEngine/View/channels/cat/list.php
+++ b/system/ee/ExpressionEngine/View/channels/cat/list.php
@@ -5,7 +5,11 @@
   <div class="panel-heading">
     <div class="form-btns form-btns-top">
       <div class="title-bar title-bar--large">
-        <h3 class="title-bar__title"><?=$cp_page_title?></h3>
+        <h3 class="title-bar__title">
+          <?=$cp_page_title?>
+          <br>
+          <i>#<?=$cat_group->group_id?></i>
+        </h3>
         <div class="title-bar__extra-tools">
   				<?php if ($can_create_categories):?>
   					<a class="tn button button--primary" href="<?=ee('CP/URL')->make('categories/create/' . $cat_group->group_id)?>"><?=lang('new_category')?></a>


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Displays the category group ID number in the group's panel heading.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves Jira issue [EECORE-1110](https://packettide.atlassian.net/browse/EECORE-1110).

First reported in GitHub issue (fixes #698 )

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->