### PR TITLE
Add better support for the Toggle field as an Entry Manager column

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -7,6 +7,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 Bullet list below, e.g.
 
    - Added <new feature>
+   - Changed how the Toggle field renders in a column in the Entry Manager
    - Fixed a bug (#<linked issue number>) where <bug behavior>.
    - Fixed a PHP 7.3+ warning that occurred when non-members triggered email notifications.
    - Fixed a bug where the initial sorting of content when populating a custom field based on other fields was incorrect.

--- a/system/ee/ExpressionEngine/Addons/toggle/ft.toggle.php
+++ b/system/ee/ExpressionEngine/Addons/toggle/ft.toggle.php
@@ -18,6 +18,7 @@ class Toggle_ft extends EE_Fieldtype
         'version' => '1.0.0'
     );
 
+    public $entry_manager_compatible = true;
     public $has_array_data = false;
 
     // used in display_field() below to set
@@ -258,29 +259,29 @@ class Toggle_ft extends EE_Fieldtype
         return true;
     }
 
+    /**
+     * @param string $data
+     * @param integer $field_id
+     * @param integer $entry
+     * @return string
+     */
     public function renderTableCell($data, $field_id, $entry)
     {
-        switch (true) {
-            case ($data === 'y'):
-                $out = lang('yes');
+        return ee('View')->make('ee:_shared/form/fields/toggle')->render([
+            'field_name' => $this->field_name,
+            'value' => $data,
+            'disabled' => true,
+        ]);
+    }
 
-                break;
-            case ($data === 'n'):
-                $out = lang('no');
-
-                break;
-            case ($data === 1):
-                $out = lang('on');
-
-                break;
-            case ($data === 0):
-            default:
-                $out = lang('off');
-
-                break;
-        }
-
-        return $out;
+    /**
+     * @return array
+     */
+    public function getTableColumnConfig()
+    {
+        return [
+            'encode' => false
+        ];
     }
 }
 


### PR DESCRIPTION
Render a disabled toggle field in the column instead of a 1, 0, yes, or no. When editing an entry the user sees a Toggle field, so give them the same experience in the Entry Manager.

## Nature of This Change

- [x] 🛁 Refactors existing code

## Is this backwards compatible?

- [x] Yes
- [ ] No