### PR TITLE
Add sticky entry column to entries table

### DIFF
--- a/changelogs/minor.md
+++ b/changelogs/minor.md
@@ -4,10 +4,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 
 ## Minor Release
 
-Bullet list below, e.g.
-   - Added Google reCAPTCHA as an option for system wide CAPTCHA
-   - Added ability to disable Live Preview on a per channel basis
-   - Added extension hooks for Fluid Fields
+   - Added Sticky entry column to entries table
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
@@ -21,6 +21,7 @@ class ColumnFactory
         'url_title' => Columns\UrlTitle::class,
         'author' => Columns\Author::class,
         'status' => Columns\Status::class,
+        'sticky' => Columns\Sticky::class,
         'entry_date' => Columns\EntryDate::class,
         'expiration_date' => Columns\ExpirationDate::class,
         'channel' => Columns\ChannelName::class,

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/Sticky.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/Sticky.php
@@ -20,7 +20,7 @@ class Sticky extends Column
 {
     public function getTableColumnLabel()
     {
-        return 'sticky';
+        return 'sticky_entry';
     }
 
     public function getTableColumnConfig()

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/Sticky.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/Sticky.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2021, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Library\CP\EntryManager\Columns;
+
+use ExpressionEngine\Library\CP\EntryManager\Columns\Column;
+use ExpressionEngine\Library\CP\Table;
+
+/**
+ * Sticky Column
+ */
+class Sticky extends Column
+{
+    public function getTableColumnLabel()
+    {
+        return 'sticky';
+    }
+
+    public function getTableColumnConfig()
+    {
+        return [
+            'type' => Table::COL_ID
+        ];
+    }
+
+    public function renderTableCell($data, $field_id, $entry)
+    {
+        switch (true) {
+            case ($entry->sticky == 1):
+            case ($entry->sticky === 'y'):
+                $out = lang('yes');
+
+                break;
+
+            default:
+                $out = lang('no');
+
+                break;
+        }
+
+        return $out;
+    }
+}

--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -239,7 +239,7 @@ class EntryListing
     {
         $entries = ee('Model')->get('ChannelEntry')
             ->with('Autosaves', 'Channel')
-            ->fields('entry_id', 'title', 'Channel.channel_title', 'Channel.preview_url', 'Channel.status_group', 'comment_total', 'entry_date', 'status')
+            ->fields('entry_id', 'title', 'Channel.channel_title', 'Channel.preview_url', 'Channel.status_group', 'comment_total', 'entry_date', 'status', 'sticky')
             ->filter('site_id', $this->site_id);
 
         if (in_array('Columns', $this->extra_filters)) {

--- a/system/ee/ExpressionEngine/Service/Filter/Columns.php
+++ b/system/ee/ExpressionEngine/Service/Filter/Columns.php
@@ -32,7 +32,7 @@ class Columns extends Filter
             $this->channel_id = $channel->channel_id;
         }
 
-        $this->default_value = ['entry_id', 'title', 'entry_date', 'author', 'status'];
+        $this->default_value = ['entry_id', 'title', 'entry_date', 'author', 'status', 'sticky'];
     }
 
     // get columns from view

--- a/system/ee/ExpressionEngine/Service/Filter/Columns.php
+++ b/system/ee/ExpressionEngine/Service/Filter/Columns.php
@@ -32,7 +32,7 @@ class Columns extends Filter
             $this->channel_id = $channel->channel_id;
         }
 
-        $this->default_value = ['entry_id', 'title', 'entry_date', 'author', 'status', 'sticky'];
+        $this->default_value = ['entry_id', 'title', 'entry_date', 'author', 'status'];
     }
 
     // get columns from view

--- a/system/ee/language/english/content_lang.php
+++ b/system/ee/language/english/content_lang.php
@@ -174,6 +174,8 @@ $lang = array(
 
     'sticky' => 'Make entry sticky?',
 
+    'sticky_entry' => 'Sticky Entry',
+
     'sticky_desc' => 'When enabled, this entry will be given preference in sorted listings.',
 
     'url_title' => '<abbr title="Unified Resource Locator">URL</abbr> title',


### PR DESCRIPTION
## Overview

Add a column for sticky on table of entries.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1293](https://github.com/ExpressionEngine/ExpressionEngine/issues/1293).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
