### PR TITLE
EECORE-1173 added noindex, nofollow headers to redirect warning page

### DIFF
--- a/system/ee/ExpressionEngine/View/_templates/out.php
+++ b/system/ee/ExpressionEngine/View/_templates/out.php
@@ -5,6 +5,7 @@
 		<meta http-equiv="content-type" content="text/html; charset=utf-8">
 		<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"  name="viewport">
 		<meta name="referrer" content="no-referrer">
+		<meta name="robots" content="noindex, nofollow">
 		<?=ee()->view->head_link('css/common.min.css')?>
 	</head>
 	<body data-ee-version="<?=APP_VER?>" class="installer-page">


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview
Adds noindex,nofollow to template used by `?URL` redirect warning page. 

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [x] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
