### PR TITLE
add a way to update signaure and manage sig settings directly from cp…

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Profile/Settings.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Profile/Settings.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This source file is part of the open source project
  * ExpressionEngine (https://expressionengine.com)
@@ -24,7 +25,7 @@ class Settings extends Profile
     {
         $id = ee()->input->get('id');
 
-        if ($id != $this->session->userdata['member_id'] && ! empty($id)) {
+        if ($id != $this->session->userdata['member_id'] && !empty($id)) {
             parent::permissionCheck();
         }
     }
@@ -81,55 +82,132 @@ class Settings extends Profile
             )
         );
 
-        // Avatar settings
-        $avatar_directory = ee('Model')->get('UploadDestination')
-            ->filter('name', 'Avatars')
-            ->filter('site_id', ee()->config->item('site_id'))
-            ->first();
-
-        if (empty($avatar_directory) || !$avatar_directory->exists()) {
-            $vars['sections']['avatar_settings'] = [
+        //Signature Settings To update the signature text
+        if (ee()->config->item('allow_signatures') === "y") {
+            $desc = $this->member->signature;
+            if (!$desc) {
+                $desc = '<b>'. lang('update_sig_text_desc_null') . '<b>';
+            } else {
+                $desc = sprintf(lang('update_sig_text_desc'), '<b>'. $this->member->signature .'<b>');
+            }
+            $vars['sections'][] = array(
                 array(
-                    'title' => 'change_avatar',
-                    'desc' => sprintf(lang('avatar_path_does_not_exist'), ee('CP/URL', 'settings/avatars')),
-                    'fields' => []
-                ),
-            ];
-        } else {
-            // Make sure the filename is not an empty string, as that will cause filesystem->exists() to return true
-            $avatar_exists = ($this->member->avatar_filename != '' && $avatar_directory->getFilesystem()->exists($this->member->avatar_filename));
-
-            $vars['sections']['avatar_settings'] = array(
-                array(
-                    'title' => 'current_avatar',
-                    'desc' => 'current_avatar_desc',
+                    'title' => 'signature_settings_text',
+                    'desc' => $desc,
                     'fields' => array(
-                        'avatar_filename' => array(
-                            'type' => 'image',
-                            'id' => 'avatar',
-                            'edit' => false,
-                            'image' => $avatar_exists ? $avatar_directory->url . $this->member->avatar_filename : '',
-                            'value' => $this->member->avatar_filename
+                        'signature' => array(
+                            'type' => 'text',
                         )
                     )
                 ),
-                array(
-                    'title' => 'change_avatar',
-                    'desc' => sprintf(lang('change_avatar_desc'), $avatar_directory->max_size),
-                    'fields' => [
-                        'upload_avatar' => [
-                            'type' => 'html',
-                            'content' => form_upload('upload_avatar')
-                        ]
-                    ]
-                )
             );
+        }
 
-            // Hide the current avatar section if the member doesn't have one
-            if (! $avatar_exists) {
-                $vars['sections']['avatar_settings'][0]['hide'] = true;
+        //Signature Settings To update the signature image
+        if (ee()->config->item('allow_signatures') === "y" && ee()->config->item('sig_allow_img_upload') === "y") {
+            $signature_directory = ee('Model')->get('UploadDestination')
+                ->filter('name', 'Signature Attachments')
+                ->filter('site_id', ee()->config->item('site_id'))
+                ->first();
+
+            if (empty($signature_directory) || !$signature_directory->exists()) {
+                $vars['sections']['signature_settings'] = [
+                    array(
+                        'title' => 'change_signature',
+                        'desc' => sprintf(lang('avatar_path_does_not_exist'), ee('CP/URL', 'settings/avatars')),
+                        'fields' => []
+                    ),
+                ];
+            } else {
+                // Make sure the filename is not an empty string, as that will cause filesystem->exists() to return true
+                $signature_exists = ($this->member->sig_img_filename != '' && $signature_directory->getFilesystem()->exists($this->member->sig_img_filename));
+
+                $vars['sections']['signature_settings'] = array(
+                    array(
+                        'title' => 'current_signature',
+                        'desc' => 'current_signature_desc',
+                        'fields' => array(
+                            'signature_filename' => array(
+                                'type' => 'image',
+                                'id' => 'signature',
+                                'edit' => false,
+                                'image' => $signature_exists ? $signature_directory->url . $this->member->sig_img_filename : '',
+                                'value' => $this->member->sig_img_filename
+                            )
+                        )
+                    ),
+                    array(
+                        'title' => 'change_signature',
+                        'desc' => sprintf(lang('change_signature_desc'), $signature_directory->max_size),
+                        'fields' => [
+                            'upload_signature' => [
+                                'type' => 'html',
+                                'content' => form_upload('upload_signature')
+                            ]
+                        ]
+                    )
+                );
+
+                // Hide the current sig section if the member doesn't have one
+                if (!$signature_exists) {
+                    $vars['sections']['signature_settings'][0]['hide'] = true;
+                }
             }
         }
+
+        if (ee()->config->item('allow_avatar_uploads') === "y") {
+            // Avatar settings
+            $avatar_directory = ee('Model')->get('UploadDestination')
+                ->filter('name', 'Avatars')
+                ->filter('site_id', ee()->config->item('site_id'))
+                ->first();
+
+            if (empty($avatar_directory) || !$avatar_directory->exists()) {
+                $vars['sections']['avatar_settings'] = [
+                    array(
+                        'title' => 'change_avatar',
+                        'desc' => sprintf(lang('avatar_path_does_not_exist'), ee('CP/URL', 'settings/avatars')),
+                        'fields' => []
+                    ),
+                ];
+            } else {
+                // Make sure the filename is not an empty string, as that will cause filesystem->exists() to return true
+                $avatar_exists = ($this->member->avatar_filename != '' && $avatar_directory->getFilesystem()->exists($this->member->avatar_filename));
+
+                $vars['sections']['avatar_settings'] = array(
+                    array(
+                        'title' => 'current_avatar',
+                        'desc' => 'current_avatar_desc',
+                        'fields' => array(
+                            'avatar_filename' => array(
+                                'type' => 'image',
+                                'id' => 'avatar',
+                                'edit' => false,
+                                'image' => $avatar_exists ? $avatar_directory->url . $this->member->avatar_filename : '',
+                                'value' => $this->member->avatar_filename
+                            )
+                        )
+                    ),
+                    array(
+                        'title' => 'change_avatar',
+                        'desc' => sprintf(lang('change_avatar_desc'), $avatar_directory->max_size),
+                        'fields' => [
+                            'upload_avatar' => [
+                                'type' => 'html',
+                                'content' => form_upload('upload_avatar')
+                            ]
+                        ]
+                    )
+                );
+
+                // Hide the current avatar section if the member doesn't have one
+                if (!$avatar_exists) {
+                    $vars['sections']['avatar_settings'][0]['hide'] = true;
+                }
+            }
+        }
+
+
 
         // Date fields need some lang values from the content lang
         ee()->lang->loadfile('content');
@@ -150,10 +228,10 @@ class Settings extends Profile
         }
 
         // Save settings
-        if (! empty($_POST)) {
+        if (!empty($_POST)) {
             $result = $this->saveSettings($vars['sections']);
 
-            if (! is_bool($result)) {
+            if (!is_bool($result)) {
                 return $result;
             }
 
@@ -187,11 +265,13 @@ class Settings extends Profile
     protected function saveSettings($settings)
     {
         unset($settings['avatar_settings']);
+        unset($settings['signatrue_settings']);
 
-        // Save the avatar
+        // Save the avatar and Signature images
         $success = $this->uploadAvatar();
+        $success2 = $this->uploadSignature();
 
-        if (! $success) {
+        if (!$success && !$success2) {
             parent::saveSettings($settings);
 
             return false;
@@ -205,7 +285,7 @@ class Settings extends Profile
     protected function uploadAvatar()
     {
         // If nothing was chosen, keep the current avatar.
-        if (! isset($_FILES['upload_avatar']) || empty($_FILES['upload_avatar']['name'])) {
+        if (!isset($_FILES['upload_avatar']) || empty($_FILES['upload_avatar']['name'])) {
             $this->member->avatar_filename = ee()->security->sanitize_filename(ee()->input->post('avatar_filename'));
 
             return true;
@@ -257,8 +337,8 @@ class Settings extends Profile
         ee()->upload->do_upload('file');
         $original = ee()->upload->upload_path . ee()->upload->file_name;
 
-        if (! @copy($original, $file_path)) {
-            if (! @move_uploaded_file($original, $file_path)) {
+        if (!@copy($original, $file_path)) {
+            if (!@move_uploaded_file($original, $file_path)) {
                 ee('CP/Alert')->makeInline('shared-form')
                     ->asIssue()
                     ->withTitle(lang('upload_filedata_error'))
@@ -273,6 +353,81 @@ class Settings extends Profile
 
         // Save the new avatar filename
         $this->member->avatar_filename = $filename;
+
+        return true;
+    }
+
+    protected function uploadSignature()
+    {
+        // If nothing was chosen, keep the current
+        if (!isset($_FILES['upload_signature']) || empty($_FILES['upload_signature']['name'])) {
+            $this->member->sig_img_filename = ee()->security->sanitize_filename(ee()->input->post('signature_filename'));
+
+            return true;
+        }
+
+        $existing = ee()->config->item('sig_img_path') . $this->member->sig_img_filename;
+
+        // Remove the member's existing signature
+        if (file_exists($existing) && is_file($existing)) {
+            unlink($existing);
+        }
+
+        ee()->load->library('filemanager');
+
+        $directory = ee('Model')->get('UploadDestination')
+            ->filter('name', 'Signature Attachments')
+            ->filter('site_id', ee()->config->item('site_id'))
+            ->first();
+
+        $upload_response = ee()->filemanager->upload_file($directory->id, 'upload_signature');
+
+        if (isset($upload_response['error'])) {
+            ee('CP/Alert')->makeInline('shared-form')
+                ->asIssue()
+                ->withTitle(lang('upload_filedata_error'))
+                ->addToBody($upload_response['error'])
+                ->now();
+
+            return false;
+        }
+
+        // We don't have the suffix, so first we explode to avoid passed by reference error
+        // Then we grab our suffix
+        $name_array = explode('.', $_FILES['upload_signature']['name']);
+        $suffix = array_pop($name_array);
+
+        $name = $_FILES['upload_signature']['name'];
+        $name = 'signature_' . $this->member->member_id . '.' . $suffix;
+
+        $file_path = ee()->filemanager->clean_filename(
+            basename($name),
+            $directory->id,
+            array('ignore_dupes' => false)
+        );
+        $filename = basename($file_path);
+
+        // Upload the file
+        ee()->load->library('upload', array('upload_path' => dirname($file_path)));
+        ee()->upload->do_upload('file');
+        $original = ee()->upload->upload_path . ee()->upload->file_name;
+
+        if (!@copy($original, $file_path)) {
+            if (!@move_uploaded_file($original, $file_path)) {
+                ee('CP/Alert')->makeInline('shared-form')
+                    ->asIssue()
+                    ->withTitle(lang('upload_filedata_error'))
+                    ->now();
+
+                return false;
+            }
+        }
+
+        unlink($original);
+        $result = (array) ee()->upload;
+
+        // Save the new signature filename
+        $this->member->sig_img_filename = $filename;
 
         return true;
     }

--- a/system/ee/ExpressionEngine/Controller/Settings/Settings.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Settings.php
@@ -102,6 +102,7 @@ class Settings extends CP_Controller
             $list->addItem(lang('member_settings'), ee('CP/URL')->make('settings/members'));
             $list->addItem(lang('messages'), ee('CP/URL')->make('settings/messages'));
             $list->addItem(lang('avatars'), ee('CP/URL')->make('settings/avatars'));
+            $list->addItem(lang('signature'), ee('CP/URL')->make('settings/signature'));
         }
 
         if (ee('Permission')->can('access_security_settings')) {

--- a/system/ee/ExpressionEngine/Controller/Settings/Signature.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Signature.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2021, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Controller\Settings;
+
+use CP_Controller;
+
+/**
+ * signatures Settings Controller
+ */
+class Signature extends Settings
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        if (! ee('Permission')->hasAll('can_access_members', 'can_admin_design')) {
+            show_error(lang('unauthorized_access'), 403);
+        }
+    }
+
+    public function index()
+    {
+        $vars['sections'] = array(
+            'url_path_settings_title' => array(
+                array(
+                    'title' => 'signature_url',
+                    'desc' => 'signature_url_desc',
+                    'fields' => array(
+                        'signature_url' => array('type' => 'text')
+                    )
+                ),
+                array(
+                    'title' => 'signature_path',
+                    'desc' => 'signature_path_desc',
+                    'fields' => array(
+                        'signature_path' => array('type' => 'text')
+                    )
+                )
+            ),
+            'signature_file_restrictions' => array(
+                array(
+                    'title' => 'signature_max_width',
+                    'fields' => array(
+                        'signature_max_width' => array('type' => 'text')
+                    )
+                ),
+                array(
+                    'title' => 'signature_max_height',
+                    'fields' => array(
+                        'signature_max_height' => array('type' => 'text')
+                    )
+                ),
+                array(
+                    'title' => 'signature_max_kb',
+                    'fields' => array(
+                        'signature_max_kb' => array('type' => 'text')
+                    )
+                )
+            )
+        );
+
+        ee()->form_validation->set_rules(array(
+            array(
+                'field' => 'signature_url',
+                'label' => 'lang:signature_url',
+                'rules' => 'strip_tags|valid_xss_check'
+            ),
+            array(
+                'field' => 'signature_path',
+                'label' => 'lang:signature_path',
+                'rules' => 'strip_tags|valid_xss_check|file_exists|writable'
+            ),
+            array(
+                'field' => 'signature_max_width',
+                'label' => 'lang:signature_max_width',
+                'rules' => 'integer'
+            ),
+            array(
+                'field' => 'signature_max_height',
+                'label' => 'lang:signature_max_height',
+                'rules' => 'integer'
+            ),
+            array(
+                'field' => 'signature_max_kb',
+                'label' => 'lang:signature_max_kb',
+                'rules' => 'integer'
+            )
+        ));
+
+        ee()->form_validation->validateNonTextInputs($vars['sections']);
+
+        $base_url = ee('CP/URL')->make('settings/signature');
+
+        if (AJAX_REQUEST) {
+            ee()->form_validation->run_ajax();
+            exit;
+        } elseif (ee()->form_validation->run() !== false) {
+            $directory_settings = array(
+                'signature_path' => ee()->input->post('signature_path'),
+                'signature_url' => ee()->input->post('signature_url'),
+                'signature_max_kb' => ee()->input->post('signature_max_kb'),
+                'signature_max_width' => ee()->input->post('signature_max_width'),
+                'signature_max_height' => ee()->input->post('signature_max_height')
+            );
+
+            if ($this->saveSettings($vars['sections'])
+                && $this->updateUploadDirectory($directory_settings)) {
+                ee()->view->set_message('success', lang('preferences_updated'), lang('preferences_updated_desc'), true);
+            }
+
+            ee()->functions->redirect($base_url);
+        } elseif (ee()->form_validation->errors_exist()) {
+            ee()->view->set_message('issue', lang('settings_save_error'), lang('settings_save_error_desc'));
+        }
+
+        ee()->view->ajax_validate = true;
+        ee()->view->base_url = $base_url;
+        ee()->view->cp_page_title = lang('signature_settings');
+        ee()->view->save_btn_text = 'btn_save_settings';
+        ee()->view->save_btn_text_working = 'btn_saving';
+
+        ee()->view->cp_breadcrumbs = array(
+            '' => lang('signature_settings')
+        );
+
+        ee()->cp->render('settings/form', $vars);
+    }
+
+    /**
+     * Update the upload preferences for the associated upload directory
+     *
+     * @param mixed $data
+     * @access private
+     * @return void
+     */
+    private function updateUploadDirectory($data)
+    {
+        $directory = ee('Model')->get('UploadDestination')
+            ->filter('name', 'Signature Attachments')
+            ->filter('site_id', ee()->config->item('site_id'))
+            ->first();
+
+        if (! $directory) {
+            $directory = ee('Model')->make('UploadDestination');
+            $directory->name = 'Signature Attachments';
+            $directory->site_id = ee()->config->item('site_id');
+            $directory->Module = ee('Model')->get('Module')->filter('module_name', 'Member')->first();
+        }
+        $directory->server_path = $data['signature_path'];
+        $directory->url = $data['signature_url'];
+        $directory->max_size = $data['signature_max_kb'];
+        $directory->max_width = $data['signature_max_width'];
+        $directory->max_height = $data['signature_max_height'];
+        $directory->Files = null;
+        $directory->save();
+
+        return true;
+    }
+}
+// END CLASS
+
+// EOF

--- a/system/ee/language/english/myaccount_lang.php
+++ b/system/ee/language/english/myaccount_lang.php
@@ -88,6 +88,10 @@ $lang = array(
 
     'change_avatar_desc' => 'Add an avatar to your profile — .gif, .jpg, .png (max %skb)',
 
+    'change_signature' => 'Change signature',
+
+    'change_signature_desc' => 'Add a signature to your profile — .jpg, .png (max %skb)',
+
     'change_password' => 'Change Password',
 
     'channel_name' => 'Post entries to channel',
@@ -133,8 +137,12 @@ $lang = array(
     'create_the_bookmarklet' => 'Create the Bookmarklet',
 
     'current_avatar' => 'Current avatar',
+    
+    'current_signature' => 'Current Signature',
 
     'current_avatar_desc' => 'This is your avatar currently in use.',
+
+    'current_signature_desc' => 'This is your signature image currently in use.',
 
     'current_member' => 'Member:',
 
@@ -458,6 +466,10 @@ $lang = array(
 
     'sidebar_updated' => 'Sidebar State Updated',
 
+    'signature_settings' => 'Image Signature',
+
+    'signature_settings_text' => 'Text Signature',
+
     'single_word_no_spaces' => 'single word, no spaces',
 
     'site_default' => 'Use site default',
@@ -520,6 +532,10 @@ $lang = array(
 
     'avatar_path_does_not_exist' => 'You avatar upload directory does not exist. Please check your <a href="%s">avatar</a> upload settings.',
     'avatars_disabled' => 'Avatars are disabled. Please update your <a href="%s">avatar</a> upload settings.',
+
+    'update_sig_text_desc' => 'Update Signature Text. <br> Your current Signature is: %s',
+
+    'update_sig_text_desc_null' => 'You currently do not have a text signature',
 
     'upload_avatar' => 'Upload — .gif, .jpg, .png (max %skb)',
 

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -43,6 +43,8 @@ $lang = array(
 
     'security_privacy' => 'Security & Privacy',
 
+    'signature' => 'Signatures',
+
     'system_settings' => 'System Settings',
 
     'template_settings' => 'Template Settings',
@@ -850,6 +852,26 @@ $lang = array(
     'anonymize_consent_logs' => 'Anonymize Consent Audit Logs',
 
     'anonymize_consent_logs_desc' => 'Selected fields will be anonimized in Consent Audit logs',
+
+    /* Signature */
+
+    'signature_file_restrictions' => 'Signature File Restrictions',
+
+    'signature_max_height' => 'Maximum height',
+   
+    'signature_max_kb' => 'Maximum file size (<abbr title="kilobytes">kb</abbr>)',
+   
+    'signature_max_width' => 'Maximum width',
+   
+    'signature_path' => 'Signature path',
+   
+    'signature_path_desc' => 'Full path location of your <code>signature</code> directory.',
+   
+    'signature_settings' => 'Signature Settings',
+   
+    'signature_url' => 'Signature directory',
+   
+    'signature_url_desc' => '<abbr title="Uniform Resource Location">URL</abbr> location of your <code>signature</code> directory.',
 
 );
 


### PR DESCRIPTION
…. For both text and image signatures. Add signature settings for image size ect

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Currently, there is no way to update signature or signature settings directly from the CP. Users have to go to the forum mod to do this which is not ideal since signatures can be used in other places (ex. They can be used in comments).  This will update the user profile (checking for if signatures are enabled).

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1266](https://github.com/ExpressionEngine/ExpressionEngine/issues/1266).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/238

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
