### PR TITLE
 Removes <generator> tag output when there are no results

### DIFF
--- a/system/ee/ExpressionEngine/Addons/rss/mod.rss.php
+++ b/system/ee/ExpressionEngine/Addons/rss/mod.rss.php
@@ -354,7 +354,6 @@ class Rss
 	<link>{$link}</link>
 	<description></description>
 	<docs>http://www.rssboard.org/rss-specification</docs>
-	<generator>ExpressionEngine v{$version} https://expressionengine.com/expressionengine</generator>
 
 	<item>
 		<title>{$content}</title>


### PR DESCRIPTION
## Overview

Fixes #1139

Removes the <generator> tag on feeds that have no content to stop data disclosure as to version of EE in use.

## Nature of This Change

- [x] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->