### PR TITLE
added check to ensure an edit_date value actually exists

### DIFF
--- a/system/ee/ExpressionEngine/Addons/rss/mod.rss.php
+++ b/system/ee/ExpressionEngine/Addons/rss/mod.rss.php
@@ -49,8 +49,8 @@ class Rss
 
         $tmp = $this->_setup_meta_query($query);
         $query = $tmp[0];
-        $last_update = $tmp[1];
-        $edit_date = $tmp[2];
+        $last_update = empty($tmp[1]) ? $tmp[3] : $tmp[1] ;
+        $edit_date = empty($tmp[2]) ? $tmp[3] : $tmp[2] ;
         $entry_date = $tmp[3];
 
         if ($query->num_rows() === 0) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview
Discovered issue where if an entry doesn't have an edit_date value (as is the case with the default theme), an error is thrown when using the RSS addon.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

