### PR TITLE
on-the-fly image manipulation fixes

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -539,10 +539,19 @@ JSC;
             }
             if (isset($params['width'])) {
                 $imageLibConfig['width'] = (int) $params['width'];
+                if ($imageLibConfig['master_dim'] == 'auto' && !isset($params['height'])) {
+                    $imageLibConfig['master_dim'] = 'width';
+                    $imageLibConfig['height'] = 100;
+                }
             }
             if (isset($params['height'])) {
                 $imageLibConfig['height'] = (int) $params['height'];
+                if ($imageLibConfig['master_dim'] == 'auto' && !isset($params['width'])) {
+                    $imageLibConfig['master_dim'] = 'height';
+                    $imageLibConfig['width'] = 100;
+                }
             }
+
             ee()->image_lib->clear();
             ee()->image_lib->initialize($imageLibConfig);
 

--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -532,6 +532,11 @@ JSC;
                 'y_axis' => isset($params['y']) ? (int) $params['y'] : 0,
                 'rotation_angle' => (isset($params['angle']) && in_array($params['angle'], ['90', '180', '270', 'vrt', 'hor'])) ? $params['angle'] : null,
             );
+            //techically, both dimentions are always required, so we'll set defaults
+            if ($imageLibConfig['master_dim'] != 'auto') {
+                $imageLibConfig['width'] = 100;
+                $imageLibConfig['height'] = 100;
+            }
             if (isset($params['width'])) {
                 $imageLibConfig['width'] = (int) $params['width'];
             }

--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -553,6 +553,12 @@ JSC;
             }
 
             ee()->image_lib->clear();
+            if (!isset($imageLibConfig['width'])) {
+                ee()->image_lib->width = '';
+            }
+            if (!isset($imageLibConfig['height'])) {
+                ee()->image_lib->height = '';
+            }
             ee()->image_lib->initialize($imageLibConfig);
 
             if (!ee()->image_lib->$function()) {


### PR DESCRIPTION
set default width and height when master_dim is specified, so that one of those could be skipped

set correct master_dim if only one dimention is specified

fixes #1108
EECORE-1215

reset width and height from previous manipulations, if not explicitely set

fixes #854
EECORE-1214