### PR TITLE
properly validate arrays when using Required rule

### DIFF
--- a/system/ee/ExpressionEngine/Service/Validation/Rule/Required.php
+++ b/system/ee/ExpressionEngine/Service/Validation/Rule/Required.php
@@ -23,6 +23,15 @@ class Required extends ValidationRule
             $value = trim($value);
         }
 
+        if (is_array($value)) {
+            $value = array_filter($value, function($val) { 
+                return $val !== '';
+            });
+            if (empty($value)) {
+                return $this->stop();
+            }
+        }
+
         if ($value === '' or is_null($value)) {
             return $this->stop();
         }


### PR DESCRIPTION
empty array and arrays that only consist of empty strings will not pass validation

@obfuscode / @matthewjohns0n / whoever will be reviewing this - I'm a little hestant whether removing empty strings from array is the right thing to do here. However our checkboxes UI have empty hidden field, which adds empty string to the submitted data array. That empty string is stripped when field is saved. So I think cleaning the posted array would be the right thing to do.

fixes #1224

EECORE-1240
