### PR TITLE
avoid entities in entries listing

### DIFF
--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/Author.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/Author.php
@@ -39,6 +39,6 @@ class Author extends Column
 
     public function renderTableCell($data, $field_id, $entry)
     {
-        return ee('Format')->make('Text', $entry->getAuthorName())->convertToEntities();
+        return ee('Format')->make('Text', $entry->getAuthorName());
     }
 }

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/ChannelName.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/ChannelName.php
@@ -39,6 +39,6 @@ class ChannelName extends Column
 
     public function renderTableCell($data, $field_id, $entry)
     {
-        return ee('Format')->make('Text', $entry->Channel->channel_title)->convertToEntities();
+        return ee('Format')->make('Text', $entry->Channel->channel_title);
     }
 }

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/Checkbox.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/Checkbox.php
@@ -32,7 +32,7 @@ class Checkbox extends Column
 
     public function renderTableCell($data, $field_id, $entry)
     {
-        $title = ee('Format')->make('Text', $entry->title)->convertToEntities();
+        $title = ee('Format')->make('Text', $entry->title)->attributeSafe();
 
         return [
             'name' => 'selection[]',

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -106,7 +106,7 @@ class Cp
             'cp_pad_table_template' => $cp_pad_table_template,
             'cp_theme_url' => $this->cp_theme_url,
             'cp_current_site_label' => ee()->config->item('site_name'),
-            'cp_screen_name' => $member->screen_name,
+            'cp_screen_name' => ee('Format')->make('Text', $member->screen_name)->attributeSafe(),
             'cp_member_primary_role_title' => $member->PrimaryRole ? $member->PrimaryRole->name : '',
             'cp_avatar_path' => ($member->avatar_filename) ? ee()->config->slash_item('avatar_url') . $member->avatar_filename : (URL_THEMES . 'asset/img/default-avatar.png'),
             'cp_avatar_width' => ($member->avatar_filename) ? $member->avatar_width : '',


### PR DESCRIPTION

protect cp_screen_name to be used as attribute

properly display non-English characters in channel names and author names inside entries listing

fixes #1184

EECORE-1199