### PR TITLE
bug fix, Field grid textarea field tool checkboxes not copying correct EECORE-1196

### DIFF
--- a/themes/ee/asset/javascript/src/cp/grid.js
+++ b/themes/ee/asset/javascript/src/cp/grid.js
@@ -857,6 +857,7 @@ Grid.Settings.prototype = {
 				// .prop('checked', true) doesn't work, must set the attribute
 				if ($(this).prop('checked')) {
 					new_input.attr('checked', 'checked');
+					new_input.attr('value', 'y');
 				}
 			}
 			// Handle radio buttons


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

EECORE-1196
fixes #1100 
Copying text areas in a grid field should now correctly copy the field tools checkboxes values when saved.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
