### PR TITLE
ensure file inside File Grid field is only uploaded once when using Channel Form

### DIFF
--- a/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
@@ -487,7 +487,7 @@ class Grid_lib
                     // Hack for File fields in Channel form to get uploading
                     // working properly. This is the same hack done in
                     // Channel_form_lib for regular File fields
-                    if (REQ !== 'CP' && $column['col_type'] === 'file') {
+                    if (REQ !== 'CP' && $column['col_type'] === 'file' && $method == 'validate') {
                         $img = ee()->file_field->validate($_FILES[$col_id]['name'], $col_id);
                         $row[$col_id] = isset($img['value']) ? $img['value'] : '';
                     }


### PR DESCRIPTION
fixes #489

EECORE-1231

note to anyone who will be reviewing this:

when saving the entry, EE (particularly, `Grid_lib`) peforms validation first and then actual saving. The `File_field` library is attempting upload for validation (https://github.com/ExpressionEngine/ExpressionEngine/blob/42020f74c333e2449e21e6ab1fa4a22c9eb5c7cc/system/ee/legacy/libraries/File_field.php#L365)
Because of this, the file was getting uploaded twice - when validating and then when saving. It looks like validation is always happening, so adding extra condition to perform upload only in that phase should fix the problem (and this is already inside special condition for Channel Form)