### PR TITLE
fixed JS error in ordering relationships fields, EECORE-1277

### DIFF
--- a/themes/ee/asset/javascript/src/jquery/ui/jquery.ui.sortable.js
+++ b/themes/ee/asset/javascript/src/jquery/ui/jquery.ui.sortable.js
@@ -426,8 +426,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		}
 
 		//Call callbacks
-		// hide to prevent the script from breaking when the order is changed
-		// this._trigger("sort", event, this._uiHash()); 
+		this._trigger("sort", event, this._uiHash()); 
 
 
 		this.lastPositionAbs = this.positionAbs;

--- a/themes/ee/asset/javascript/src/jquery/ui/jquery.ui.sortable.js
+++ b/themes/ee/asset/javascript/src/jquery/ui/jquery.ui.sortable.js
@@ -412,7 +412,6 @@ return $.widget("ui.sortable", $.ui.mouse, {
 				} else {
 					break;
 				}
-
 				this._trigger("change", event, this._uiHash());
 				break;
 			}
@@ -427,7 +426,9 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		}
 
 		//Call callbacks
-		this._trigger("sort", event, this._uiHash());
+		// hide to prevent the script from breaking when the order is changed
+		// this._trigger("sort", event, this._uiHash()); 
+
 
 		this.lastPositionAbs = this.positionAbs;
 		return false;
@@ -493,6 +494,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		}
 
 		if (this.placeholder) {
+
 			//$(this.placeholder[0]).remove(); would have been the jQuery way - unfortunately, it unbinds ALL events from the original node!
 			if(this.placeholder[0].parentNode) {
 				this.placeholder[0].parentNode.removeChild(this.placeholder[0]);

--- a/themes/ee/cp/js/build/components/relationship.js
+++ b/themes/ee/cp/js/build/components/relationship.js
@@ -90,6 +90,11 @@ function (_React$Component) {
           // Save the start index for later
           $(_assertThisInitialized(_this)).attr('data-start-index', ui.item.index());
         },
+        helper: function(event, row)  // Fixed an issue where the helper was the same as the current item.
+        {
+          var $helper = row.clone();
+          return $helper;
+        },
         stop: function stop(event, ui) {
           var newIndex = ui.item.index();
           var oldIndex = $(_assertThisInitialized(_this)).attr('data-start-index'); // Cancel the sort so jQeury doesn't move the items

--- a/themes/ee/cp/js/build/components/relationship.js
+++ b/themes/ee/cp/js/build/components/relationship.js
@@ -85,15 +85,14 @@ function (_React$Component) {
         containment: 'parent',
         handle: '.list-item__handle',
         items: '.list-item',
-        sort: EE.sortable_sort_helper,
+        sort: function sort(event, ui) {
+          try {
+            EE.sortable_sort_helper(event, ui);
+          } catch (error) {}
+        },
         start: function start(event, ui) {
           // Save the start index for later
           $(_assertThisInitialized(_this)).attr('data-start-index', ui.item.index());
-        },
-        helper: function(event, row)  // Fixed an issue where the helper was the same as the current item.
-        {
-          var $helper = row.clone();
-          return $helper;
         },
         stop: function stop(event, ui) {
           var newIndex = ui.item.index();

--- a/themes/ee/cp/js/src/components/relationship.jsx
+++ b/themes/ee/cp/js/src/components/relationship.jsx
@@ -122,7 +122,11 @@ class Relationship extends React.Component {
 			containment: 'parent',
 			handle: '.list-item__handle',
 			items: '.list-item',
-			sort: EE.sortable_sort_helper,
+			sort: (event, ui) => {
+                try {
+                    EE.sortable_sort_helper(event, ui)
+                } catch (error) {}
+            },
 			start: (event, ui) => {
 				// Save the start index for later
 				$(this).attr('data-start-index', ui.item.index());


### PR DESCRIPTION
the error appeared after:
1. the image has been upload into the grid field
2. were added 2 items to the relationship field 
3. were re-ordered these relationship fields