### PR TITLE
Exclude EE comments from being processed with Template Debugger

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -40,6 +40,7 @@ Bullet list below, e.g.
    - Fixed a bug with the error message when importing invalid channel sets
    - Fix a bug with debug variables not being filtered
    - Fix a bug with the importer converter filter
+   - Fix a bug ([#1086](https://github.com/ExpressionEngine/ExpressionEngine/issues/1086) where `{exp:` tags within EE comments would be found / reported by the tag debugger.
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/ExpressionEngine/Library/Advisor/TemplateAdvisor.php
+++ b/system/ee/ExpressionEngine/Library/Advisor/TemplateAdvisor.php
@@ -70,6 +70,12 @@ class TemplateAdvisor
                 ];
             }
 
+            // remove any EE comments in template first (to prevent tags within comments being flagged as problems)
+            // this can be destructive as we don't make any persistent changes to templates and getAllTags does not
+            // return line numbers of found tags
+            $regex_comments = '/(\{!--\s(?:.|\R)*?\s--\})/';
+            $template_data = preg_replace($regex_comments, '', $template_data);
+
             $tags_found = preg_match_all($regexp, $template_data, $keys, PREG_PATTERN_ORDER);
 
             $tmpl_info['details'][] = $keys;


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Addresses issue 1086.
Remove any EE comments in template before scanning for tags (to prevent tags within comments being flagged as problems).
Removal can be destructive as we don't make any persistent changes to templates and getAllTags does not return line numbers of found tags

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1086](https://github.com/ExpressionEngine/ExpressionEngine/issues/1086).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [X] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
No documentation implications.