### PR TITLE
Set has_publish_fields to default to no when generating an addon

### DIFF
--- a/system/ee/ExpressionEngine/Service/Generator/AddonGenerator.php
+++ b/system/ee/ExpressionEngine/Service/Generator/AddonGenerator.php
@@ -55,7 +55,7 @@ class AddonGenerator
         $this->author_url = $data['author_url'];
         $this->has_settings = get_bool_from_string($data['has_settings']);
         $this->has_cp_backend = $data['has_settings'] ? 'y' : 'n';
-        $this->has_publish_fields = $data['has_settings'] ? 'y' : 'n';
+        $this->has_publish_fields = 'n';
         $this->hooks = isset($data['hooks']) ? $data['hooks'] : null;
         $this->services = isset($data['services']) ? $data['services'] : null;
         $this->compatibility = isset($data['compatibility']) ? $data['compatibility'] : null;


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Set has_publish_fields to default to no when generating an addon

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
