### PR TITLE
language fixes

### DIFF
--- a/system/ee/language/english/cp_lang.php
+++ b/system/ee/language/english/cp_lang.php
@@ -760,7 +760,7 @@ $lang = array(
 
     'reindex_not_needed_desc' => 'Your search index is up-to-date!',
 
-    'reindex_explained_desc' => 'The search index can become stale if you have recently changed whether or not certain field types are searchable.<br>Please see the <a href="' . DOC_URL . '/cp/utilities/reindex.html">user guide</a> for more details.',
+    'reindex_explained_desc' => 'The search index can become stale if you have recently changed whether or not certain field types are searchable.<br>Please see the <a href="' . DOC_URL . '/control-panel/utilities.html#search-reindex">user guide</a> for more details.',
 
     /* Permissions */
 

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -318,7 +318,7 @@ $lang = array(
 
     'enable_sql_caching' => 'Cache dynamic channel queries?',
 
-    'enable_sql_caching_desc' => 'When enabled, the speed of dynamic channel pages will be improved. do <b>not</b> use if you need the "future entries" or "expiring entries" features.',
+    'enable_sql_caching_desc' => 'When enabled, the speed of dynamic channel pages will be improved. Do <b>not</b> use if you need the "future entries" or "expiring entries" features.',
 
     'gd' => 'GD',
 


### PR DESCRIPTION
fixes #1414 where there was a typo in language string

fixes #1412 where link to reindex documentation was wrong

EECORE-1437
