### PR TITLE
Fix issue with cross platform newline matching

### DIFF
--- a/system/ee/ExpressionEngine/Service/Generator/AddonGenerator.php
+++ b/system/ee/ExpressionEngine/Service/Generator/AddonGenerator.php
@@ -425,7 +425,7 @@ class AddonGenerator
 
     private function clearLine($string, $contents)
     {
-        return str_replace($string . "\n", '', $contents);
+        return preg_replace("~" . preg_quote($string) . "~", '', $contents);
     }
 
     public function slug($word)


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fixes issue with  cross platform newline matching. Lines  in  the  addon setup  file were not getting  replaced properly when  using  windows. 


<!-- If this pull request resolves a project issue, provide a link: -->
Resolves EEPRO-247

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
