### PR TITLE
fixes and tests for autosave features

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -254,12 +254,13 @@ abstract class AbstractPublish extends CP_Controller
                     $i,
                     $edit_date,
                     $authors[$entry->author_id],
-                    '<span class="st-open">' . lang('current') . '</span>'
+                    '<a href="' . ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id) . '"><span class="st-open">' . lang('current') . '</span></a>'
                 )
             );
             $i--;
         }
 
+        $currentAutosaveId = null;
         foreach ($entry->getAutosaves()->sortBy('edit_date')->reverse() as $autosave) {
             if (! isset($authors[$autosave->author_id]) && $autosave->Author) {
                 $authors[$autosave->author_id] = $autosave->Author->getMemberName();
@@ -280,6 +281,9 @@ abstract class AbstractPublish extends CP_Controller
             );
 
             $attrs = ($autosave->getId() == $autosave_id) ? array('class' => 'selected') : array();
+            if ($autosave->getId() == $autosave_id) {
+                $currentAutosaveId = $autosave->getId();
+            }
 
             $data[] = array(
                 'attrs' => $attrs,
@@ -291,6 +295,10 @@ abstract class AbstractPublish extends CP_Controller
                 )
             );
             $i--;
+        }
+
+        if ($autosave_id && empty($currentAutosaveId)) {
+            $data[0]['attrs'] = ['class' => 'selected'];
         }
 
         $table->setData($data);

--- a/system/ee/ExpressionEngine/View/_shared/form/buttons.php
+++ b/system/ee/ExpressionEngine/View/_shared/form/buttons.php
@@ -9,6 +9,9 @@
                 $buttons[$i]['attrs'] .= ' data-shortcut="' . (string) $button['shortcut'] . '"';
             } 
             if (isset($button['value']) && strpos($button['value'], 'save') === 0) {
+                if ($i == 0 && !isset($buttons[$i]['attrs'])) {
+                    $buttons[$i]['attrs'] = ' data-shortcut="s"';
+                }
                 $submits[] = $buttons[$i];
                 unset($buttons[$i]);
             }

--- a/tests/cypress/cypress/integration/publish/edit.ee6.js
+++ b/tests/cypress/cypress/integration/publish/edit.ee6.js
@@ -7,6 +7,7 @@ const page = new Edit;
 
 context('Publish Page - Edit', () => {
   beforeEach(function(){
+    //cy.task('db:seed')
     cy.auth();
     cy.hasNoErrors()
   })
@@ -14,5 +15,55 @@ context('Publish Page - Edit', () => {
   it('shows a 404 with no given entry_id', () => {
     page.load()
     cy.contains("404")
+  })
+
+  context('autosaving', () => {
+    it('autosaves the changes', () => {
+      cy.visit('admin.php?/cp/publish/edit/entry/1')
+      cy.get('input[name=title]').clear().type('Auto Saved Title');
+      cy.wait(65000);// 60 sec before the ajax + 5 sec to finish
+      cy.get('.main-nav__title h1 span').contains('Auto Saved');
+
+      cy.visit('admin.php?/cp/publish/edit')
+      cy.get('tbody tr:last-child').should('have.class', 'auto-saved')
+      cy.get('tbody tr:last-child span.auto-save').should('exist')
+
+      cy.get('tbody tr:last-child a').first().click();
+      cy.get('input[name=title]').invoke('val').then((val) => { expect(val).to.be.equal("Getting to Know ExpressionEngine") })
+
+      cy.get('[rel=t-autosaves]').click();
+      cy.get('a[title=View]').click()
+      cy.get('input[name=title]').invoke('val').then((val) => { expect(val).to.be.equal("Auto Saved Title") })
+
+      cy.get('[rel=t-autosaves]').click();
+      cy.get('a').contains('Current').click()
+      cy.get('input[name=title]').invoke('val').then((val) => { expect(val).to.be.equal("Getting to Know ExpressionEngine") })
+
+      page.get('save').click()
+      cy.visit('admin.php?/cp/publish/edit/entry/1')
+      cy.get('[rel=t-autosaves]').should('not.exist');
+
+      cy.visit('admin.php?/cp/publish/edit')
+      cy.get('tbody tr:last-child').should('not.have.class', 'auto-saved')
+      cy.get('tbody tr:last-child span.auto-save').should('not.exist')
+
+      
+    })
+
+    it('prevent navigating away', () => {
+      cy.visit('admin.php?/cp/publish/edit/entry/1')
+      var alerted = false;
+      cy.get('input[name=title]').clear().type('Auto Saved Title');
+      cy.on('window:confirm', (str) => {
+        expect(str).to.equal('When you leave, any data entered will be lost. Are you sure you want to leave?')
+        alerted = true;
+      })
+      cy.get('a').contains('Overview').click().then(() => {
+        expect(alerted).to.eq(true)
+      })
+      
+
+      
+    })
   })
 })

--- a/themes/ee/asset/javascript/src/cp/form_validation.js
+++ b/themes/ee/asset/javascript/src/cp/form_validation.js
@@ -11,14 +11,10 @@
 
 $(document).ready(function() {
 	EE.cp.formValidation.init();
-	try {
-		sessionStorage.removeItem("preventNavigateAway");
-	} catch (e) {}
 });
 
 EE.cp.formValidation = {
 
-	shouldPreventNavigateAway: false,
 	paused: false,
 	_validationCallbacks: [],
 
@@ -231,9 +227,6 @@ EE.cp.formValidation = {
 
 		form.each(function(index, el) {
 			that.bindInputs($(this));
-			if ($(el).parent().is('[data-publish]')) {
-				that.shouldPreventNavigateAway = true;
-			}
 		});
 	},
 
@@ -265,13 +258,6 @@ EE.cp.formValidation = {
 		if ( ! form.hasClass('ajax-validate')) {
 			this._toggleErrorForFields(field, 'success');
 			return;
-		}
-
-		//prevent navigating away if something has changed
-		if (this.shouldPreventNavigateAway) {
-			try {
-				sessionStorage.setItem("preventNavigateAway", true);
-			} catch (e) {}
 		}
 
 		var that = this,

--- a/themes/ee/asset/javascript/src/cp/publish/publish.js
+++ b/themes/ee/asset/javascript/src/cp/publish/publish.js
@@ -13,6 +13,9 @@ $(document).ready(function () {
 	var ajaxRequest;
 	var debounceTimeout;
 	var isNavigatingAway = false;
+	try {
+		sessionStorage.removeItem("preventNavigateAway");
+	} catch (e) {}
 
 	function debounceAjax(func, wait) {
 	    var result;
@@ -83,6 +86,9 @@ $(document).ready(function () {
 		var autosaving = false;
 
 		publishForm.on("entry:startAutosave", function() {
+			try {
+				sessionStorage.setItem("preventNavigateAway", true);
+			} catch (e) {}
 			publishForm.trigger("entry:autosave");
 
 			if (autosaving) {


### PR DESCRIPTION

ensure 's' shortcut is always available for saving forms

enable loading current version when working with autosaves

always highlight current version in autosaves when it's loaded

completely move the functionality to prevent navigating away into autosaving JS

cover autosaving and navigating away with tests