### PR TITLE
Add default hook when generating an Ext

### DIFF
--- a/system/ee/ExpressionEngine/Cli/Commands/CommandMakeAddon.php
+++ b/system/ee/ExpressionEngine/Cli/Commands/CommandMakeAddon.php
@@ -145,6 +145,7 @@ class CommandMakeAddon extends Cli
             $this->data['hooks'] = $this->getOptionOrAsk(
                 '--hooks',
                 'command_make_addon_ext_hooks',
+                'example_hook'
             );
         }
 

--- a/system/ee/ExpressionEngine/Service/Generator/AddonGenerator.php
+++ b/system/ee/ExpressionEngine/Service/Generator/AddonGenerator.php
@@ -137,7 +137,16 @@ class AddonGenerator
         $extension_settings = '';
 
         foreach ($this->hooks as $hook) {
-            $hookData = Hooks::getByKey(strtoupper($hook));
+            $hookData = Hooks::getByKey(trim(strtoupper($hook)));
+
+            // If we didnt get a real hook, set up a default
+            if ($hookData === false) {
+                $hookData = [
+                    'name' => $hook,
+                    'params' => '',
+                    'library' => ''
+                ];
+            }
 
             $hookArrayStub = $this->filesystem->read($this->stub('hook_array.php'));
             $hookArrayStub = $this->write('hook_name', $hook, $hookArrayStub);


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fixes a bug where there was no default hook when generating an ext, which is required.


## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
