### PR TITLE
Bug/6.dev/drop column row size

### DIFF
--- a/system/ee/installer/updates/ud_6_00_00_b_1.php
+++ b/system/ee/installer/updates/ud_6_00_00_b_1.php
@@ -596,9 +596,7 @@ class Updater
             ee()->db->insert_batch('permissions', $insert);
         }
 
-        foreach ($permissions as $permission) {
-            ee()->smartforge->drop_column('member_groups', $permission);
-        }
+        ee()->smartforge->drop_column_batch('member_groups', $permissions);
     }
 
     private function reassignChannelsToRoles()

--- a/system/ee/legacy/database/DB_forge.php
+++ b/system/ee/legacy/database/DB_forge.php
@@ -269,10 +269,10 @@ class CI_DB_forge
     }
 
     /**
-     * Column Drop
+     * Batched Column Drop
      *
      * @access	public
-     * @param	string $table The table that contains the column to drop
+     * @param	string $table The table that contains the columns to drop
      * @param	array $array An array of column names to drop
      * @return	CI_DB_result The query result object
      */
@@ -282,9 +282,9 @@ class CI_DB_forge
             show_error('A table name is required for that operation.');
         }
 
-		if ( ! is_array($column_names)) {
-			$column_name = array($column_names);
-		}
+        if ( ! is_array($column_names)) {
+            $column_name = array($column_names);
+        }
 
         if (empty($column_names)) {
             show_error('A column name is required for that operation.');

--- a/system/ee/legacy/database/DB_forge.php
+++ b/system/ee/legacy/database/DB_forge.php
@@ -269,6 +269,36 @@ class CI_DB_forge
     }
 
     /**
+     * Column Drop
+     *
+     * @access	public
+     * @param	string $table The table that contains the column to drop
+     * @param	array $array An array of column names to drop
+     * @return	CI_DB_result The query result object
+     */
+    public function drop_column_batch($table, $column_names)
+    {
+        if (empty($table)) {
+            show_error('A table name is required for that operation.');
+        }
+
+		if ( ! is_array($column_names)) {
+			$column_name = array($column_names);
+		}
+
+        if (empty($column_names)) {
+            show_error('A column name is required for that operation.');
+        }
+
+        $sql = $this->_alter_table('DROP', $this->db->dbprefix . $table, $column_names);
+
+        // Cached field names have changed
+        unset($this->db->data_cache['field_names'][$table]);
+
+        return $this->db->query($sql);
+    }
+
+    /**
      * Column Modify
      *
      * @access	public

--- a/system/ee/legacy/database/DB_forge.php
+++ b/system/ee/legacy/database/DB_forge.php
@@ -282,7 +282,7 @@ class CI_DB_forge
             show_error('A table name is required for that operation.');
         }
 
-        if ( ! is_array($column_names)) {
+        if (! is_array($column_names)) {
             $column_name = array($column_names);
         }
 

--- a/system/ee/legacy/database/drivers/mysqli/mysqli_forge.php
+++ b/system/ee/legacy/database/drivers/mysqli/mysqli_forge.php
@@ -189,6 +189,15 @@ class CI_DB_mysqli_forge extends CI_DB_forge
 
         // DROP has everything it needs now.
         if ($alter_type == 'DROP') {
+			if (is_array($fields)) {
+				$drop_batch = '';
+				foreach ($fields as $col) {
+					$drop_batch .= 'DROP '.$this->db->_protect_identifiers($col).", \n\t";
+				}
+
+				return $sql . rtrim(substr($drop_batch, 5), ", \n\t");
+			}
+
             return $sql . $this->db->_protect_identifiers($fields);
         }
 

--- a/system/ee/legacy/database/drivers/mysqli/mysqli_forge.php
+++ b/system/ee/legacy/database/drivers/mysqli/mysqli_forge.php
@@ -189,14 +189,14 @@ class CI_DB_mysqli_forge extends CI_DB_forge
 
         // DROP has everything it needs now.
         if ($alter_type == 'DROP') {
-			if (is_array($fields)) {
-				$drop_batch = '';
-				foreach ($fields as $col) {
-					$drop_batch .= 'DROP '.$this->db->_protect_identifiers($col).", \n\t";
-				}
+            if (is_array($fields)) {
+                $drop_batch = '';
+                foreach ($fields as $col) {
+                    $drop_batch .= 'DROP ' . $this->db->_protect_identifiers($col) . ", \n\t";
+                }
 
-				return $sql . rtrim(substr($drop_batch, 5), ", \n\t");
-			}
+                return $sql . rtrim(substr($drop_batch, 5), ", \n\t");
+            }
 
             return $sql . $this->db->_protect_identifiers($fields);
         }

--- a/system/ee/legacy/libraries/Smartforge.php
+++ b/system/ee/legacy/libraries/Smartforge.php
@@ -156,9 +156,9 @@ class Smartforge
             return false;
         }
 
-		$valid_columns = array_intersect($column_names, ee()->db->list_fields($table));
+        $valid_columns = array_intersect($column_names, ee()->db->list_fields($table));
 
-        if ( ! empty($valid_columns)) {
+        if (! empty($valid_columns)) {
             return ee()->dbforge->drop_column_batch($table, $column_names);
         }
 

--- a/system/ee/legacy/libraries/Smartforge.php
+++ b/system/ee/legacy/libraries/Smartforge.php
@@ -138,6 +138,36 @@ class Smartforge
     }
 
     /**
+     * Column Drop Batch
+     *
+     * Drop multiple columns in the given database table if it already exists.
+     *
+     * @access	public
+     * @param	string	the table name
+     * @param	array	the column names
+     * @return	bool
+     */
+    public function drop_column_batch($table, $column_names)
+    {
+        // Check to make sure table exists
+        if (! ee()->db->table_exists($table)) {
+            ee()->logger->updater(__METHOD__ . " failed. Table '" . ee()->db->dbprefix . "$table' does not exist.", true);
+
+            return false;
+        }
+
+		$valid_columns = array_intersect($column_names, ee()->db->list_fields($table));
+
+        if ( ! empty($valid_columns)) {
+            return ee()->dbforge->drop_column_batch($table, $column_names);
+        }
+
+        ee()->logger->updater("Could not drop columns '" . ee()->db->dbprefix . "$table'. Columns do not exist.", true);
+
+        return false;
+    }
+
+    /**
      * Table Drop
      *
      * Drop a table from the database


### PR DESCRIPTION
There is a very rare issue in the upgrade from v5-6 where you can get a MySQL error:

```
SQLSTATE[42000]: Syntax error or access violation: 1118 Row size too large. The maximum row size for the used table type, not counting BLOBs, is 8126. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs:

ALTER TABLE `exp_member_groups` DROP `can_delete_all_comments`
```

I can't for the life of me figure out why dropping columns would cause a row size error.  In both cases I've seen it, it was on MariaDB and both cases threw the error in the same spot- ALTER TABLE `exp_member_groups` DROP `can_delete_all_comments`.

Google failed me.  BUT I figured we really should have a batch column drop, it would save a bit of memory and it makes sense to have, and by happy coincidence, it solves this weirdo bug.  

So- new batch column delete function added and implemented in the v5 upgrade that was hitting the row size error.

The one thing that may be missing is clean roll back functionality.  The automatic roll back failed in this spot anyway, but I did nothing to make this know how to add the columns back.  So it would probably fail here too.  I could use some thoughts on that issue.  So pinging @matthewjohns0n for review and eyeballs on the roll back issue.



## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [ ] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
