### PR TITLE
EECORE-1312 Get Variable Modifiers working for comments again

### DIFF
--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3504,7 +3504,13 @@ class EE_Template
         }
 
         // same with modified, sometimes devs run this method themselves instead of a full parse_variables()
-        if ($this->modified_vars === false) {
+        /*
+        Reason for if condtion change:
+        mod.comment switched to using this function instead of parse_variables function and now no Variable Modifiers work in comments
+        i.e. {comment:limit characters="20"} will not parse correctly. The getModifiedVariables() is never run here and is run without any checks
+        in parse_variables().  Keep the $this->modified_vars === false condition because of comment above.
+        */
+        if (empty($this->modified_vars) || $this->modified_vars === false) {
             $this->modified_vars = $this->getModifiedVariables();
         }
 

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3504,12 +3504,6 @@ class EE_Template
         }
 
         // same with modified, sometimes devs run this method themselves instead of a full parse_variables()
-        /*
-        Reason for if condtion change:
-        mod.comment switched to using this function instead of parse_variables function and now no Variable Modifiers work in comments
-        i.e. {comment:limit characters="20"} will not parse correctly. The getModifiedVariables() is never run here and is run without any checks
-        in parse_variables().  Keep the $this->modified_vars === false condition because of comment above.
-        */
         if (empty($this->modified_vars) || $this->modified_vars === false) {
             $this->modified_vars = $this->getModifiedVariables();
         }


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview
EECORE-1312
issue id #1264 

Mod.comment had changes that has it use function parse_variables_row instead of function parse_variables.  

parse_variables_row's condition to run getModifiedVariables was not being met. (getModifiedVariables was called directly in parse_variables.)

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).
Resolves: https://github.com/ExpressionEngine/ExpressionEngine/issues/1264
## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
