### PR TITLE
fixed bug when during field creation selecting "populate from another…

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Fields/Fields.php
+++ b/system/ee/ExpressionEngine/Controller/Fields/Fields.php
@@ -439,8 +439,8 @@ class Fields extends AbstractFieldsController
 
         $field->set(ee('Security/XSS')->clean($_POST));
 
-        if ($field->field_pre_populate) {
-            list($channel_id, $field_id) = explode('_', $_POST['field_pre_populate_id']);
+        if ($field->field_pre_populate && ee('Request')->post('field_pre_populate_id')) {
+            list($channel_id, $field_id) = explode('_', ee('Request')->post('field_pre_populate_id'));
 
             $field->field_pre_channel_id = $channel_id;
             $field->field_pre_field_id = $field_id;


### PR DESCRIPTION
… field" with no field selected caused AJAX error

fixes #375

EECORE-1227

Thank you for contributing to ExpressionEngine! -->
