### PR TITLE
fix fetching option fieldtypes in channel form for PHP8

### DIFF
--- a/system/ee/ExpressionEngine/Addons/date/ft.date.php
+++ b/system/ee/ExpressionEngine/Addons/date/ft.date.php
@@ -88,8 +88,10 @@ class Date_ft extends EE_Fieldtype
      *
      * @param 	array
      */
-    public function display_field($field_data)
+    public function display_field($data)
     {
+        $field_data = $data;
+        
         ee()->lang->loadfile('content');
 
         $special = array('entry_date', 'expiration_date', 'comment_expiration_date');


### PR DESCRIPTION
session cache was not working properly in PHP8; remove it as it does not add much benefit anyways
resolves #746

related to https://github.com/ExpressionEngine/ExpressionEngine/pull/761

fixed channel form error when using date field in PHP8

fixes #837

EECORE-1230