### PR TITLE
update default theme install to install RSS add-on by default

### DIFF
--- a/system/ee/installer/site_themes/default/extra.json
+++ b/system/ee/installer/site_themes/default/extra.json
@@ -41,6 +41,7 @@
 		}
 	},
 	"modules": [
-		"email"
+		"email",
+		"rss"
 	]
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview
This installs the RSS add-on with the default theme since the default theme uses the RSS add-on.


## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [ x] Yes
- [ ] No
