### PR TITLE
fix the issue with member roles loading

### DIFF
--- a/system/ee/ExpressionEngine/Addons/forum/mod.forum_core.php
+++ b/system/ee/ExpressionEngine/Addons/forum/mod.forum_core.php
@@ -676,7 +676,7 @@ class Forum_Core extends Forum
                 return ee('Permission')->isSuperAdmin();
             }
 
-            $member = ee('Model')->get('Member', $member_id)->with('PrimaryRole', 'Roles', 'RoleGroups')->first();
+            $member = ee('Model')->get('Member', $member_id)->with('PrimaryRole', 'Roles', 'RoleGroups')->all()->first();
 
             if (! $member) {
                 return false;
@@ -7037,7 +7037,7 @@ class Forum_Core extends Forum
         }
 
         // Fetch the member info
-        $member = ee('Model')->get('Member', $this->current_id)->with('PrimaryRole', 'Roles', 'RoleGroups')->first();
+        $member = ee('Model')->get('Member', $this->current_id)->with('PrimaryRole', 'Roles', 'RoleGroups')->all()->first();
 
         if (! $member) {
             return $this->trigger_error();
@@ -7101,7 +7101,7 @@ class Forum_Core extends Forum
         }
 
         // Fetch the member info
-        $member = ee('Model')->get('Member', $this->current_id)->with('PrimaryRole', 'Roles', 'RoleGroups')->first();
+        $member = ee('Model')->get('Member', $this->current_id)->with('PrimaryRole', 'Roles', 'RoleGroups')->all()->first();
 
         if (! $member) {
             return $this->trigger_error();
@@ -9512,6 +9512,7 @@ class Forum_Core extends Forum
         $member = ee('Model')->get('Member')
             ->with('PrimaryRole', 'Roles', 'RoleGroups')
             ->filter('username', $username)
+            ->all()
             ->first();
 
         if (! $member) {

--- a/system/ee/ExpressionEngine/Addons/member/mod.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member.php
@@ -2598,6 +2598,7 @@ class Member
         $member = ee('Model')
             ->get('Member', $member_id)
             ->with('PrimaryRole', 'Roles', 'RoleGroups')
+            ->all()
             ->first();
 
         if (!$member) {

--- a/system/ee/ExpressionEngine/Controller/Members/Profile/Profile.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Profile/Profile.php
@@ -51,7 +51,7 @@ class Profile extends CP_Controller
         $this->query_string = $qs;
         $this->base_url = ee('CP/URL')->make('members/profile/settings');
         $this->base_url->setQueryStringVariable('id', $id);
-        $this->member = ee('Model')->get('Member', $id)->with('PrimaryRole', 'Roles', 'RoleGroups')->first();
+        $this->member = ee('Model')->get('Member', $id)->with('PrimaryRole', 'Roles', 'RoleGroups')->all()->first();
 
         if (is_null($this->member)) {
             show_404();

--- a/system/ee/legacy/libraries/Auth.php
+++ b/system/ee/legacy/libraries/Auth.php
@@ -125,7 +125,7 @@ class Auth
         $authed = $this->_retrieve_http_basic();
 
         if ($authed !== false) {
-            $member = ee('Model')->get('Member', $authed->member('member_id'))->with('PrimaryRole', 'Roles', 'RoleGroups')->first();
+            $member = ee('Model')->get('Member', $authed->member('member_id'))->with('PrimaryRole', 'Roles', 'RoleGroups')->all()->first();
 
             $authed = false;
 
@@ -619,7 +619,7 @@ class Auth_result
     public function has_permission($perm)
     {
         if (empty($this->permissions)) {
-            $member = ee('Model')->get('Member', $this->member('member_id'))->with('PrimaryRole', 'Roles', 'RoleGroups')->first();
+            $member = ee('Model')->get('Member', $this->member('member_id'))->with('PrimaryRole', 'Roles', 'RoleGroups')->all()->first();
 
             if ($member->role_id == 1) {
                 return true;

--- a/system/ee/legacy/libraries/Session.php
+++ b/system/ee/legacy/libraries/Session.php
@@ -353,7 +353,7 @@ class EE_Session
     public function create_new_session($member_id, $admin_session = false, $can_debug = false)
     {
         if (! is_object($this->member_model) || $this->member_model->member_id != $member_id) {
-            $this->member_model = ee('Model')->get('Member', $member_id)->with('PrimaryRole', 'Roles', 'RoleGroups')->first();
+            $this->member_model = ee('Model')->get('Member', $member_id)->with('PrimaryRole', 'Roles', 'RoleGroups')->all()->first();
         }
 
         if ($this->access_cp == true or $this->member_model->can('access_cp')) {
@@ -1183,6 +1183,7 @@ class EE_Session
         if (! is_object($this->member_model) || $member_model->member_id != $member_id) {
             $this->member_model = ee('Model')->get('Member', $member_id)
                 ->with('PrimaryRole', 'Roles', 'RoleGroups')
+                ->all()
                 ->first();
         }
 


### PR DESCRIPTION
Since we added eager loading to associated Roles for member,
we need to change the queries to fetch all records and then
use `first()` to get the first model from collection.
The issue was initially introduced with [fea88fe]

fixes #1439

EECORE-1456