### PR TITLE
Fix anonymous template group creation

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -46,6 +46,7 @@ Bullet list below, e.g.
    - Fix a bug with Typography parse_url function
    - Added CLI commands for generating Prolets and Widgets
    - Fixed a CLI bug where it didnt ask for the migration location if not specified
+   - Fix white screen on first access to a group template which exists on files, but not yet on database
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/legacy/models/template_model.php
+++ b/system/ee/legacy/models/template_model.php
@@ -417,7 +417,9 @@ class Template_model extends CI_Model
 
         // If a user other than Super Admin is creating a template group, give them
         // access to the group they just created
-        if (! ee('Permission')->isSuperAdmin()) {
+        // We need also check if the user is logged in,
+        // because it can be a anonymous request
+        if (!ee('Permission')->isSuperAdmin() && $this->session->userdata('member_id')) {
             $data = array();
             $data['group_id'] = $this->session->userdata('group_id');
             $data['template_group_id'] = $template_group_id;


### PR DESCRIPTION
## Overview

Fix white screen on first access to a group template which exists on files, but not yet on database.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1356](https://github.com/ExpressionEngine/ExpressionEngine/issues/1356).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
