### PR TITLE
Ask for migration location by default instead of defaulting to EE

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -45,6 +45,7 @@ Bullet list below, e.g.
    - Fix a bug with the importer converter filter
    - Fix a bug with Typography parse_url function
    - Added CLI commands for generating Prolets and Widgets
+   - Fixed a CLI bug where it didnt ask for the migration location if not specified
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/ExpressionEngine/Cli/Commands/CommandMakeMigration.php
+++ b/system/ee/ExpressionEngine/Cli/Commands/CommandMakeMigration.php
@@ -88,8 +88,7 @@ class CommandMakeMigration extends Cli
 
         $this->info(lang('command_make_migration_using_migration_name') . $this->migration_name);
 
-        // Set location
-        $this->migration_location = $this->option('--location', 'ExpressionEngine');
+        $this->migration_location  = $this->getOptionOrAsk("--location", lang('command_make_migration_where_to_generate_migration'), 'ExpressionEngine');
 
         // Set migration type based on create/update flags
         if ($this->option('--create')) {

--- a/system/ee/ExpressionEngine/Service/Migration/Factory.php
+++ b/system/ee/ExpressionEngine/Service/Migration/Factory.php
@@ -110,6 +110,14 @@ class Factory
             }
         }
 
+        // In this case, location is an add-on, so we need the addon folder to exist
+        if ($location !== 'ExpressionEngine') {
+            // Make sure the addon exists
+            if (!ee('Addon')->get($location)) {
+                throw new \Exception(lang('cli_error_the_specified_addon_does_not_exist'), 1);
+            }
+        }
+
         $migrationPath = $this->getMigrationPath($location);
 
         if (! $this->filesystem->isDir($migrationPath)) {

--- a/system/ee/language/english/cli_lang.php
+++ b/system/ee/language/english/cli_lang.php
@@ -92,6 +92,8 @@ $lang = array(
     'command_make_migration_what_table_is_migration_for'        => 'What table is this migration for?',
     'command_make_migration_ask_migration_action'               => 'What is the migration action',
     'command_make_migration_ask_migration_category'             => 'What is the migration category',
+    'command_make_migration_where_to_generate_migration'        => 'Where should we generate this migration? (ExpressionEngine or existing add-on)',
+
     // make:migration options
     'command_make_migration_option_name'                        => 'Name of migration',
     'command_make_migration_option_table'                       => 'Table name',


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Ask for the migration location when generating a migration instead of defaulting to ExpressionEngine.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
