### PR TITLE
added edit_date to entries for default theme install

### DIFF
--- a/system/ee/ExpressionEngine/Service/Theme/ThemeInstaller.php
+++ b/system/ee/ExpressionEngine/Service/Theme/ThemeInstaller.php
@@ -421,7 +421,7 @@ class ThemeInstaller
                 $entry->month = date('m');
                 $entry->day = date('d');
                 $entry->entry_date = ee()->localize->now;
-
+                $entry->edit_date = ee()->localize->now;
                 $post_mock = array();
 
                 foreach ($entry_data->custom_fields as $key => $val) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview
Adds edit_date value to default theme entries, which was found to cause issues when not entered into database.


## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
