### PR TITLE
Removed hard coded addons

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/ExpressionEngine/Controller/Addons/Addons.php
@@ -32,8 +32,7 @@ class Addons extends CP_Controller
     public function __construct()
     {
         parent::__construct();
-        ee()->cp->add_js_script(array('file'=> array('cp/addons/add-ons-index'),));
-
+        
         ee('CP/Alert')->makeDeprecationNotice()->now();
 
         if (! ee('Permission')->can('access_addons')) {
@@ -223,7 +222,7 @@ class Addons extends CP_Controller
 
         ee()->javascript->set_global('lang.remove_confirm', lang('addon') . ': <b>### ' . lang('addons') . '</b>');
         ee()->cp->add_js_script(array(
-            'file' => ['cp/confirm_remove', 'cp/add-ons'],
+            'file' => ['cp/addons/add-ons-index', 'cp/confirm_remove', 'cp/add-ons'],
         ));
         
 

--- a/system/ee/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/ExpressionEngine/Controller/Addons/Addons.php
@@ -17,6 +17,7 @@ use ExpressionEngine\Library\CP\Table;
 /**
  * Addons Controller
  */
+
 class Addons extends CP_Controller
 {
     public $perpage = 25;
@@ -31,6 +32,7 @@ class Addons extends CP_Controller
     public function __construct()
     {
         parent::__construct();
+        ee()->cp->add_js_script(array('file'=> array('cp/addons/add-ons-index'),));
 
         ee('CP/Alert')->makeDeprecationNotice()->now();
 
@@ -223,6 +225,7 @@ class Addons extends CP_Controller
         ee()->cp->add_js_script(array(
             'file' => ['cp/confirm_remove', 'cp/add-ons'],
         ));
+        
 
         ee()->view->cp_breadcrumbs = array(
             '' => lang('addons')

--- a/system/ee/ExpressionEngine/View/_shared/modal_confirm_remove.php
+++ b/system/ee/ExpressionEngine/View/_shared/modal_confirm_remove.php
@@ -3,7 +3,10 @@
 
 		<?=form_open($form_url, '', (isset($hidden)) ? $hidden : array())?>
 		<div class="dialog__header">
-			<div class="dialog__icon"><i class="fas fa-trash-alt"></i></div>
+		   
+			<?php if (!isset($noTrash)) : ?>
+				<div class="dialog__icon"><i class="fas fa-trash-alt"></i></div>
+			<?php endif; ?>
 			<h2 class="dialog__title"><?=isset($title) ? $title : lang('confirm_removal') ?></h2>
 			<div class="dialog__close js-modal-close"><i class="fas fa-times"></i></div>
 		</div>

--- a/system/ee/ExpressionEngine/View/addons/index.php
+++ b/system/ee/ExpressionEngine/View/addons/index.php
@@ -2,8 +2,8 @@
 <div class="panel panel__no-main-title">
 	<div class="tbl-ctrls">
 		<div class="panel-heading">
-			<div class="app-notice-wrap"><?= ee('CP/Alert')->getAllInlines() ?></div>
-			<?php if (!empty($updates) && count($updates) == 1) : ?>
+			<div class="app-notice-wrap"><?=ee('CP/Alert')->getAllInlines() ?></div>
+			<?php if (!empty($updates) && count($updates)==1) : ?>
 				<div id="alert_banner" class="alert">
 					<div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
 					<div id="alert" class="alert__close">
@@ -11,12 +11,11 @@
 					</div>
 					<p class="alert__title"> <br>
 					<p class="alert__title"><?php echo lang('update'); ?><br>
-						<?php
-						$there = lang('there_is');
-						$single = lang('single_update');
-						$count = count($updates);
-						echo sprintf($there, $count , $single);
+						<?php 
+						$count=count($updates);
+						echo sprintf(lang('single_update'), $count); 
 						?>
+						
 						<a id="show_me"><?php echo lang('show'); ?></a>
 					</p>
 						
@@ -30,16 +29,17 @@
 						<a id="alert_close" class="fas fa-times alert__close-icon"></a>
 					</div>
 					<p class="alert__title"><?php echo lang('updates'); ?><br>
-						<?php
-						$there = lang('there_are');
-						$multi = lang('multi_updates');
-						$count = count($updates);
-						echo sprintf($there, $count , $multi);
+						
+						<?php 
+						$count=count($updates);
+						echo sprintf(lang('multi_updates'), $count); 
 						?>
 						<a id="show_me"><?php echo lang('show'); ?></a>
 					</p>
 				</div>
 			<?php endif; ?>
+
+			
 
 
 			<div class="form-btns form-btns-top">
@@ -47,12 +47,13 @@
 					<div class="filter-bar">
 						<div class="filter-bar__item ">
 							<div class="filter-search-bar__item ">
-								<button type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="status" title="status"><?php echo lang('filter_by_status'); ?></button>
+								<button id = "current_status" type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="status" title="status"><?php echo lang('filter_by_status'); ?></button>
 								<div class="dropdown">
 									<div class="dropdown__scroll">
 										<a class="dropdown__link" id="installed_sort"><?php echo lang('installed'); ?></a>
 										<a class="dropdown__link" id="uninstalled_sort"><?php echo lang('uninstalled'); ?></a>
 										<a class="dropdown__link" id="update_sort"><?php echo lang('update_available'); ?></a>
+										<a class="dropdown__link" id="show_all"><?php echo lang('all_addons'); ?></a>
 									</div>
 								</div>
 							</div>
@@ -65,7 +66,7 @@
 							</div>
 						</div>
 
-						<?php ee()->cp->add_js_script(array('file' => array('cp/addons/add-ons-index'),)); ?>
+						
 
 					</div>
 				</div>
@@ -99,7 +100,7 @@
 					</thead>
 
 					<tbody class="list-group">
-						<?php $addons = $installed;
+						<?php $addons=$installed;
 						foreach ($addons as $addon) : ?>
 
 							<?php if (isset($addon['update'])) {
@@ -111,16 +112,16 @@
 								<span class="collapsed-label"><?php echo lang('name'); ?></span>
 								<a>
 									<div class="addon-name-table d-flex align-items-center">
-										<img src="<?= $addon["icon_url"] ?>" class="addon-icon-table">
-										<div class = "name_of_addon">
-											<strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"> <?= $addon["description"] ?> </span>
+										<img src="<?=$addon["icon_url"] ?>" class="addon-icon-table">
+										<div class="name_of_addon">
+											<strong><?=$addon["name"] ?></strong><br><span class="meta-info text-muted"> <?=$addon["description"] ?> </span>
 										</div>
 									</div>
 								</a>
 							</td>
 							<td>
 								<span class="collapsed-label"><?php echo lang('version'); ?></span>
-								<?= $addon["version"] ?>
+								<?=$addon["version"] ?>
 							</td>
 							<td class="manage">
 								<span class="collapsed-label"><?php echo lang('manage'); ?></span>
@@ -128,14 +129,14 @@
 									<div class="button-group button-group-xsmall">
 
 										<?php if (isset($addon['manual_url'])) : ?>
-											<a href="<?= $addon['manual_url'] ?>" class="manual button button--default" <?php if ($addon['manual_external']) {
+											<a href="<?=$addon['manual_url'] ?>" class="manual button button--default" <?php if ($addon['manual_external']) {
 																															echo 'rel="external"';
 																														} ?>></a>
 										<?php endif; ?>
 
-										<?php if (isset($addon['settings_url'])) : ?><a class="settings button button--default" href="<?= $addon['settings_url'] ?>" title="Settings"><span class="hidden"><?= lang('settings') ?></span></a> <?php endif; ?>
+										<?php if (isset($addon['settings_url'])) : ?><a class="settings button button--default" href="<?=$addon['settings_url'] ?>" title=<?=lang('settings') ?>><span class="hidden"><?=lang('settings') ?></span></a> <?php endif; ?>
 
-										<?php if (isset($addon['update'])) : ?> <a href="" data-post-url="<?= $addon['update_url'] ?>" class="button button--primary button--small">
+										<?php if (isset($addon['update'])) : ?> <a href="" data-post-url="<?=$addon['update_url'] ?>" class="button button--primary button--small">
 												<?php echo sprintf(lang('update_to_version'), '<br />' . $addon['update']); ?>
 											</a> <?php endif; ?>
 
@@ -146,40 +147,40 @@
 
 							<td class="app-listing__cell app-listing__cell--input text--center">
 								<?php if (ee('Permission')->hasAll('can_admin_addons') && $addon['installed']) : ?>
-									<a href="<?= $addon['remove_url'] ?>" class="button button--primary button--small" onclick="return confirm('<?php echo lang('confirm'); ?> <?= $addon['name'] ?>')"><?= lang('uninstall') ?></a>
+									<a href="<?=$addon['remove_url'] ?>" class="button button--primary button--small" onclick="return confirm('<?php echo lang('confirm'); ?> <?=$addon['name'] ?>')"><?=lang('uninstall') ?></a>
 								<?php endif; ?>
 							</td>
 
 							<td class="app-listing__cell app-listing__cell--input text--center">
 								<div class="list-item__checkbox">
-									<input name="selection[]" type="checkbox" value="<?= $addon["package"] ?>" data-confirm="<?= $addon["name"] ?>">
+									<input name="selection[]" type="checkbox" value="<?=$addon["package"] ?>" data-confirm="<?=$addon["name"] ?>">
 								</div>
 							</td>
 
 
 						<?php endforeach; ?>
 
-						<?php $addons = $installed;
+						<?php $addons=$installed;
 						foreach ($uninstalled as $addon) : ?>
 							<tr class="app-listing__row_uninstalled">
 								<td>
 									<span class="collapsed-label"><?php echo lang('name'); ?></span>
 
 									<div class="addon-name-table d-flex align-items-center">
-										<img src="<?= $addon["icon_url"] ?>" class="addon-icon-table">
-										<div class = "name_of_addon">
-											<strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"><?= $addon["description"] ?></span>
+										<img src="<?=$addon["icon_url"] ?>" class="addon-icon-table">
+										<div class="name_of_addon">
+											<strong><?=$addon["name"] ?></strong><br><span class="meta-info text-muted"><?=$addon["description"] ?></span>
 										</div>
 									</div>
 
 								</td>
 								<td>
 									<span class="collapsed-label"><?php echo lang('version'); ?></span>
-									<?= $addon["version"] ?>
+									<?=$addon["version"] ?>
 								</td>
 								<td>
 									<span class="collapsed-label"><?php echo lang('manage'); ?></span>
-									<a href="" data-post-url="<?= $addon['install_url'] ?>" class="button button--primary button--small"><?= lang('install') ?></a>
+									<a href="" data-post-url="<?=$addon['install_url'] ?>" class="button button--primary button--small"><?=lang('install') ?></a>
 								</td>
 								<td class="app-listing__cell app-listing__cell--input text--center">
 									<p> -- </p>
@@ -187,7 +188,7 @@
 
 								<td class="app-listing__cell app-listing__cell--input text--center">
 									<div class="list-item__checkbox">
-										<input name="selection[]" type="checkbox" value="<?= $addon["package"] ?>" data-confirm="<?= $addon["name"] ?>">
+										<input name="selection[]" type="checkbox" value="<?=$addon["package"] ?>" data-confirm="<?=$addon["name"] ?>">
 									</div>
 								</td>
 
@@ -204,30 +205,30 @@
 
 			</div>
 			<?php $this->embed('ee:_shared/form/bulk-action-bar', [
-				'options' => [
+				'options'=> [
 					[
-						'value' => "",
-						'text' => '-- ' . lang('with_selected') . ' --'
+						'value'=> "",
+						'text'=> '-- ' . lang('with_selected') . ' --'
 					],
 					[
-						'value' => "remove",
-						'text' => lang('delete'),
-						'attrs' => 'data-confirm-trigger="selected" rel="modal-confirm-remove"'
+						'value'=> "remove",
+						'text'=> lang('delete'),
+						'attrs'=> 'data-confirm-trigger="selected" rel="modal-confirm-remove"'
 					],
 					[
-						'value' => "update",
-						'text' => lang('update'),
-						'attrs' => 'data-confirm-trigger="selected" rel="modal-confirm-update"'
+						'value'=> "update",
+						'text'=> lang('update'),
+						'attrs'=> 'data-confirm-trigger="selected" rel="modal-confirm-update"'
 
 					],
 					[
-						'value' => "install",
-						'text' => lang('install'),
-						'attrs' => 'data-confirm-trigger="selected" rel="modal-confirm-install"'
+						'value'=> "install",
+						'text'=> lang('install'),
+						'attrs'=> 'data-confirm-trigger="selected" rel="modal-confirm-install"'
 
 					]
 				],
-				'modal' => true
+				'modal'=> true
 			]); ?>
 		</form>
 	</div>
@@ -236,64 +237,64 @@
 
 <?php
 
-$modal_vars_install = array(
-	'name' => 'modal-confirm-install',
-	'form_url' => $form_url,
-	'title' => lang('bulk_install_title'),
-	'alert' => lang('bulk_install'),
-	'noTrash' => true,
-	'button' => [
-		'text' => lang('bulk_install_button'),
-		'working' => lang('bulk_install_button')
+$modal_vars_install=array(
+	'name'=> 'modal-confirm-install',
+	'form_url'=> $form_url,
+	'title'=> lang('bulk_install_title'),
+	'alert'=> lang('bulk_install'),
+	'noTrash'=> true,
+	'button'=> [
+		'text'=> lang('bulk_install_button'),
+		'working'=> lang('bulk_install_button')
 	],
-	'hidden' => array(
-		'bulk_action' => 'install'
+	'hidden'=> array(
+		'bulk_action'=> 'install'
 	)
 );
 
-$modal_in = $this->make('ee:_shared/modal_confirm_remove')->render($modal_vars_install);
+$modal_in=$this->make('ee:_shared/modal_confirm_remove')->render($modal_vars_install);
 ee('CP/Modal')->addModal('install', $modal_in);
 ?>
 
 
 <?php
 
-$modal_vars_update = array(
-	'name' => 'modal-confirm-update',
-	'form_url' => $form_url,
-	'title' => lang('bulk_update_title'),
-	'alert' => lang('bulk_update'),
-	'noTrash' => true,
-	'button' => [
-		'text' => lang('bulk_update_button'),
-		'working' => lang('bulk_update_button')
+$modal_vars_update=array(
+	'name'=> 'modal-confirm-update',
+	'form_url'=> $form_url,
+	'title'=> lang('bulk_update_title'),
+	'alert'=> lang('bulk_update'),
+	'noTrash'=> true,
+	'button'=> [
+		'text'=> lang('bulk_update_button'),
+		'working'=> lang('bulk_update_button')
 	],
-	'hidden' => array(
-		'bulk_action' => 'update'
+	'hidden'=> array(
+		'bulk_action'=> 'update'
 	)
 );
 
-$modal_up = $this->make('ee:_shared/modal_confirm_remove')->render($modal_vars_update);
+$modal_up=$this->make('ee:_shared/modal_confirm_remove')->render($modal_vars_update);
 ee('CP/Modal')->addModal('update', $modal_up);
 ?>
 
 
 <?php
 
-$modal_vars = array(
-	'name' => 'modal-confirm-remove',
-	'form_url' => $form_url,
-	'title' => lang('confirm_uninstall'),
-	'alert' => lang('confirm_uninstall_desc'),
-	'button' => [
-		'text' => lang('btn_confirm_and_uninstall'),
-		'working' => lang('btn_confirm_and_uninstall_working')
+$modal_vars=array(
+	'name'=> 'modal-confirm-remove',
+	'form_url'=> $form_url,
+	'title'=> lang('confirm_uninstall'),
+	'alert'=> lang('confirm_uninstall_desc'),
+	'button'=> [
+		'text'=> lang('btn_confirm_and_uninstall'),
+		'working'=> lang('btn_confirm_and_uninstall_working')
 	],
-	'hidden' => array(
-		'bulk_action' => 'remove'
+	'hidden'=> array(
+		'bulk_action'=> 'remove'
 	)
 );
 
-$modal = $this->make('ee:_shared/modal_confirm_remove')->render($modal_vars);
+$modal=$this->make('ee:_shared/modal_confirm_remove')->render($modal_vars);
 ee('CP/Modal')->addModal('delete', $modal);
 ?>

--- a/system/ee/ExpressionEngine/View/addons/index.php
+++ b/system/ee/ExpressionEngine/View/addons/index.php
@@ -68,7 +68,7 @@
 			<div class="js-list-group-wrap">
 				<table id="main_Table" cellspacing="0">
 					<thead>
-						<tr class="app-listing__row app-listing__row--head">
+						<tr class="app-listing__row_h app-listing__row--head">
 							<th class="column-sort-header">
 								<a href="" class="column-sort column-sort--desc"><?php echo lang('name'); ?></a>
 							</th>
@@ -103,7 +103,7 @@
 								<a href="">
 									<div class="addon-name-table d-flex align-items-center">
 										<img src="<?= $addon["icon_url"] ?>" alt="Add-On Name" class="addon-icon-table">
-										<div>
+										<div class = "name_of_addon">
 											<strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"> <?= $addon["description"] ?> </span>
 										</div>
 									</div>
@@ -113,7 +113,7 @@
 								<span class="collapsed-label"><?php echo lang('version'); ?></span>
 								<?= $addon["version"] ?>
 							</td>
-							<td>
+							<td class="manage">
 								<span class="collapsed-label"><?php echo lang('manage'); ?></span>
 								<div class="button-toolbar toolbar">
 									<div class="button-group button-group-xsmall">
@@ -158,7 +158,7 @@
 
 									<div class="addon-name-table d-flex align-items-center">
 										<img src="<?= $addon["icon_url"] ?>" alt="Add-On Name" class="addon-icon-table">
-										<div>
+										<div class = "name_of_addon">
 											<strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"><?= $addon["description"] ?></span>
 										</div>
 									</div>

--- a/system/ee/ExpressionEngine/View/addons/index.php
+++ b/system/ee/ExpressionEngine/View/addons/index.php
@@ -1,5 +1,4 @@
 <?php $this->extend('_templates/default-nav', array(), 'outer_box'); ?>
-
 <div class="panel panel__no-main-title">
 	<div class="tbl-ctrls">
 		<div class="panel-heading">
@@ -178,8 +177,12 @@
 								</td>
 
 								<td class="app-listing__cell app-listing__cell--input text--center">
-									<p> -- </p>
+									<div class="list-item__checkbox">
+										<input name="selection[]" type="checkbox" value="<?= $addon["package"] ?>" data-confirm="<?= $addon["name"] ?>">
+									</div>
 								</td>
+
+
 							</tr>
 
 						<?php endforeach; ?>
@@ -201,6 +204,18 @@
 						'value' => "remove",
 						'text' => lang('delete'),
 						'attrs' => 'data-confirm-trigger="selected" rel="modal-confirm-remove"'
+					],
+					[
+						'value' => "update",
+						'text' => lang('update'),
+						'attrs' => 'data-confirm-trigger="selected" rel="modal-confirm-update"'
+
+					],
+					[
+						'value' => "install",
+						'text' => lang('install'),
+						'attrs' => 'data-confirm-trigger="selected" rel="modal-confirm-install"'
+
 					]
 				],
 				'modal' => true
@@ -209,6 +224,49 @@
 	</div>
 
 </div>
+
+<?php
+
+$modal_vars_install = array(
+	'name' => 'modal-confirm-install',
+	'form_url' => $form_url,
+	'title' => lang('bulk_install_title'),
+	'alert' => lang('bulk_install'),
+	'noTrash' => true,
+	'button' => [
+		'text' => lang('bulk_install_button'),
+		'working' => lang('bulk_install_button')
+	],
+	'hidden' => array(
+		'bulk_action' => 'install'
+	)
+);
+
+$modal_in = $this->make('ee:_shared/modal_confirm_remove')->render($modal_vars_install);
+ee('CP/Modal')->addModal('install', $modal_in);
+?>
+
+
+<?php
+
+$modal_vars_update = array(
+	'name' => 'modal-confirm-update',
+	'form_url' => $form_url,
+	'title' => lang('bulk_update_title'),
+	'alert' => lang('bulk_update'),
+	'noTrash' => true,
+	'button' => [
+		'text' => lang('bulk_update_button'),
+		'working' => lang('bulk_update_button')
+	],
+	'hidden' => array(
+		'bulk_action' => 'update'
+	)
+);
+
+$modal_up = $this->make('ee:_shared/modal_confirm_remove')->render($modal_vars_update);
+ee('CP/Modal')->addModal('update', $modal_up);
+?>
 
 
 <?php

--- a/system/ee/ExpressionEngine/View/addons/index.php
+++ b/system/ee/ExpressionEngine/View/addons/index.php
@@ -1,300 +1,304 @@
-<?php $this->extend('_templates/default-nav', array(), 'outer_box'); ?>
-<div class="panel panel__no-main-title">
-	<div class="tbl-ctrls">
-		<div class="panel-heading">
-			<div class="app-notice-wrap"><?=ee('CP/Alert')->getAllInlines() ?></div>
-			<?php if (!empty($updates) && count($updates)==1) : ?>
-				<div id="alert_banner" class="alert">
-					<div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
-					<div id="alert" class="alert__close">
-						<a id="alert_close" class="fas fa-times alert__close-icon"></a>
-					</div>
-					<p class="alert__title"> <br>
-					<p class="alert__title"><?php echo lang('update'); ?><br>
-						<?php 
-						$count=count($updates);
-						echo sprintf(lang('single_update'), $count); 
-						?>
-						
-						<a id="show_me"><?php echo lang('show'); ?></a>
-					</p>
-						
-				</div>
-			<?php endif; ?>
+<head>
 
-			<?php if (!empty($updates) && count($updates) > 1) : ?>
-				<div id="alert_banner" class="alert">
-					<div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
-					<div id="alert" class="alert__close">
-						<a id="alert_close" class="fas fa-times alert__close-icon"></a>
-					</div>
-					<p class="alert__title"><?php echo lang('updates'); ?><br>
-						
-						<?php 
-						$count=count($updates);
-						echo sprintf(lang('multi_updates'), $count); 
-						?>
-						<a id="show_me"><?php echo lang('show'); ?></a>
-					</p>
-				</div>
-			<?php endif; ?>
+</head>
 
-			
-
-
-			<div class="form-btns form-btns-top">
-				<div class="title-bar js-filters-collapsable title-bar--large">
-					<div class="filter-bar">
-						<div class="filter-bar__item ">
-							<div class="filter-search-bar__item ">
-								<button id = "current_status" type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="status" title="status"><?php echo lang('all_addons'); ?></button>
-								<div id = "drop_down" class="dropdown">
-									<div class="dropdown__scroll">
-										<a class="dropdown__link" id="show_all"><?php echo lang('all_addons'); ?></a>
-										<a class="dropdown__link" id="installed_sort"><?php echo lang('installed'); ?></a>
-										<a class="dropdown__link" id="uninstalled_sort"><?php echo lang('uninstalled'); ?></a>
-										<a class="dropdown__link" id="update_sort"><?php echo lang('update_available'); ?></a>
-									</div>
-								</div>
-							</div>
-						</div>
-						<div class="filter-bar__item filter-search-form">
-							<div class="filter-search-bar__item">
-								<div class="search-input">
-									<input id="search_term" class="search-input__input input--small" type="text" name="filter_by_keyword" value="" placeholder="Search">
-								</div>
-							</div>
-						</div>
-
-						
-
-					</div>
-				</div>
+<body>
+	<?php $this->extend('_templates/default-nav', array(), 'outer_box'); ?>
+	<div style="width: 100%;">
+		<div style="float: left; width: 20%" class="secondary-sidebar">
+			<div class="box sidebar">
+				<h4 class="sidebar__section-title "><?php echo lang('sidebar_sort'); ?></h4>
+				<a style="cursor: pointer;" class="sidebar__link active" id="show_all"><?php echo lang('all_addons'); ?></a>
+				<a style="cursor: pointer;" class="sidebar__link" id="installed_sort"><?php echo lang('installed'); ?></a>
+				<a style="cursor: pointer;" class="sidebar__link" id="uninstalled_sort"><?php echo lang('uninstalled'); ?></a>
+				<a style="cursor: pointer;" class="sidebar__link" id="update_sort"><?php echo lang('update_available'); ?></a>
 			</div>
 		</div>
 
+		<div style="margin-left: 20%;" class="container">
+			<div class="panel panel__no-main-title">
+				<div class="tbl-ctrls">
+					<div class="panel-heading">
+						<div class="app-notice-wrap"><?= ee('CP/Alert')->getAllInlines() ?></div>
+						<?php if (!empty($updates) && count($updates) == 1) : ?>
+							<div id="alert_banner" class="alert">
+								<div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
+								<div id="alert" class="alert__close">
+									<a id="alert_close" class="fas fa-times alert__close-icon"></a>
+								</div>
+								<p class="alert__title"> <br>
+								<p class="alert__title"><?php echo lang('update'); ?><br>
+									<?php
+									$count = count($updates);
+									echo sprintf(lang('single_update'), $count);
+									?>
 
-		<form class="form-standard-unique">
-			<div class="js-list-group-wrap">
-				<table id="main_Table" cellspacing="0">
-					<thead>
-						<tr class="app-listing__row_h app-listing__row--head">
-							<th class="column-sort-header">
-								<a href="" class="column-sort column-sort--desc"><?php echo lang('name'); ?></a>
-							</th>
-							<th class="column-sort-header">
-								<a href="" class="column-sort column-sort--desc"><?php echo lang('version'); ?></a>
-							</th>
-							<th class="column-sort-header">
-								<a class="column-sort column-sort--desc"><?php echo lang('manage'); ?></a>
-							</th>
-							<th class="app-listing__header text--center">
-								<label><?php echo lang('uninstall'); ?> </label>
-							</th>
+									<a id="show_me"><?php echo lang('show'); ?></a>
+								</p>
 
-							<th class="app-listing__header text--center">
-								<label ><?php echo lang('select_all'); ?></label>
-								<input  class="input--no-mrg" type="checkbox" title="Select All">
-							</th>
-						</tr>
-					</thead>
+							</div>
+						<?php endif; ?>
 
-					<tbody class="list-group">
-						<?php $addons=$installed;
-						foreach ($addons as $addon) : ?>
+						<?php if (!empty($updates) && count($updates) > 1) : ?>
+							<div id="alert_banner" class="alert">
+								<div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
+								<div id="alert" class="alert__close">
+									<a id="alert_close" class="fas fa-times alert__close-icon"></a>
+								</div>
+								<p class="alert__title"><?php echo lang('updates'); ?><br>
 
-							<?php if (isset($addon['update'])) {
-								echo '<tr  class="app-listing__row_update">';
-							} else {
-								echo '<tr  class="app-listing__row">';
-							} ?>
-							<td>
-								<span class="collapsed-label"><?php echo lang('name'); ?></span>
-								<a>
-									<div class="addon-name-table d-flex align-items-center">
-										<img src="<?=$addon["icon_url"] ?>" class="addon-icon-table">
-										<div class="name_of_addon">
-											<strong><?=$addon["name"] ?></strong><br><span class="meta-info text-muted"> <?=$addon["description"] ?> </span>
+									<?php
+									$count = count($updates);
+									echo sprintf(lang('multi_updates'), $count);
+									?>
+									<a id="show_me"><?php echo lang('show'); ?></a>
+								</p>
+							</div>
+						<?php endif; ?>
+
+
+
+
+						<div class="form-btns form-btns-top">
+							<div class="title-bar js-filters-collapsable title-bar--large">
+								<div class="filter-bar">
+									<div class="filter-bar__item filter-search-form">
+										<div class="filter-search-bar__item">
+											<div class="search-input">
+												<input id="search_term" class="search-input__input input--small" type="text" name="filter_by_keyword" value="" placeholder="Search">
+											</div>
 										</div>
 									</div>
-								</a>
-							</td>
-							<td>
-								<span class="collapsed-label"><?php echo lang('version'); ?></span>
-								<?=$addon["version"] ?>
-							</td>
-							<td class="manage">
-								<span class="collapsed-label"><?php echo lang('manage'); ?></span>
-								<div class="button-toolbar toolbar">
-									<div class="button-group button-group-xsmall">
-
-										<?php if (isset($addon['manual_url'])) : ?>
-											<a href="<?=$addon['manual_url'] ?>" class="manual button button--default" <?php if ($addon['manual_external']) {
-																															echo 'rel="external"';
-																														} ?>></a>
-										<?php endif; ?>
-
-										<?php if (isset($addon['settings_url'])) : ?><a class="settings button button--default" href="<?=$addon['settings_url'] ?>" title=<?=lang('settings') ?>><span class="hidden"><?=lang('settings') ?></span></a> <?php endif; ?>
-
-										<?php if (isset($addon['update'])) : ?> <a href="" data-post-url="<?=$addon['update_url'] ?>" class="button button--primary button--small">
-												<?php echo sprintf(lang('update_to_version'), '<br />' . $addon['update']); ?>
-											</a> <?php endif; ?>
-
-									</div>
 								</div>
-							</td>
+							</div>
+						</div>
+					</div>
 
 
-							<td class="app-listing__cell app-listing__cell--input text--center">
-								<?php if (ee('Permission')->hasAll('can_admin_addons') && $addon['installed']) : ?>
-									<a href="<?=$addon['remove_url'] ?>" class="button button--primary button--small" onclick="return confirm('<?php echo lang('confirm'); ?> <?=$addon['name'] ?>')"><?=lang('uninstall') ?></a>
-								<?php endif; ?>
-							</td>
+					<form class="form-standard-unique">
+						<div class="js-list-group-wrap">
+							<table id="main_Table" cellspacing="0">
+								<thead>
+									<tr class="app-listing__row_h app-listing__row--head">
+										<th class="column-sort-header">
+											<a href="" class="column-sort column-sort--desc"><?php echo lang('name'); ?></a>
+										</th>
+										<th class="column-sort-header">
+											<a href="" class="column-sort column-sort--desc"><?php echo lang('version'); ?></a>
+										</th>
+										<th class="column-sort-header">
+											<a class="column-sort column-sort--desc"><?php echo lang('manage'); ?></a>
+										</th>
+										<th class="app-listing__header text--center">
+											<label><?php echo lang('uninstall'); ?> </label>
+										</th>
 
-							<td class="app-listing__cell app-listing__cell--input text--center">
-								<div class="list-item__checkbox">
-									<input name="selection[]" type="checkbox" value="<?=$addon["package"] ?>" data-confirm="<?=$addon["name"] ?>">
-								</div>
-							</td>
+										<th class="app-listing__header text--center">
+											<label><?php echo lang('select_all'); ?></label>
+											<input class="input--no-mrg" type="checkbox" title="Select All">
+										</th>
+									</tr>
+								</thead>
+
+								<tbody class="list-group">
+									<?php $addons = $installed;
+									foreach ($addons as $addon) : ?>
+
+										<?php if (isset($addon['update'])) {
+											echo '<tr  class="app-listing__row_update">';
+										} else {
+											echo '<tr  class="app-listing__row">';
+										} ?>
+										<td>
+											<span class="collapsed-label"><?php echo lang('name'); ?></span>
+											<a>
+												<div class="addon-name-table d-flex align-items-center">
+													<img src="<?= $addon["icon_url"] ?>" class="addon-icon-table">
+													<div class="name_of_addon">
+														<strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"> <?= $addon["description"] ?> </span>
+													</div>
+												</div>
+											</a>
+										</td>
+										<td>
+											<span class="collapsed-label"><?php echo lang('version'); ?></span>
+											<?= $addon["version"] ?>
+										</td>
+										<td class="manage">
+											<span class="collapsed-label"><?php echo lang('manage'); ?></span>
+											<div class="button-toolbar toolbar">
+												<div class="button-group button-group-xsmall">
+
+													<?php if (isset($addon['manual_url'])) : ?>
+														<a href="<?= $addon['manual_url'] ?>" class="manual button button--default" <?php if ($addon['manual_external']) {
+																																		echo 'rel="external"';
+																																	} ?>></a>
+													<?php endif; ?>
+
+													<?php if (isset($addon['settings_url'])) : ?><a class="settings button button--default" href="<?= $addon['settings_url'] ?>" title=<?= lang('settings') ?>><span class="hidden"><?= lang('settings') ?></span></a> <?php endif; ?>
+
+													<?php if (isset($addon['update'])) : ?> <a href="" data-post-url="<?= $addon['update_url'] ?>" class="button button--primary button--small">
+															<?php echo sprintf(lang('update_to_version'), '<br />' . $addon['update']); ?>
+														</a> <?php endif; ?>
+
+												</div>
+											</div>
+										</td>
 
 
-						<?php endforeach; ?>
+										<td class="app-listing__cell app-listing__cell--input text--center">
+											<?php if (ee('Permission')->hasAll('can_admin_addons') && $addon['installed']) : ?>
+												<a href="<?= $addon['remove_url'] ?>" class="button button--primary button--small" onclick="return confirm('<?php echo lang('confirm'); ?> <?= $addon['name'] ?>')"><?= lang('uninstall') ?></a>
+											<?php endif; ?>
+										</td>
 
-						<?php $addons=$installed;
-						foreach ($uninstalled as $addon) : ?>
-							<tr class="app-listing__row_uninstalled">
-								<td>
-									<span class="collapsed-label"><?php echo lang('name'); ?></span>
-
-									<div class="addon-name-table d-flex align-items-center">
-										<img src="<?=$addon["icon_url"] ?>" class="addon-icon-table">
-										<div class="name_of_addon">
-											<strong><?=$addon["name"] ?></strong><br><span class="meta-info text-muted"><?=$addon["description"] ?></span>
-										</div>
-									</div>
-
-								</td>
-								<td>
-									<span class="collapsed-label"><?php echo lang('version'); ?></span>
-									<?=$addon["version"] ?>
-								</td>
-								<td>
-									<span class="collapsed-label"><?php echo lang('manage'); ?></span>
-									<a href="" data-post-url="<?=$addon['install_url'] ?>" class="button button--primary button--small"><?=lang('install') ?></a>
-								</td>
-								<td class="app-listing__cell app-listing__cell--input text--center">
-									<p> -- </p>
-								</td>
-
-								<td class="app-listing__cell app-listing__cell--input text--center">
-									<div class="list-item__checkbox">
-										<input name="selection[]" type="checkbox" value="<?=$addon["package"] ?>" data-confirm="<?=$addon["name"] ?>">
-									</div>
-								</td>
+										<td class="app-listing__cell app-listing__cell--input text--center">
+											<div class="list-item__checkbox">
+												<input name="selection[]" type="checkbox" value="<?= $addon["package"] ?>" data-confirm="<?= $addon["name"] ?>">
+											</div>
+										</td>
 
 
-							</tr>
+									<?php endforeach; ?>
 
-						<?php endforeach; ?>
+									<?php $addons = $installed;
+									foreach ($uninstalled as $addon) : ?>
+										<tr class="app-listing__row_uninstalled">
+											<td>
+												<span class="collapsed-label"><?php echo lang('name'); ?></span>
+
+												<div class="addon-name-table d-flex align-items-center">
+													<img src="<?= $addon["icon_url"] ?>" class="addon-icon-table">
+													<div class="name_of_addon">
+														<strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"><?= $addon["description"] ?></span>
+													</div>
+												</div>
+
+											</td>
+											<td>
+												<span class="collapsed-label"><?php echo lang('version'); ?></span>
+												<?= $addon["version"] ?>
+											</td>
+											<td>
+												<span class="collapsed-label"><?php echo lang('manage'); ?></span>
+												<a href="" data-post-url="<?= $addon['install_url'] ?>" class="button button--primary button--small"><?= lang('install') ?></a>
+											</td>
+											<td class="app-listing__cell app-listing__cell--input text--center">
+												<p> -- </p>
+											</td>
+
+											<td class="app-listing__cell app-listing__cell--input text--center">
+												<div class="list-item__checkbox">
+													<input name="selection[]" type="checkbox" value="<?= $addon["package"] ?>" data-confirm="<?= $addon["name"] ?>">
+												</div>
+											</td>
+
+
+										</tr>
+
+									<?php endforeach; ?>
 
 
 
-					</tbody>
+								</tbody>
 
-				</table>
+							</table>
+
+						</div>
+						<?php $this->embed('ee:_shared/form/bulk-action-bar', [
+							'options' => [
+								[
+									'value' => "",
+									'text' => '-- ' . lang('with_selected') . ' --'
+								],
+								[
+									'value' => "remove",
+									'text' => lang('delete'),
+									'attrs' => 'data-confirm-trigger="selected" rel="modal-confirm-remove"'
+								],
+								[
+									'value' => "update",
+									'text' => lang('update'),
+									'attrs' => 'data-confirm-trigger="selected" rel="modal-confirm-update"'
+
+								],
+								[
+									'value' => "install",
+									'text' => lang('install'),
+									'attrs' => 'data-confirm-trigger="selected" rel="modal-confirm-install"'
+
+								]
+							],
+							'modal' => true
+						]); ?>
+					</form>
+				</div>
 
 			</div>
-			<?php $this->embed('ee:_shared/form/bulk-action-bar', [
-				'options'=> [
-					[
-						'value'=> "",
-						'text'=> '-- ' . lang('with_selected') . ' --'
-					],
-					[
-						'value'=> "remove",
-						'text'=> lang('delete'),
-						'attrs'=> 'data-confirm-trigger="selected" rel="modal-confirm-remove"'
-					],
-					[
-						'value'=> "update",
-						'text'=> lang('update'),
-						'attrs'=> 'data-confirm-trigger="selected" rel="modal-confirm-update"'
-
-					],
-					[
-						'value'=> "install",
-						'text'=> lang('install'),
-						'attrs'=> 'data-confirm-trigger="selected" rel="modal-confirm-install"'
-
-					]
-				],
-				'modal'=> true
-			]); ?>
-		</form>
+		</div>
 	</div>
 
-</div>
+	<?php
 
-<?php
+	$modal_vars_install = array(
+		'name' => 'modal-confirm-install',
+		'form_url' => $form_url,
+		'title' => lang('bulk_install_title'),
+		'alert' => lang('bulk_install'),
+		'noTrash' => true,
+		'button' => [
+			'text' => lang('bulk_install_button'),
+			'working' => lang('bulk_install_button')
+		],
+		'hidden' => array(
+			'bulk_action' => 'install'
+		)
+	);
 
-$modal_vars_install=array(
-	'name'=> 'modal-confirm-install',
-	'form_url'=> $form_url,
-	'title'=> lang('bulk_install_title'),
-	'alert'=> lang('bulk_install'),
-	'noTrash'=> true,
-	'button'=> [
-		'text'=> lang('bulk_install_button'),
-		'working'=> lang('bulk_install_button')
-	],
-	'hidden'=> array(
-		'bulk_action'=> 'install'
-	)
-);
-
-$modal_in=$this->make('ee:_shared/modal_confirm_remove')->render($modal_vars_install);
-ee('CP/Modal')->addModal('install', $modal_in);
-?>
+	$modal_in = $this->make('ee:_shared/modal_confirm_remove')->render($modal_vars_install);
+	ee('CP/Modal')->addModal('install', $modal_in);
+	?>
 
 
-<?php
+	<?php
 
-$modal_vars_update=array(
-	'name'=> 'modal-confirm-update',
-	'form_url'=> $form_url,
-	'title'=> lang('bulk_update_title'),
-	'alert'=> lang('bulk_update'),
-	'noTrash'=> true,
-	'button'=> [
-		'text'=> lang('bulk_update_button'),
-		'working'=> lang('bulk_update_button')
-	],
-	'hidden'=> array(
-		'bulk_action'=> 'update'
-	)
-);
+	$modal_vars_update = array(
+		'name' => 'modal-confirm-update',
+		'form_url' => $form_url,
+		'title' => lang('bulk_update_title'),
+		'alert' => lang('bulk_update'),
+		'noTrash' => true,
+		'button' => [
+			'text' => lang('bulk_update_button'),
+			'working' => lang('bulk_update_button')
+		],
+		'hidden' => array(
+			'bulk_action' => 'update'
+		)
+	);
 
-$modal_up=$this->make('ee:_shared/modal_confirm_remove')->render($modal_vars_update);
-ee('CP/Modal')->addModal('update', $modal_up);
-?>
+	$modal_up = $this->make('ee:_shared/modal_confirm_remove')->render($modal_vars_update);
+	ee('CP/Modal')->addModal('update', $modal_up);
+	?>
 
 
-<?php
+	<?php
 
-$modal_vars=array(
-	'name'=> 'modal-confirm-remove',
-	'form_url'=> $form_url,
-	'title'=> lang('confirm_uninstall'),
-	'alert'=> lang('confirm_uninstall_desc'),
-	'button'=> [
-		'text'=> lang('btn_confirm_and_uninstall'),
-		'working'=> lang('btn_confirm_and_uninstall_working')
-	],
-	'hidden'=> array(
-		'bulk_action'=> 'remove'
-	)
-);
+	$modal_vars = array(
+		'name' => 'modal-confirm-remove',
+		'form_url' => $form_url,
+		'title' => lang('confirm_uninstall'),
+		'alert' => lang('confirm_uninstall_desc'),
+		'button' => [
+			'text' => lang('btn_confirm_and_uninstall'),
+			'working' => lang('btn_confirm_and_uninstall_working')
+		],
+		'hidden' => array(
+			'bulk_action' => 'remove'
+		)
+	);
 
-$modal=$this->make('ee:_shared/modal_confirm_remove')->render($modal_vars);
-ee('CP/Modal')->addModal('delete', $modal);
-?>
+	$modal = $this->make('ee:_shared/modal_confirm_remove')->render($modal_vars);
+	ee('CP/Modal')->addModal('delete', $modal);
+	?>
+</body>

--- a/system/ee/ExpressionEngine/View/addons/index.php
+++ b/system/ee/ExpressionEngine/View/addons/index.php
@@ -47,13 +47,13 @@
 					<div class="filter-bar">
 						<div class="filter-bar__item ">
 							<div class="filter-search-bar__item ">
-								<button id = "current_status" type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="status" title="status"><?php echo lang('filter_by_status'); ?></button>
-								<div class="dropdown">
+								<button id = "current_status" type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="status" title="status"><?php echo lang('all_addons'); ?></button>
+								<div id = "drop_down" class="dropdown">
 									<div class="dropdown__scroll">
+										<a class="dropdown__link" id="show_all"><?php echo lang('all_addons'); ?></a>
 										<a class="dropdown__link" id="installed_sort"><?php echo lang('installed'); ?></a>
 										<a class="dropdown__link" id="uninstalled_sort"><?php echo lang('uninstalled'); ?></a>
 										<a class="dropdown__link" id="update_sort"><?php echo lang('update_available'); ?></a>
-										<a class="dropdown__link" id="show_all"><?php echo lang('all_addons'); ?></a>
 									</div>
 								</div>
 							</div>

--- a/system/ee/ExpressionEngine/View/addons/index.php
+++ b/system/ee/ExpressionEngine/View/addons/index.php
@@ -6,25 +6,38 @@
 			<?php if (!empty($updates) && count($updates) == 1) : ?>
 				<div id="alert_banner" class="alert">
 					<div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
-					<div id="alert" href="" class="alert__close">
+					<div id="alert" class="alert__close">
 						<a id="alert_close" class="fas fa-times alert__close-icon"></a>
 					</div>
 					<p class="alert__title"> <br>
 					<p class="alert__title"><?php echo lang('update'); ?><br>
-						<?php echo lang('there_is'); ?> <strong><?= count($updates) ?></strong> <?php echo lang('single_update'); ?> <a id="ShowMe"><?php echo lang('show'); ?></a></p>
+						<?php
+						$there = lang('there_is');
+						$single = lang('single_update');
+						$count = count($updates);
+						echo sprintf($there, $count , $single);
+						?>
+						<a id="show_me"><?php echo lang('show'); ?></a>
+					</p>
+						
 				</div>
 			<?php endif; ?>
 
 			<?php if (!empty($updates) && count($updates) > 1) : ?>
 				<div id="alert_banner" class="alert">
 					<div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
-					<div id="alert" href="" class="alert__close">
+					<div id="alert" class="alert__close">
 						<a id="alert_close" class="fas fa-times alert__close-icon"></a>
 					</div>
 					<p class="alert__title"><?php echo lang('updates'); ?><br>
-
-						<?php echo lang('there_are'); ?> <strong><?= count($updates) ?></strong> <?php echo lang('multi_updates'); ?> <a id="ShowMe"><?php echo lang('show'); ?></a></p>
-					<p></p>
+						<?php
+						$there = lang('there_are');
+						$multi = lang('multi_updates');
+						$count = count($updates);
+						echo sprintf($there, $count , $multi);
+						?>
+						<a id="show_me"><?php echo lang('show'); ?></a>
+					</p>
 				</div>
 			<?php endif; ?>
 
@@ -34,12 +47,12 @@
 					<div class="filter-bar">
 						<div class="filter-bar__item ">
 							<div class="filter-search-bar__item ">
-								<button type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="status" title="status">status</button>
+								<button type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="status" title="status"><?php echo lang('filter_by_status'); ?></button>
 								<div class="dropdown">
 									<div class="dropdown__scroll">
-										<a class="dropdown__link" id="Installed_Sort"><?php echo lang('installed'); ?></a>
-										<a class="dropdown__link" id="Uninstalled_Sort"><?php echo lang('uninstalled'); ?></a>
-										<a class="dropdown__link" id="Update_Sort"><?php echo lang('update_available'); ?></a>
+										<a class="dropdown__link" id="installed_sort"><?php echo lang('installed'); ?></a>
+										<a class="dropdown__link" id="uninstalled_sort"><?php echo lang('uninstalled'); ?></a>
+										<a class="dropdown__link" id="update_sort"><?php echo lang('update_available'); ?></a>
 									</div>
 								</div>
 							</div>
@@ -47,17 +60,13 @@
 						<div class="filter-bar__item filter-search-form">
 							<div class="filter-search-bar__item">
 								<div class="search-input">
-									<input id="Search_Term" class="search-input__input input--small" type="text" name="filter_by_keyword" value="" placeholder="Search">
+									<input id="search_term" class="search-input__input input--small" type="text" name="filter_by_keyword" value="" placeholder="Search">
 								</div>
 							</div>
 						</div>
 
-						<script src="themes\ee\cp\js\src\cp\add-ons-index.js">
+						<?php ee()->cp->add_js_script(array('file' => array('cp/addons/add-ons-index'),)); ?>
 
-						</script>
-						<div class="filter-bar__item ">
-
-						</div>
 					</div>
 				</div>
 			</div>
@@ -83,8 +92,8 @@
 							</th>
 
 							<th class="app-listing__header text--center">
-								<label for="tbl_6092f7c1be4f4-select-all">Select All</label>
-								<input id="tbl_6092f7c1be4f4-select-all" class="input--no-mrg" type="checkbox" title="Select All">
+								<label ><?php echo lang('select_all'); ?></label>
+								<input  class="input--no-mrg" type="checkbox" title="Select All">
 							</th>
 						</tr>
 					</thead>
@@ -100,9 +109,9 @@
 							} ?>
 							<td>
 								<span class="collapsed-label"><?php echo lang('name'); ?></span>
-								<a href="">
+								<a>
 									<div class="addon-name-table d-flex align-items-center">
-										<img src="<?= $addon["icon_url"] ?>" alt="Add-On Name" class="addon-icon-table">
+										<img src="<?= $addon["icon_url"] ?>" class="addon-icon-table">
 										<div class = "name_of_addon">
 											<strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"> <?= $addon["description"] ?> </span>
 										</div>
@@ -124,7 +133,7 @@
 																														} ?>></a>
 										<?php endif; ?>
 
-										<?php if (isset($addon['settings_url'])) : ?><a class="settings button button--default" href="<?= $addon['settings_url'] ?>" title="Settings"><span class="hidden">Settings</span></a> <?php endif; ?>
+										<?php if (isset($addon['settings_url'])) : ?><a class="settings button button--default" href="<?= $addon['settings_url'] ?>" title="Settings"><span class="hidden"><?= lang('settings') ?></span></a> <?php endif; ?>
 
 										<?php if (isset($addon['update'])) : ?> <a href="" data-post-url="<?= $addon['update_url'] ?>" class="button button--primary button--small">
 												<?php echo sprintf(lang('update_to_version'), '<br />' . $addon['update']); ?>
@@ -157,7 +166,7 @@
 									<span class="collapsed-label"><?php echo lang('name'); ?></span>
 
 									<div class="addon-name-table d-flex align-items-center">
-										<img src="<?= $addon["icon_url"] ?>" alt="Add-On Name" class="addon-icon-table">
+										<img src="<?= $addon["icon_url"] ?>" class="addon-icon-table">
 										<div class = "name_of_addon">
 											<strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"><?= $addon["description"] ?></span>
 										</div>

--- a/system/ee/ExpressionEngine/View/addons/index.php
+++ b/system/ee/ExpressionEngine/View/addons/index.php
@@ -1,323 +1,232 @@
 <?php $this->extend('_templates/default-nav', array(), 'outer_box'); ?>
 
 <div class="panel panel__no-main-title">
-  <div class="tbl-ctrls">
-       <form>
-      <div class="panel-heading">
-        <div class="app-notice-wrap"><?=ee('CP/Alert')->getAllInlines()?></div>
+	<div class="tbl-ctrls">
+		<div class="panel-heading">
+			<div class="app-notice-wrap"><?= ee('CP/Alert')->getAllInlines() ?></div>
+			<?php if (!empty($updates) && count($updates) == 1) : ?>
+				<div id="alert_banner" class="alert">
+					<div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
+					<div id="alert" href="" class="alert__close">
+						<a id="alert_close" class="fas fa-times alert__close-icon"></a>
+					</div>
+					<p class="alert__title"> <br>
+					<p class="alert__title"><?php echo lang('update'); ?><br>
+						<?php echo lang('there_is'); ?> <strong><?= count($updates) ?></strong> <?php echo lang('single_update'); ?> <a id="ShowMe"><?php echo lang('show'); ?></a></p>
+				</div>
+			<?php endif; ?>
 
-        
-          
-            
+			<?php if (!empty($updates) && count($updates) > 1) : ?>
+				<div id="alert_banner" class="alert">
+					<div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
+					<div id="alert" href="" class="alert__close">
+						<a id="alert_close" class="fas fa-times alert__close-icon"></a>
+					</div>
+					<p class="alert__title"><?php echo lang('updates'); ?><br>
 
-            <?php if (! empty($updates) && count($updates) == 1 ) : ?>
-              <div id = "alert_banner" class="alert">
-              <div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
-              <?php
-              echo '<div id = "alert" href="" class="alert__close">';
-              echo '<a onclick="hide()" id = "alert_close" class="fas fa-times alert__close-icon"></a>';
-              echo '</div>';
-              ?>
-                <p class="alert__title">Update Available <br> 
-                There is <strong><?=count($updates)?></strong> installed add-on with updates available. <a onclick = "typeFilter('app-listing__row_update')">Show me...</a></p>
-                <p></p>
-              </div>
-            <?php endif; ?>
-
-            <?php if (! empty($updates) && count($updates) > 1 ) : ?>
-              <div id = "alert_banner" class="alert">
-              <div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
-              <?php
-              echo '<div id = "alert" href="" class="alert__close">';
-              echo '<a onclick="hide()" id = "alert_close" class="fas fa-times alert__close-icon"></a>';
-              echo '</div>';
-              ?>
-                <p class="alert__title">Updates Available <br> 
-                There are <strong><?=count($updates)?></strong> installed add-on with updates available. <a onclick = "typeFilter('app-listing__row_update')">Show me...</a></p>
-                <p></p>
-              </div>
-            <?php endif; ?>
-
-            <script> 
-              function hide() { 
-                document.getElementById("alert_banner").style.display='none'; 
-                return false;
-              }
-            </script> 
-            
-          
-        
-        
+						<?php echo lang('there_are'); ?> <strong><?= count($updates) ?></strong> <?php echo lang('multi_updates'); ?> <a id="ShowMe"><?php echo lang('show'); ?></a></p>
+					<p></p>
+				</div>
+			<?php endif; ?>
 
 
-        <div class="form-btns form-btns-top">
-          <div class="title-bar js-filters-collapsable title-bar--large">
-            <h3 class="title-bar__title">Add-Ons</h3>
-            <div class="filter-bar">
-    					<div class="filter-bar__item ">
-        				<div class="filter-search-bar__item ">
-                	<button type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="status" title="status">status</button>
-                	<div class="dropdown">
-                    <div class="dropdown__scroll">
-					            <a class="dropdown__link" onclick = "typeFilter('app-listing__row')" >Installed</a>
-                      <a class="dropdown__link"  onclick = "typeFilter('app-listing__row_uninstalled')">Uninstalled</a>
-                      <a class="dropdown__link"  onclick = "typeFilter('app-listing__row_update')">Update Available</a>
-            				</div>
-                	</div>
-              	</div>
-        			</div>
-    					<div class="filter-bar__item filter-search-form">
-        				<div class="filter-search-bar__item">
-                	<div class="search-input">
-                		<input id = "Search_Term" class="search-input__input input--small" type="text" name="filter_by_keyword" value="" placeholder="Search" onkeyup="searchFilter()">
-                	</div>
-                </div>
-        			</div>
+			<div class="form-btns form-btns-top">
+				<div class="title-bar js-filters-collapsable title-bar--large">
+					<div class="filter-bar">
+						<div class="filter-bar__item ">
+							<div class="filter-search-bar__item ">
+								<button type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="status" title="status">status</button>
+								<div class="dropdown">
+									<div class="dropdown__scroll">
+										<a class="dropdown__link" id="Installed_Sort"><?php echo lang('installed'); ?></a>
+										<a class="dropdown__link" id="Uninstalled_Sort"><?php echo lang('uninstalled'); ?></a>
+										<a class="dropdown__link" id="Update_Sort"><?php echo lang('update_available'); ?></a>
+									</div>
+								</div>
+							</div>
+						</div>
+						<div class="filter-bar__item filter-search-form">
+							<div class="filter-search-bar__item">
+								<div class="search-input">
+									<input id="Search_Term" class="search-input__input input--small" type="text" name="filter_by_keyword" value="" placeholder="Search">
+								</div>
+							</div>
+						</div>
 
-              <script>
-                function searchFilter() {
-                var input, filter, table, tr, td, i, txtValue;
-                input = document.getElementById("Search_Term");
-                filter = input.value.toUpperCase();
-                table = document.getElementById("main_Table");
-                tr = table.getElementsByTagName("tr");
-                for (i = 0; i < tr.length; i++) {
-                  td = tr[i].getElementsByTagName("strong")[0];
-                  if (td) {
-                    txtValue = td.textContent || td.innerText;
-                    if (txtValue.toUpperCase().indexOf(filter) > -1) {
-                      tr[i].style.display = "";
-                    } else {
-                      tr[i].style.display = "none";
-                    }
-                  }       
-                }
-              }
+						<script src="themes\ee\cp\js\src\cp\add-ons-index.js">
 
-              function typeFilter(input){
-                var table, vr;
-                table = document.getElementById("main_Table");
-                tr = table.getElementsByTagName("tr");
+						</script>
+						<div class="filter-bar__item ">
 
-                for (i = 0; i < tr.length; i++) {
-                   if(tr[i].className == input){
-                    tr[i].style.display = "";
-                   }else {
-                      tr[i].style.display = "none";
-                   }
-                }
-                return false;
-              }
-              </script>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
 
 
-
-    					<div class="filter-bar__item ">
-
-        			</div>
-          	</div>
-          </div>
-        </div>
-      </div>
-      <div class="table-responsive table-responsive--collapsible">
-        <table id = "main_Table" cellspacing="0">
-  				<thead>
-      			<tr class="app-listing__row app-listing__row--head">
-							<th class="column-sort-header column-sort-header--active">
-								<a href="" class="column-sort column-sort--desc">Name</a>
+		<form class="form-standard-unique">
+			<div class="js-list-group-wrap">
+				<table id="main_Table" cellspacing="0">
+					<thead>
+						<tr class="app-listing__row app-listing__row--head">
+							<th class="column-sort-header">
+								<a href="" class="column-sort column-sort--desc"><?php echo lang('name'); ?></a>
 							</th>
 							<th class="column-sort-header">
-								<a href="" class="column-sort column-sort--desc">Version</a>
+								<a href="" class="column-sort column-sort--desc"><?php echo lang('version'); ?></a>
 							</th>
 							<th class="column-sort-header">
-								<a class="column-sort column-sort--desc">Manage</a>
+								<a class="column-sort column-sort--desc"><?php echo lang('manage'); ?></a>
 							</th>
 							<th class="app-listing__header text--center">
-								<label for="tbl_6092f7c1be4f4-select-all" >Uninstall </label>
-								
+								<label><?php echo lang('uninstall'); ?> </label>
+							</th>
+
+							<th class="app-listing__header text--center">
+								<label for="tbl_6092f7c1be4f4-select-all">Select All</label>
+								<input id="tbl_6092f7c1be4f4-select-all" class="input--no-mrg" type="checkbox" title="Select All">
 							</th>
 						</tr>
-      		</thead>
-           
-      		<tbody>
+					</thead>
 
-           <?php $addons = $installed; foreach ($addons as $addon):?> 
+					<tbody class="list-group">
+						<?php $addons = $installed;
+						foreach ($addons as $addon) : ?>
 
-            <?php if (isset($addon['update'])){
-              echo '<tr  class="app-listing__row_update">';
-            }             
-            else{
-              echo '<tr  class="app-listing__row">';
-            }?>
-              
-             
+							<?php if (isset($addon['update'])) {
+								echo '<tr  class="app-listing__row_update">';
+							} else {
+								echo '<tr  class="app-listing__row">';
+							} ?>
+							<td>
+								<span class="collapsed-label"><?php echo lang('name'); ?></span>
+								<a href="">
+									<div class="addon-name-table d-flex align-items-center">
+										<img src="<?= $addon["icon_url"] ?>" alt="Add-On Name" class="addon-icon-table">
+										<div>
+											<strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"> <?= $addon["description"] ?> </span>
+										</div>
+									</div>
+								</a>
+							</td>
+							<td>
+								<span class="collapsed-label"><?php echo lang('version'); ?></span>
+								<?= $addon["version"] ?>
+							</td>
+							<td>
+								<span class="collapsed-label"><?php echo lang('manage'); ?></span>
+								<div class="button-toolbar toolbar">
+									<div class="button-group button-group-xsmall">
 
-              <td>
-                <span class="collapsed-label">Name</span>
-                <a href="">
-                  <div class="addon-name-table d-flex align-items-center">
-                    <img src="<?= $addon["icon_url"]?>" alt="Add-On Name" class="addon-icon-table">
-                    <div>
-                      <strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"> <?= $addon["description"] ?> </span>
-                    </div>
-                  </div>
-                </a>
-              </td>
-              <td>
-                <span class="collapsed-label">Version</span>
-                <?= $addon["version"] ?>
-              </td>
-              <td>
-                <span class="collapsed-label">Manage</span>
-                <div class="button-toolbar toolbar">
-                  <div class="button-group button-group-xsmall">
+										<?php if (isset($addon['manual_url'])) : ?>
+											<a href="<?= $addon['manual_url'] ?>" class="manual button button--default" <?php if ($addon['manual_external']) {
+																															echo 'rel="external"';
+																														} ?>></a>
+										<?php endif; ?>
 
-                  <?php if (isset($addon['manual_url'])) : ?>
-			            <a href="<?= $addon['manual_url'] ?>" class="manual button button--default"<?php if ($addon['manual_external']) {
-                  echo 'rel="external"';
-                  } ?>></a>
-		              <?php endif; ?>
-                  
-                  <?php if (isset($addon['settings_url'])): ?><a class="settings button button--default" href="<?= $addon['settings_url'] ?>" title="Settings"><span class="hidden">Settings</span></a> <?php endif; ?>
-                   
-                    <?php if (isset($addon['update'])): ?> <a href="" data-post-url="<?=$addon['update_url']?>" class="button button--primary button--small">
-			                  <?php echo sprintf(lang('update_to_version'), '<br />' . $addon['update']); ?>
-		                    </a> <?php endif; ?>
+										<?php if (isset($addon['settings_url'])) : ?><a class="settings button button--default" href="<?= $addon['settings_url'] ?>" title="Settings"><span class="hidden">Settings</span></a> <?php endif; ?>
 
-                    
-              	  </div>
-                </div>
+										<?php if (isset($addon['update'])) : ?> <a href="" data-post-url="<?= $addon['update_url'] ?>" class="button button--primary button--small">
+												<?php echo sprintf(lang('update_to_version'), '<br />' . $addon['update']); ?>
+											</a> <?php endif; ?>
 
-              </td>
-
-
-              <td class="app-listing__cell app-listing__cell--input text--center">
-							      <?php if (ee('Permission')->hasAll('can_admin_addons') && $addon['installed']) : ?> 
-                      <!-- <a class="dropdown__link dropdown__link--danger m-link" href="" rel="modal-confirm-remove" data-action-url="<?= $addon['remove_url'] ?>" data-confirm="<?= $addon['name'] ?>"><?= lang('uninstall') ?></a> -->
-                      <a href="<?= $addon['remove_url'] ?>" class="button button--primary button--small" onclick= "return confirm('Are you sure you want to delete <?= $addon['name'] ?>')"><?= lang('uninstall') ?></a>
-                    <?php endif; ?>
+									</div>
+								</div>
 							</td>
 
-						</tr>
-			      
-            <?php endforeach; ?>
 
-            <?php $addons = $installed; foreach ($uninstalled as $addon):?> 
-              <tr class="app-listing__row_uninstalled">
-              <td>
-                <span class="collapsed-label">Name</span>
-
-                  <div class="addon-name-table d-flex align-items-center">
-                    <img src="<?= $addon["icon_url"]?>" alt="Add-On Name" class="addon-icon-table">
-                    <div>
-                      <strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"><?= $addon["description"] ?></span>
-                    </div>
-                  </div>
-
-              </td>
-              <td>
-                <span class="collapsed-label">Version</span>
-                <?= $addon["version"] ?>
-              </td>
-              <td>
-                <span class="collapsed-label">Manage</span>
-                <a href="" data-post-url="<?= $addon['install_url'] ?>" class="button button--primary button--small"><?= lang('install') ?></a>
-              </td>
-              <td class="app-listing__cell app-listing__cell--input text--center">
-								<p> -- </p>
+							<td class="app-listing__cell app-listing__cell--input text--center">
+								<?php if (ee('Permission')->hasAll('can_admin_addons') && $addon['installed']) : ?>
+									<a href="<?= $addon['remove_url'] ?>" class="button button--primary button--small" onclick="return confirm('<?php echo lang('confirm'); ?> <?= $addon['name'] ?>')"><?= lang('uninstall') ?></a>
+								<?php endif; ?>
 							</td>
-						</tr>
 
-            <?php endforeach; ?>
+							<td class="app-listing__cell app-listing__cell--input text--center">
+								<div class="list-item__checkbox">
+									<input name="selection[]" type="checkbox" value="<?= $addon["package"] ?>" data-confirm="<?= $addon["name"] ?>">
+								</div>
+							</td>
+
+
+						<?php endforeach; ?>
+
+						<?php $addons = $installed;
+						foreach ($uninstalled as $addon) : ?>
+							<tr class="app-listing__row_uninstalled">
+								<td>
+									<span class="collapsed-label"><?php echo lang('name'); ?></span>
+
+									<div class="addon-name-table d-flex align-items-center">
+										<img src="<?= $addon["icon_url"] ?>" alt="Add-On Name" class="addon-icon-table">
+										<div>
+											<strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"><?= $addon["description"] ?></span>
+										</div>
+									</div>
+
+								</td>
+								<td>
+									<span class="collapsed-label"><?php echo lang('version'); ?></span>
+									<?= $addon["version"] ?>
+								</td>
+								<td>
+									<span class="collapsed-label"><?php echo lang('manage'); ?></span>
+									<a href="" data-post-url="<?= $addon['install_url'] ?>" class="button button--primary button--small"><?= lang('install') ?></a>
+								</td>
+								<td class="app-listing__cell app-listing__cell--input text--center">
+									<p> -- </p>
+								</td>
+
+								<td class="app-listing__cell app-listing__cell--input text--center">
+									<p> -- </p>
+								</td>
+							</tr>
+
+						<?php endforeach; ?>
+
+
 
 					</tbody>
-      	</table>
-      </div>
-    </form>
-  </div>
-</div>
 
-<!-- Below is the old add-ons layout -->
+				</table>
 
-<div class="panel">
-  <div class="panel-body">
-
-<div class="tab-wrap">
-	<div class="app-notice-wrap"><?=ee('CP/Alert')->getAllInlines()?></div>
-
-<div class="tab-bar">
-	<div class="tab-bar__tabs">
-		<button type="button" class="tab-bar__tab active js-tab-button" rel="t-0"><?=lang('installed')?></button>
-		<button type="button" class="tab-bar__tab js-tab-button" rel="t-2">
-			<?=lang('updates')?>
-
-			<?php if (! empty($updates)) : ?>
-			<span class="tab-bar__tab-notification"><?=count($updates)?></span>
-			<?php endif; ?>
-		</button>
-	</div>
-</div>
-
-<div class="tab t-0 tab-open">
-
-	<div class="add-on-card-list">
-		<?php $addons = $installed; foreach ($addons as $addon): ?>
-			<?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => false]); ?>
-		<?php endforeach; ?>
+			</div>
+			<?php $this->embed('ee:_shared/form/bulk-action-bar', [
+				'options' => [
+					[
+						'value' => "",
+						'text' => '-- ' . lang('with_selected') . ' --'
+					],
+					[
+						'value' => "remove",
+						'text' => lang('delete'),
+						'attrs' => 'data-confirm-trigger="selected" rel="modal-confirm-remove"'
+					]
+				],
+				'modal' => true
+			]); ?>
+		</form>
 	</div>
 
-	<?php if (count($uninstalled)): ?>
-		<h4 class="line-heading"><?=lang('uninstalled')?></h4>
-		<hr>
-
-		<div class="add-on-card-list">
-			<?php foreach ($uninstalled as $addon): ?>
-				<?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => false]); ?>
-			<?php endforeach; ?>
-		</div>
-	<?php endif; ?>
 </div>
 
-<div class="tab t-2">
-	<div class="add-on-card-list">
-		<?php foreach ($updates as $addon): ?>
-			<?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => true]); ?>
-		<?php endforeach; ?>
-	</div>
-</div>
-
-</div>
-
-</div>
-</div>
 
 <?php
 
 $modal_vars = array(
-    'name' => 'modal-confirm-remove',
-    'form_url' => $form_url,
-    'title' => lang('confirm_uninstall'),
-    'alert' => lang('confirm_uninstall_desc'),
-    'button' => [
-        'text' => lang('btn_confirm_and_uninstall'),
-        'working' => lang('btn_confirm_and_uninstall_working')
-    ],
-    'hidden' => array(
-
-    )
+	'name' => 'modal-confirm-remove',
+	'form_url' => $form_url,
+	'title' => lang('confirm_uninstall'),
+	'alert' => lang('confirm_uninstall_desc'),
+	'button' => [
+		'text' => lang('btn_confirm_and_uninstall'),
+		'working' => lang('btn_confirm_and_uninstall_working')
+	],
+	'hidden' => array(
+		'bulk_action' => 'remove'
+	)
 );
 
-$modal = $this->make('ee:_shared/modal_confirm_delete')->render($modal_vars);
+$modal = $this->make('ee:_shared/modal_confirm_remove')->render($modal_vars);
 ee('CP/Modal')->addModal('delete', $modal);
 ?>
-
-
-
-
-
-
-<!-- Below is the old add-ons layout -->
-
-
-
-

--- a/system/ee/ExpressionEngine/View/addons/index.php
+++ b/system/ee/ExpressionEngine/View/addons/index.php
@@ -2,19 +2,54 @@
 
 <div class="panel panel__no-main-title">
   <div class="tbl-ctrls">
-    <form>
+       <form>
       <div class="panel-heading">
         <div class="app-notice-wrap"><?=ee('CP/Alert')->getAllInlines()?></div>
-        <div class="alert">
-          <div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
-          <div class="alert__content">
-              <p class="alert__title">Updates Available</p>
-              <p>There are <strong>2</strong> installed add-ons with updates available. <a href="">Show me...</a></p>
-          </div>
-          <a href="" class="alert__close">
-              <i class="fas fa-times alert__close-icon"></i>
-          </a>
-      </div>
+
+        
+          
+            
+
+            <?php if (! empty($updates) && count($updates) == 1 ) : ?>
+              <div id = "alert_banner" class="alert">
+              <div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
+              <?php
+              echo '<div id = "alert" href="" class="alert__close">';
+              echo '<a onclick="hide()" id = "alert_close" class="fas fa-times alert__close-icon"></a>';
+              echo '</div>';
+              ?>
+                <p class="alert__title">Update Available <br> 
+                There is <strong><?=count($updates)?></strong> installed add-on with updates available. <a onclick = "typeFilter('app-listing__row_update')">Show me...</a></p>
+                <p></p>
+              </div>
+            <?php endif; ?>
+
+            <?php if (! empty($updates) && count($updates) > 1 ) : ?>
+              <div id = "alert_banner" class="alert">
+              <div class="alert__icon"><i class="fas fa-info-circle fa-fw"></i></div>
+              <?php
+              echo '<div id = "alert" href="" class="alert__close">';
+              echo '<a onclick="hide()" id = "alert_close" class="fas fa-times alert__close-icon"></a>';
+              echo '</div>';
+              ?>
+                <p class="alert__title">Updates Available <br> 
+                There are <strong><?=count($updates)?></strong> installed add-on with updates available. <a onclick = "typeFilter('app-listing__row_update')">Show me...</a></p>
+                <p></p>
+              </div>
+            <?php endif; ?>
+
+            <script> 
+              function hide() { 
+                document.getElementById("alert_banner").style.display='none'; 
+                return false;
+              }
+            </script> 
+            
+          
+        
+        
+
+
         <div class="form-btns form-btns-top">
           <div class="title-bar js-filters-collapsable title-bar--large">
             <h3 class="title-bar__title">Add-Ons</h3>
@@ -24,9 +59,9 @@
                 	<button type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="status" title="status">status</button>
                 	<div class="dropdown">
                     <div class="dropdown__scroll">
-					            <a class="dropdown__link" href="">Installed</a>
-                      <a class="dropdown__link" href="">Uninstalled</a>
-                      <a class="dropdown__link" href="">Update Available</a>
+					            <a class="dropdown__link" onclick = "typeFilter('app-listing__row')" >Installed</a>
+                      <a class="dropdown__link"  onclick = "typeFilter('app-listing__row_uninstalled')">Uninstalled</a>
+                      <a class="dropdown__link"  onclick = "typeFilter('app-listing__row_update')">Update Available</a>
             				</div>
                 	</div>
               	</div>
@@ -34,35 +69,58 @@
     					<div class="filter-bar__item filter-search-form">
         				<div class="filter-search-bar__item">
                 	<div class="search-input">
-                		<input class="search-input__input input--small" type="text" name="filter_by_keyword" value="" placeholder="Search">
+                		<input id = "Search_Term" class="search-input__input input--small" type="text" name="filter_by_keyword" value="" placeholder="Search" onkeyup="searchFilter()">
                 	</div>
                 </div>
         			</div>
+
+              <script>
+                function searchFilter() {
+                var input, filter, table, tr, td, i, txtValue;
+                input = document.getElementById("Search_Term");
+                filter = input.value.toUpperCase();
+                table = document.getElementById("main_Table");
+                tr = table.getElementsByTagName("tr");
+                for (i = 0; i < tr.length; i++) {
+                  td = tr[i].getElementsByTagName("strong")[0];
+                  if (td) {
+                    txtValue = td.textContent || td.innerText;
+                    if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                      tr[i].style.display = "";
+                    } else {
+                      tr[i].style.display = "none";
+                    }
+                  }       
+                }
+              }
+
+              function typeFilter(input){
+                var table, vr;
+                table = document.getElementById("main_Table");
+                tr = table.getElementsByTagName("tr");
+
+                for (i = 0; i < tr.length; i++) {
+                   if(tr[i].className == input){
+                    tr[i].style.display = "";
+                   }else {
+                      tr[i].style.display = "none";
+                   }
+                }
+                return false;
+              }
+              </script>
+
+
+
     					<div class="filter-bar__item ">
-        				<div class="filter-search-bar__item">
-                	<button type="button" class="has-sub filter-bar__button js-dropdown-toggle button button--default button--small" data-filter-label="show">show				<span class="faded">(25)</span>
-            			</button>
-                	<div class="dropdown">
-            				<div class="dropdown__search">
-                			<div class="search-input">
-                  			<input type="text" name="perpage" value="" placeholder="custom limit" data-threshold="1000" data-threshold-text="Viewing more than 1000 items at a time may result in reduced performance." class="search-input__input input--small">
-                			</div>
-                		</div>
-										<a class="dropdown__link" href="">25 results</a>
-										<a class="dropdown__link" href="">50 results</a>
-										<a class="dropdown__link" href="">75 results</a>
-										<a class="dropdown__link" href="">100 results</a>
-										<a class="dropdown__link" href="">150 results</a>
-										<a class="dropdown__link" href="">All Add-Ons</a>
-      						</div>
-                </div>
+
         			</div>
           	</div>
           </div>
         </div>
       </div>
       <div class="table-responsive table-responsive--collapsible">
-        <table cellspacing="0">
+        <table id = "main_Table" cellspacing="0">
   				<thead>
       			<tr class="app-listing__row app-listing__row--head">
 							<th class="column-sort-header column-sort-header--active">
@@ -75,203 +133,109 @@
 								<a class="column-sort column-sort--desc">Manage</a>
 							</th>
 							<th class="app-listing__header text--center">
-								<label for="tbl_6092f7c1be4f4-select-all" class="hidden">Select All</label>
-								<input id="tbl_6092f7c1be4f4-select-all" class="input--no-mrg" type="checkbox" title="Select All">
+								<label for="tbl_6092f7c1be4f4-select-all" >Uninstall </label>
+								
 							</th>
 						</tr>
       		</thead>
+           
       		<tbody>
-						<tr class="app-listing__row">
+
+           <?php $addons = $installed; foreach ($addons as $addon):?> 
+
+            <?php if (isset($addon['update'])){
+              echo '<tr  class="app-listing__row_update">';
+            }             
+            else{
+              echo '<tr  class="app-listing__row">';
+            }?>
+              
+             
+
               <td>
                 <span class="collapsed-label">Name</span>
                 <a href="">
                   <div class="addon-name-table d-flex align-items-center">
-                    <img src="http://expressionengine.test/themes/ee/asset/img/default-addon-icon.svg" alt="Add-On Name" class="addon-icon-table">
+                    <img src="<?= $addon["icon_url"]?>" alt="Add-On Name" class="addon-icon-table">
                     <div>
-                      <strong>Add-On Name</strong><br><span class="meta-info text-muted">This is a description of the add-on.</span>
+                      <strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"> <?= $addon["description"] ?> </span>
                     </div>
                   </div>
                 </a>
               </td>
               <td>
                 <span class="collapsed-label">Version</span>
-                2.1.0
+                <?= $addon["version"] ?>
               </td>
               <td>
                 <span class="collapsed-label">Manage</span>
                 <div class="button-toolbar toolbar">
                   <div class="button-group button-group-xsmall">
-          	    		<a class="manual button button--default" href="" title="Manual"><span class="hidden">Manual</span></a>
-          	    		<a class="settings button button--default" href="admin.php?/cp/channels/layouts/3" title="Settings"><span class="hidden">Settings</span></a>
-                    <a class="button button--default" href="" title="Update">Update</a>
+
+                  <?php if (isset($addon['manual_url'])) : ?>
+			            <a href="<?= $addon['manual_url'] ?>" class="manual button button--default"<?php if ($addon['manual_external']) {
+                  echo 'rel="external"';
+                  } ?>></a>
+		              <?php endif; ?>
+                  
+                  <?php if (isset($addon['settings_url'])): ?><a class="settings button button--default" href="<?= $addon['settings_url'] ?>" title="Settings"><span class="hidden">Settings</span></a> <?php endif; ?>
+                   
+                    <?php if (isset($addon['update'])): ?> <a href="" data-post-url="<?=$addon['update_url']?>" class="button button--primary button--small">
+			                  <?php echo sprintf(lang('update_to_version'), '<br />' . $addon['update']); ?>
+		                    </a> <?php endif; ?>
+
+                    
               	  </div>
                 </div>
+
               </td>
+
+
               <td class="app-listing__cell app-listing__cell--input text--center">
-								<label class="hidden" for="tbl_6092f7c1be4f4-2-0">Select Row</label>
-								<input id="tbl_6092f7c1be4f4-2-0" class="input--no-mrg" name="selection[]" value="1" data-confirm="" type="checkbox">
+							      <?php if (ee('Permission')->hasAll('can_admin_addons') && $addon['installed']) : ?> 
+                      <!-- <a class="dropdown__link dropdown__link--danger m-link" href="" rel="modal-confirm-remove" data-action-url="<?= $addon['remove_url'] ?>" data-confirm="<?= $addon['name'] ?>"><?= lang('uninstall') ?></a> -->
+                      <a href="<?= $addon['remove_url'] ?>" class="button button--primary button--small" onclick= "return confirm('Are you sure you want to delete <?= $addon['name'] ?>')"><?= lang('uninstall') ?></a>
+                    <?php endif; ?>
 							</td>
+
 						</tr>
-            <tr class="app-listing__row">
+			      
+            <?php endforeach; ?>
+
+            <?php $addons = $installed; foreach ($uninstalled as $addon):?> 
+              <tr class="app-listing__row_uninstalled">
               <td>
                 <span class="collapsed-label">Name</span>
-                <a href="">
+
                   <div class="addon-name-table d-flex align-items-center">
-                    <img src="http://expressionengine.test/themes/ee/asset/img/default-addon-icon.svg" alt="Add-On Name" class="addon-icon-table">
+                    <img src="<?= $addon["icon_url"]?>" alt="Add-On Name" class="addon-icon-table">
                     <div>
-                      <strong>Add-On Name</strong><br><span class="meta-info text-muted">This is a description of the add-on.</span>
+                      <strong><?= $addon["name"] ?></strong><br><span class="meta-info text-muted"><?= $addon["description"] ?></span>
                     </div>
                   </div>
-                </a>
+
               </td>
               <td>
                 <span class="collapsed-label">Version</span>
-                2.1.0
+                <?= $addon["version"] ?>
               </td>
               <td>
                 <span class="collapsed-label">Manage</span>
-                <div class="button-toolbar toolbar">
-                  <div class="button-group button-group-xsmall">
-          	    		<a class="manual button button--default" href="" title="Manual"><span class="hidden">Manual</span></a>
-          	    		<a class="settings button button--default" href="admin.php?/cp/channels/layouts/3" title="Settings"><span class="hidden">Settings</span></a>
-                    <a class="button button--default" href="" title="Update">Update</a>
-              	  </div>
-                </div>
+                <a href="" data-post-url="<?= $addon['install_url'] ?>" class="button button--primary button--small"><?= lang('install') ?></a>
               </td>
               <td class="app-listing__cell app-listing__cell--input text--center">
-								<label class="hidden" for="tbl_6092f7c1be4f4-2-0">Select Row</label>
-								<input id="tbl_6092f7c1be4f4-2-0" class="input--no-mrg" name="selection[]" value="1" data-confirm="" type="checkbox">
+								<p> -- </p>
 							</td>
 						</tr>
-            <tr class="app-listing__row">
-              <td>
-                <span class="collapsed-label">Name</span>
-                <a href="">
-                  <div class="addon-name-table d-flex align-items-center">
-                    <img src="http://expressionengine.test/themes/ee/asset/img/default-addon-icon.svg" alt="Add-On Name" class="addon-icon-table">
-                    <div>
-                      <strong>Add-On Name</strong><br><span class="meta-info text-muted">This is a description of the add-on.</span>
-                    </div>
-                  </div>
-                </a>
-              </td>
-              <td>
-                <span class="collapsed-label">Version</span>
-                2.1.0
-              </td>
-              <td>
-                <span class="collapsed-label">Manage</span>
-                <div class="button-toolbar toolbar">
-                  <div class="button-group button-group-xsmall">
-          	    		<a class="manual button button--default" href="" title="Manual"><span class="hidden">Manual</span></a>
-          	    		<a class="settings button button--default" href="admin.php?/cp/channels/layouts/3" title="Settings"><span class="hidden">Settings</span></a>
-              	  </div>
-                </div>
-              </td>
-              <td class="app-listing__cell app-listing__cell--input text--center">
-								<label class="hidden" for="tbl_6092f7c1be4f4-2-0">Select Row</label>
-								<input id="tbl_6092f7c1be4f4-2-0" class="input--no-mrg" name="selection[]" value="1" data-confirm="" type="checkbox">
-							</td>
-						</tr>
-            <tr class="app-listing__row">
-              <td>
-                <span class="collapsed-label">Name</span>
-                <a href="">
-                  <div class="addon-name-table d-flex align-items-center">
-                    <img src="http://expressionengine.test/themes/ee/asset/img/default-addon-icon.svg" alt="Add-On Name" class="addon-icon-table">
-                    <div>
-                      <strong>Add-On Name</strong><br><span class="meta-info text-muted">This is a description of the add-on.</span>
-                    </div>
-                  </div>
-                </a>
-              </td>
-              <td>
-                <span class="collapsed-label">Version</span>
-                2.1.0
-              </td>
-              <td>
-                <span class="collapsed-label">Manage</span>
-                <div class="button-toolbar toolbar">
-                  <div class="button-group button-group-xsmall">
-          	    		<a class="manual button button--default" href="" title="Manual"><span class="hidden">Manual</span></a>
-          	    		<a class="settings button button--default" href="admin.php?/cp/channels/layouts/3" title="Settings"><span class="hidden">Settings</span></a>
-              	  </div>
-                </div>
-              </td>
-              <td class="app-listing__cell app-listing__cell--input text--center">
-								<label class="hidden" for="tbl_6092f7c1be4f4-2-0">Select Row</label>
-								<input id="tbl_6092f7c1be4f4-2-0" class="input--no-mrg" name="selection[]" value="1" data-confirm="" type="checkbox">
-							</td>
-						</tr>
-            <tr class="app-listing__row">
-              <td>
-                <span class="collapsed-label">Name</span>
-                <!-- <a href=""> -->
-                  <div class="addon-name-table d-flex align-items-center">
-                    <img src="http://expressionengine.test/themes/ee/asset/img/default-addon-icon.svg" alt="Add-On Name" class="addon-icon-table">
-                    <div>
-                      <strong>Add-On Name</strong><br><span class="meta-info text-muted">This is a description of the add-on.</span>
-                    </div>
-                  </div>
-                <!-- </a> -->
-              </td>
-              <td>
-                <span class="collapsed-label">Version</span>
-                2.1.0
-              </td>
-              <td>
-                <span class="collapsed-label">Manage</span>
-                <a href="" class="button button--primary button--xsmall">Install</a>
-              </td>
-              <td class="app-listing__cell app-listing__cell--input text--center">
-								<label class="hidden" for="tbl_6092f7c1be4f4-2-0">Select Row</label>
-								<input id="tbl_6092f7c1be4f4-2-0" class="input--no-mrg" name="selection[]" value="1" data-confirm="" type="checkbox">
-							</td>
-						</tr>
-            <tr class="app-listing__row">
-              <td>
-                <span class="collapsed-label">Name</span>
-                <!-- <a href=""> -->
-                  <div class="addon-name-table d-flex align-items-center">
-                    <img src="http://expressionengine.test/themes/ee/asset/img/default-addon-icon.svg" alt="Add-On Name" class="addon-icon-table">
-                    <div>
-                      <strong>Add-On Name</strong><br><span class="meta-info text-muted">This is a description of the add-on.</span>
-                    </div>
-                  </div>
-                <!-- </a> -->
-              </td>
-              <td>
-                <span class="collapsed-label">Version</span>
-                2.1.0
-              </td>
-              <td>
-                <span class="collapsed-label">Manage</span>
-                <a href="" class="button button--primary button--xsmall">Install</a>
-              </td>
-              <td class="app-listing__cell app-listing__cell--input text--center">
-								<label class="hidden" for="tbl_6092f7c1be4f4-2-0">Select Row</label>
-								<input id="tbl_6092f7c1be4f4-2-0" class="input--no-mrg" name="selection[]" value="1" data-confirm="" type="checkbox">
-							</td>
-						</tr>
+
+            <?php endforeach; ?>
+
 					</tbody>
       	</table>
       </div>
     </form>
   </div>
 </div>
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 <!-- Below is the old add-ons layout -->
 
@@ -346,3 +310,14 @@ $modal_vars = array(
 $modal = $this->make('ee:_shared/modal_confirm_delete')->render($modal_vars);
 ee('CP/Modal')->addModal('delete', $modal);
 ?>
+
+
+
+
+
+
+<!-- Below is the old add-ons layout -->
+
+
+
+

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -182,6 +182,19 @@ $lang = array(
 
     'version' => 'Version',
 
+     /*Messages To User*/
+
+     'confirm' => 'Are you sure you want to delete',
+     'multi_updates' => 'installed add-ons with updates available.',
+     'name' => 'Name',
+     'single_update' => 'installed add-on with updates available.',
+     'there_are' => 'There Are',
+     'there_is' => 'There Is',
+     
+     'show' => 'Show me ...',
+     'update_available' => 'Update',
+     'manage' => 'Manage'
+
 );
 
 // EOF

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -203,7 +203,9 @@ $lang = array(
      'bulk_install_title' => 'Bulk Installer',
      'bulk_install_button' => 'Install Now!',
      'settings' => 'Settings',
-     'select_all' => 'Select All'
+     'select_all' => 'Select All',
+
+     'sidebar_sort' => 'Sort By Status:'
 
 );
 

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -193,7 +193,16 @@ $lang = array(
      
      'show' => 'Show me ...',
      'update_available' => 'Update',
-     'manage' => 'Manage'
+     'manage' => 'Manage',
+
+     'bulk_update' => 'Update the Following? ...',
+     'bulk_update_title' => 'Bulk Updater',
+     'bulk_update_button' => 'Update Now!',
+
+
+     'bulk_install' => 'Install the Following? ...',
+     'bulk_install_title' => 'Bulk Installer',
+     'bulk_install_button' => 'Install Now!'
 
 );
 

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -188,8 +188,8 @@ $lang = array(
      'multi_updates' => 'installed add-ons with updates available.',
      'name' => 'Name',
      'single_update' => 'installed add-on with updates available.',
-     'there_are' => 'There Are',
-     'there_is' => 'There Is',
+     'there_are' => 'There Are %d %s',
+     'there_is' => 'There Is %d %s',
      
      'show' => 'Show me ...',
      'update_available' => 'Update',
@@ -202,7 +202,9 @@ $lang = array(
 
      'bulk_install' => 'Install the Following? ...',
      'bulk_install_title' => 'Bulk Installer',
-     'bulk_install_button' => 'Install Now!'
+     'bulk_install_button' => 'Install Now!',
+     'settings' => 'Settings',
+     'select_all' => 'Select All'
 
 );
 

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -185,11 +185,10 @@ $lang = array(
      /*Messages To User*/
 
      'confirm' => 'Are you sure you want to delete',
-     'multi_updates' => 'installed add-ons with updates available.',
+     'multi_updates' => 'There are %s installed add-ons with updates available.',
      'name' => 'Name',
-     'single_update' => 'installed add-on with updates available.',
-     'there_are' => 'There Are %d %s',
-     'there_is' => 'There Is %d %s',
+     'single_update' => 'There is %s installed add-on with updates available.',
+
      
      'show' => 'Show me ...',
      'update_available' => 'Update',

--- a/tests/cypress/cypress/elements/pages/addons/AddonManager.js
+++ b/tests/cypress/cypress/elements/pages/addons/AddonManager.js
@@ -49,6 +49,15 @@ class AddonManager extends ControlPanel {
             "third_party_pages": third_party_prefix + 'div.paginate ul li a',
             "third_party_bulk_action": third_party_prefix + 'form fieldset.bulk-action-bar select[name="bulk_action"]',
             "third_party_action_submit_button": third_party_prefix + 'form fieldset.bulk-action-bar button',
+
+            // New Addon Table Based Layout
+            "head" : '.app-listing__row_h',
+            "uninstalled" : 'tr.app-listing__row_uninstalled',
+            "name" : 'div.name_of_addon strong',
+            'installed' : 'tr.app-listing__row'
+
+
+
         })
     }
 

--- a/themes/ee/asset/javascript/src/cp/addons/add-ons-index.js
+++ b/themes/ee/asset/javascript/src/cp/addons/add-ons-index.js
@@ -32,6 +32,30 @@ window.onload = function () {
     if(Update){
         Update.addEventListener('click', FilterUpdate);
     }
+
+    var All = document.getElementById("show_all");
+    if(All){
+        All.addEventListener('click', ShowAll);
+    }
+
+
+    function ShowAll(){
+        var table, name;
+        table = document.getElementById("main_Table");
+        tr = table.getElementsByTagName("tr");
+        name = document.getElementById("current_status");
+
+        for (i = 0; i < tr.length; i++) {
+            if(tr[i].className == "app-listing__row" ||tr[i].className == "app-listing__row_h app-listing__row--head"){
+            tr[i].style.display = "";
+            }else {
+                tr[i].style.display = "";
+            }
+        }
+        name.innerText = All.innerText;
+
+        return false;
+    }
     
 
     function hide() { 
@@ -60,9 +84,10 @@ window.onload = function () {
 
 
     function FilterUpdate(){
-        var table, vr;
+        var table, name;
         table = document.getElementById("main_Table");
         tr = table.getElementsByTagName("tr");
+        name = document.getElementById("current_status");
 
         for (i = 0; i < tr.length; i++) {
             if(tr[i].className == "app-listing__row_update"||tr[i].className == "app-listing__row_h app-listing__row--head"){
@@ -71,13 +96,15 @@ window.onload = function () {
                 tr[i].style.display = "none";
             }
         }
+        name.innerText = Update.innerText;
         return false;
     }
 
     function FilterInstalled(){
-        var table, vr;
+        var table, name;
         table = document.getElementById("main_Table");
         tr = table.getElementsByTagName("tr");
+        name = document.getElementById("current_status");
 
         for (i = 0; i < tr.length; i++) {
             if(tr[i].className == "app-listing__row" ||tr[i].className == "app-listing__row_h app-listing__row--head"){
@@ -86,13 +113,15 @@ window.onload = function () {
                 tr[i].style.display = "none";
             }
         }
+        name.innerText = Installed.innerText;
         return false;
     }
 
     function FilterUninstalled(){
-        var table, vr;
+        var table, name;
         table = document.getElementById("main_Table");
         tr = table.getElementsByTagName("tr");
+        name = document.getElementById("current_status");
 
         for (i = 0; i < tr.length; i++) {
             if(tr[i].className == "app-listing__row_uninstalled"||tr[i].className == "app-listing__row_h app-listing__row--head"){
@@ -101,6 +130,7 @@ window.onload = function () {
                 tr[i].style.display = "none";
             }
         }
+        name.innerText = Uninstalled.innerText;
         return false;
     }
 }

--- a/themes/ee/asset/javascript/src/cp/addons/add-ons-index.js
+++ b/themes/ee/asset/javascript/src/cp/addons/add-ons-index.js
@@ -53,6 +53,8 @@ window.onload = function () {
             }
         }
         name.innerText = All.innerText;
+        document.getElementById('drop_down').className = "dropdown";
+        document.getElementById('current_status').className = "has-sub filter-bar__button js-dropdown-toggle button button--default button--small";
 
         return false;
     }
@@ -97,6 +99,8 @@ window.onload = function () {
             }
         }
         name.innerText = Update.innerText;
+        document.getElementById('drop_down').className = "dropdown";
+        document.getElementById('current_status').className = "has-sub filter-bar__button js-dropdown-toggle button button--default button--small";
         return false;
     }
 
@@ -114,6 +118,8 @@ window.onload = function () {
             }
         }
         name.innerText = Installed.innerText;
+        document.getElementById('drop_down').className = "dropdown";
+        document.getElementById('current_status').className = "has-sub filter-bar__button js-dropdown-toggle button button--default button--small";
         return false;
     }
 
@@ -131,6 +137,8 @@ window.onload = function () {
             }
         }
         name.innerText = Uninstalled.innerText;
+        document.getElementById('drop_down').className = "dropdown";
+        document.getElementById('current_status').className = "has-sub filter-bar__button js-dropdown-toggle button button--default button--small";
         return false;
     }
 }

--- a/themes/ee/asset/javascript/src/cp/addons/add-ons-index.js
+++ b/themes/ee/asset/javascript/src/cp/addons/add-ons-index.js
@@ -52,10 +52,12 @@ window.onload = function () {
                 tr[i].style.display = "";
             }
         }
-        name.innerText = All.innerText;
-        document.getElementById('drop_down').className = "dropdown";
-        document.getElementById('current_status').className = "has-sub filter-bar__button js-dropdown-toggle button button--default button--small";
+        document.getElementById('installed_sort').className="sidebar__link";
+        document.getElementById('update_sort').className="sidebar__link";
+        document.getElementById('uninstalled_sort').className="sidebar__link";
 
+        document.getElementById('show_all').className="sidebar__link  active";
+       
         return false;
     }
     
@@ -98,9 +100,11 @@ window.onload = function () {
                 tr[i].style.display = "none";
             }
         }
-        name.innerText = Update.innerText;
-        document.getElementById('drop_down').className = "dropdown";
-        document.getElementById('current_status').className = "has-sub filter-bar__button js-dropdown-toggle button button--default button--small";
+        document.getElementById('installed_sort').className="sidebar__link";
+        document.getElementById('show_all').className="sidebar__link";
+        document.getElementById('uninstalled_sort').className="sidebar__link";
+
+        document.getElementById('update_sort').className="sidebar__link  active";
         return false;
     }
 
@@ -117,9 +121,11 @@ window.onload = function () {
                 tr[i].style.display = "none";
             }
         }
-        name.innerText = Installed.innerText;
-        document.getElementById('drop_down').className = "dropdown";
-        document.getElementById('current_status').className = "has-sub filter-bar__button js-dropdown-toggle button button--default button--small";
+        document.getElementById('uninstalled_sort').className="sidebar__link";
+        document.getElementById('show_all').className="sidebar__link";
+        document.getElementById('update_sort').className="sidebar__link";
+        
+        document.getElementById('installed_sort').className="sidebar__link  active";
         return false;
     }
 
@@ -136,9 +142,11 @@ window.onload = function () {
                 tr[i].style.display = "none";
             }
         }
-        name.innerText = Uninstalled.innerText;
-        document.getElementById('drop_down').className = "dropdown";
-        document.getElementById('current_status').className = "has-sub filter-bar__button js-dropdown-toggle button button--default button--small";
+        document.getElementById('installed_sort').className="sidebar__link";
+        document.getElementById('show_all').className="sidebar__link";
+        document.getElementById('update_sort').className="sidebar__link";
+
+        document.getElementById('uninstalled_sort').className="sidebar__link  active";
         return false;
     }
 }

--- a/themes/ee/asset/javascript/src/cp/addons/add-ons-index.js
+++ b/themes/ee/asset/javascript/src/cp/addons/add-ons-index.js
@@ -1,16 +1,16 @@
 window.onload = function () {
-    var Search_Term = document.getElementById("Search_Term");
+    var Search_Term = document.getElementById("search_term");
     if(Search_Term){
         Search_Term.addEventListener('input', SearchFilter);
     }
     
-    var Installed = document.getElementById("Installed_Sort");
+    var Installed = document.getElementById("installed_sort");
     if(Installed){
         Installed.addEventListener('click', FilterInstalled);
     }
     
 
-    var Uninstalled = document.getElementById("Uninstalled_Sort");
+    var Uninstalled = document.getElementById("uninstalled_sort");
     if(Uninstalled){
         Uninstalled.addEventListener('click', FilterUninstalled);
     }
@@ -22,13 +22,13 @@ window.onload = function () {
     }
    
 
-    var see_updates = document.getElementById("ShowMe");
+    var see_updates = document.getElementById("show_me");
     if(see_updates){
         see_updates.addEventListener('click', FilterUpdate);
     }
     
 
-    var Update = document.getElementById("Update_Sort");
+    var Update = document.getElementById("update_sort");
     if(Update){
         Update.addEventListener('click', FilterUpdate);
     }
@@ -41,7 +41,7 @@ window.onload = function () {
 
     function SearchFilter() {
         var input, filter, table, tr, td, i, txtValue;
-        input = document.getElementById("Search_Term");
+        input = document.getElementById("search_term");
         filter = input.value.toUpperCase();
         table = document.getElementById("main_Table");
         tr = table.getElementsByTagName("tr");

--- a/themes/ee/cp/js/src/cp/add-ons-index.js
+++ b/themes/ee/cp/js/src/cp/add-ons-index.js
@@ -65,7 +65,7 @@ window.onload = function () {
         tr = table.getElementsByTagName("tr");
 
         for (i = 0; i < tr.length; i++) {
-            if(tr[i].className == "app-listing__row_update"){
+            if(tr[i].className == "app-listing__row_update"||tr[i].className == "app-listing__row_h app-listing__row--head"){
             tr[i].style.display = "";
             }else {
                 tr[i].style.display = "none";
@@ -80,7 +80,7 @@ window.onload = function () {
         tr = table.getElementsByTagName("tr");
 
         for (i = 0; i < tr.length; i++) {
-            if(tr[i].className == "app-listing__row"){
+            if(tr[i].className == "app-listing__row" ||tr[i].className == "app-listing__row_h app-listing__row--head"){
             tr[i].style.display = "";
             }else {
                 tr[i].style.display = "none";
@@ -95,7 +95,7 @@ window.onload = function () {
         tr = table.getElementsByTagName("tr");
 
         for (i = 0; i < tr.length; i++) {
-            if(tr[i].className == "app-listing__row_uninstalled"){
+            if(tr[i].className == "app-listing__row_uninstalled"||tr[i].className == "app-listing__row_h app-listing__row--head"){
             tr[i].style.display = "";
             }else {
                 tr[i].style.display = "none";

--- a/themes/ee/cp/js/src/cp/add-ons-index.js
+++ b/themes/ee/cp/js/src/cp/add-ons-index.js
@@ -1,0 +1,106 @@
+window.onload = function () {
+    var Search_Term = document.getElementById("Search_Term");
+    if(Search_Term){
+        Search_Term.addEventListener('input', SearchFilter);
+    }
+    
+    var Installed = document.getElementById("Installed_Sort");
+    if(Installed){
+        Installed.addEventListener('click', FilterInstalled);
+    }
+    
+
+    var Uninstalled = document.getElementById("Uninstalled_Sort");
+    if(Uninstalled){
+        Uninstalled.addEventListener('click', FilterUninstalled);
+    }
+    
+
+    var close_banner = document.getElementById("alert_close");
+    if(close_banner){
+        close_banner.addEventListener('click', hide);
+    }
+   
+
+    var see_updates = document.getElementById("ShowMe");
+    if(see_updates){
+        see_updates.addEventListener('click', FilterUpdate);
+    }
+    
+
+    var Update = document.getElementById("Update_Sort");
+    if(Update){
+        Update.addEventListener('click', FilterUpdate);
+    }
+    
+
+    function hide() { 
+        document.getElementById("alert_banner").style.display='none'; 
+        return false;
+    }
+
+    function SearchFilter() {
+        var input, filter, table, tr, td, i, txtValue;
+        input = document.getElementById("Search_Term");
+        filter = input.value.toUpperCase();
+        table = document.getElementById("main_Table");
+        tr = table.getElementsByTagName("tr");
+        for (i = 0; i < tr.length; i++) {
+            td = tr[i].getElementsByTagName("strong")[0];
+            if (td) {
+                txtValue = td.textContent || td.innerText;
+            if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                tr[i].style.display = "";
+            } else {
+                tr[i].style.display = "none";
+            }
+            }       
+        }
+    }
+
+
+    function FilterUpdate(){
+        var table, vr;
+        table = document.getElementById("main_Table");
+        tr = table.getElementsByTagName("tr");
+
+        for (i = 0; i < tr.length; i++) {
+            if(tr[i].className == "app-listing__row_update"){
+            tr[i].style.display = "";
+            }else {
+                tr[i].style.display = "none";
+            }
+        }
+        return false;
+    }
+
+    function FilterInstalled(){
+        var table, vr;
+        table = document.getElementById("main_Table");
+        tr = table.getElementsByTagName("tr");
+
+        for (i = 0; i < tr.length; i++) {
+            if(tr[i].className == "app-listing__row"){
+            tr[i].style.display = "";
+            }else {
+                tr[i].style.display = "none";
+            }
+        }
+        return false;
+    }
+
+    function FilterUninstalled(){
+        var table, vr;
+        table = document.getElementById("main_Table");
+        tr = table.getElementsByTagName("tr");
+
+        for (i = 0; i < tr.length; i++) {
+            if(tr[i].className == "app-listing__row_uninstalled"){
+            tr[i].style.display = "";
+            }else {
+                tr[i].style.display = "none";
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

This is changing Andy Johnson's Add-on page so that instead of being hardcoded in the table it is automatically filled with the cards.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [ ] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
