### PR TITLE
perfomance improvements

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -2094,13 +2094,15 @@ class Channel
 				LEFT JOIN exp_channel_data	AS wd ON t.entry_id = wd.entry_id
 				LEFT JOIN exp_members		AS m  ON m.member_id = t.author_id ";
 
-        if (! empty($this->mfields)) {
+        $mfieldCount = 0;
+        if ($this->enable['member_data'] && ! empty($this->mfields)) {
             $sql .= ", md.* ";
             $from .= "LEFT JOIN exp_member_data	AS md ON md.member_id = m.member_id ";
 
             foreach ($this->mfields as $mfield) {
                 // Only join non-legacy field tables
                 if ($mfield[2] == 'n') {
+                    $mfieldCount++;
                     $field_id = $mfield[0];
                     $table = "exp_member_data_field_{$field_id}";
                     $sql .= ", {$table}.*";
@@ -2109,31 +2111,30 @@ class Channel
             }
         }
 
-        $cache_key = "mod.channel/Channels/" . implode(',', $channel_ids);
-
-        if (($channels = ee()->session->cache(__CLASS__, $cache_key, false)) === false) {
-            $channels = ee('Model')->get('Channel', $channel_ids)
-                ->with('FieldGroups', 'CustomFields')
-                ->all();
-
-            ee()->session->set_cache(__CLASS__, $cache_key, $channels);
-        }
-
         $fields = array();
 
-        foreach ($channels as $channel) {
-            foreach ($channel->getAllCustomFields() as $field) {
-                if (! $field->legacy_field_data) {
-                    $fields[$field->field_id] = $field;
+        if ($this->enable['custom_fields']) {
+            $cache_key = "mod.channel/Channels/" . implode(',', $channel_ids);
+
+            if (($channels = ee()->session->cache(__CLASS__, $cache_key, false)) === false) {
+                $channels = ee('Model')->get('Channel', $channel_ids)
+                    ->with('FieldGroups', 'CustomFields')
+                    ->all();
+
+                ee()->session->set_cache(__CLASS__, $cache_key, $channels);
+            }
+
+            foreach ($channels as $channel) {
+                foreach ($channel->getAllCustomFields() as $field) {
+                    if (! $field->legacy_field_data) {
+                        $fields[$field->field_id] = $field;
+                    }
                 }
             }
         }
 
         //MySQL has limit of 61 joins, so we need to make sure to not hit it
-        $join_limit = 61 - 4;
-        if (!empty($this->mfields)) {
-            $join_limit = $join_limit - 1 - count($this->mfields);
-        }
+        $join_limit = 61 - 7 - $mfieldCount;
         $chunks = array_chunk($fields, $join_limit);
 
         $chunk = (array_shift($chunks)) ?: array();

--- a/system/ee/legacy/libraries/Session.php
+++ b/system/ee/legacy/libraries/Session.php
@@ -605,9 +605,12 @@ class EE_Session
         $this->userdata['group_description'] = $this->member_model->PrimaryRole->description;
 
         // Add in the Permissions for backwards compatibility
-        foreach ($this->member_model->getPermissions() as $perm => $perm_id) {
+        $permissions = $this->member_model->getPermissions();
+        foreach ($permissions as $perm => $perm_id) {
             $this->userdata[$perm] = 'y';
         }
+        //ensure we get those cached, as they are not cached on model layer yet
+        $this->set_cache("ExpressionEngine\Model\Member\Member", "Member/{$this->userdata['member_id']}/Permissions", $permissions);
 
         // Remember me may have validated the user agent for us, if so create a fingerprint now that we
         // can salt it properly for the user

--- a/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
@@ -39,7 +39,7 @@ class EE_Channel_simple_variable_parser implements EE_Channel_parser_component
         $result_path = (preg_match("/" . LD . $pre->prefix() . "member_search_path\s*=(.*?)" . RD . "/s", $tagdata, $match)) ? $match[1] : 'search/results';
         $result_path = str_replace(array('"',"'"), "", $result_path);
 
-        return ee()->functions->fetch_site_index(0, 0) . QUERY_MARKER . 'ACT=' . ee()->functions->fetch_action_id('Search', 'do_search') . '&amp;result_path=' . $result_path . '&amp;mbr=';
+        return (strpos($tagdata, 'member_search_path') !== false ) ? ee()->functions->fetch_site_index(0, 0) . QUERY_MARKER . 'ACT=' . ee()->functions->fetch_action_id('Search', 'do_search') . '&amp;result_path=' . $result_path . '&amp;mbr=' : '';
     }
 
     /**


### PR DESCRIPTION
cache member permissions directly in session library

only preparse {member_search_path} if it's present in template

if {exp:channel:entries} tag has disable="custom_fields" parameter, do not join custom fields

also reduce fields chunk size for joins

fixes #1280

EECORE-1332

fixes #751