### PR TITLE
Return and after should never be an array

### DIFF
--- a/system/ee/EllisLab/ExpressionEngine/View/account/login.php
+++ b/system/ee/EllisLab/ExpressionEngine/View/account/login.php
@@ -3,7 +3,7 @@
 <div class="box">
 	<h1><b><?=$header?></b><span class="icon-locked"></span></h1>
 	<?=ee('CP/Alert')->getAllInlines()?>
-	<?=form_open(ee('CP/URL')->make('login/authenticate'), array(), array('return_path' => $return_path, 'after' => ee()->input->get_post('after')))?>
+	<?=form_open(ee('CP/URL')->make('login/authenticate'), array(), array('return_path' => $return_path, 'after' => $after))?>
 		<fieldset>
 			<?=lang('username', 'username')?>
 			<?=form_input(array('dir' => 'ltr', 'name' => "username", 'id' => "username", 'value' => $username, 'maxlength' => USERNAME_MAX_LENGTH, 'tabindex' => 1))?>

--- a/system/ee/legacy/controllers/cp/login.php
+++ b/system/ee/legacy/controllers/cp/login.php
@@ -137,14 +137,20 @@ class Login extends CP_Controller {
 
 		$this->view->header = ($site_label) ? lang('log_into') . ' ' . $site_label : lang('login');
 
+        // Return and after should be strings
+        $return = !is_array($this->input->get('return')) ? $this->input->get('return') : '';
+        $after = !is_array($this->input->get('after')) ? $this->input->get('after') : '';
+
 		if ($this->input->get('BK'))
 		{
 			$this->view->return_path = ee('Encrypt')->encode($this->input->get('BK'));
 		}
-		else if ($this->input->get('return'))
+		else if ($return)
 		{
-			$this->view->return_path = $this->input->get('return');
+            $this->view->return_path = ee('Security/XSS')->clean($return);
 		}
+
+        $this->view->after = ee('Security/XSS')->clean($after);
 
 		$this->view->cp_page_title = lang('login');
 


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fixes a bug where return value wasnt working properly.

Resolves EECORE-1345



## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pulls/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

If you have not already, please sign the Contributor License Agreement: https://www.clahub.com/agreements/ExpressionEngine/ExpressionEngine

Thank you for contributing to ExpressionEngine! -->
