### PR TITLE
add sticky="none" parameter for exp:channel:entries

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -1144,6 +1144,8 @@ class Channel
         // Only Sticky Entries
         if (ee()->TMPL->fetch_param('sticky') == 'only') {
             $sql .= " AND t.sticky = 'y' ";
+        } elseif (ee()->TMPL->fetch_param('sticky') == 'none') {
+            $sql .= " AND t.sticky != 'y' ";
         }
 
         /**------


### PR DESCRIPTION
fixes #488

EECORE-1334

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/237
