### PR TITLE
Fixed a bug with group id's being set wrong on role cp page

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -34,6 +34,7 @@ Bullet list below, e.g.
    - Fix bug with member import error
    - Fixed a bug in the channel title filtering in the control panel
    - Fix a bug with avatar filename in controller profile settings
+   - Fixed a bug with group id's being set wrong on role cp page
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/ExpressionEngine/Controller/Members/Roles/AbstractRoles.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Roles/AbstractRoles.php
@@ -43,7 +43,7 @@ abstract class AbstractRoles extends CP_Controller
         if (ee('Permission')->can('create_roles')) {
             $header['action_button'] = [
                 'text' => lang('new_role'),
-                'href' => ee('CP/URL')->make('members/roles/create/' . ee('Request')->get('group_id') ?: '')
+                'href' => ee('CP/URL')->make('members/roles/create/' . (int) ee('Request')->get('group_id') ?: '')
             ];
         }
 


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fixed a bug with group id's being set wrong on role cp page

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
