### PR TITLE
Fixed a bug with the error message when importing invalid channel sets

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -8,6 +8,7 @@ Bullet list below, e.g.
    - Added <new feature>
    - Fixed a bug (#<linked issue number>) where <bug behavior>.
 
+   - Fixed a bug with the error message when importing invalid channel sets
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/EllisLab/ExpressionEngine/Controller/Channels/Sets.php
+++ b/system/ee/EllisLab/ExpressionEngine/Controller/Channels/Sets.php
@@ -67,6 +67,14 @@ class Sets extends AbstractChannelsController {
 
 				$vars['errors'] = $errors;
 			}
+			elseif (strtolower(pathinfo($set_file['name'], PATHINFO_EXTENSION)) !== 'zip')
+			{
+				ee('CP/Alert')->makeInline('shared-form')
+					->asIssue()
+					->withTitle(lang('channel_set_filetype_error'))
+					->addToBody(lang('channel_set_filetype_error_desc'))
+					->now();
+			}
 			else
 			{
 				$set = ee('ChannelSet')->importUpload($set_file);

--- a/system/ee/legacy/language/english/channel_lang.php
+++ b/system/ee/legacy/language/english/channel_lang.php
@@ -54,6 +54,10 @@ $lang = array(
 
 'channel_set_upload_error_desc' => 'We were unable to import the channel, please make sure your cache folder is writable.',
 
+'channel_set_filetype_error' => 'Cannot Import Channel',
+
+'channel_set_filetype_error_desc' => 'We were unable to import the channel; only zip files are supported.',
+
 'channel_set_invalid' => 'Not a valid channel set. Missing channel_set.json file.',
 
 'channel_set_incompatible' => 'Incompatible channel set. This channel set requires ExpressionEngine %d.0.0 or newer.',


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fixed a bug with the error message when importing invalid channel sets

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
