### PR TITLE
Remove deprecated window status

### DIFF
--- a/system/ee/templates/_themes/forum/blue/forum_member/message_folder.html
+++ b/system/ee/templates/_themes/forum/blue/forum_member/message_folder.html
@@ -35,7 +35,7 @@
 
 <div class='defaultRight'>
 <span class='defaultBold'>
-<a href='{path:compose_message}'  onmouseover="window.status='{lang:compose_messages}';" onmouseout="window.status='';" >{lang:compose_message}</a>
+<a href='{path:compose_message}'>{lang:compose_message}</a>
 </span>
 
 </div>

--- a/system/ee/templates/_themes/forum/blue/forum_member/message_menu_rows.html
+++ b/system/ee/templates/_themes/forum/blue/forum_member/message_menu_rows.html
@@ -1,5 +1,5 @@
     
 <div class='menuItem'>
-<a href='{link}' onmouseover="window.status='{title}';" onmouseout="window.status='';" >{title}</a>
+<a href='{link}'>{title}</a>
 </div>   
  

--- a/system/ee/templates/_themes/forum/default/forum_member/message_folder.html
+++ b/system/ee/templates/_themes/forum/default/forum_member/message_folder.html
@@ -35,7 +35,7 @@
 
 <div class='defaultRight'>
 <span class='defaultBold'>
-<a href='{path:compose_message}'  onmouseover="window.status='{lang:compose_messages}';" onmouseout="window.status='';" >{lang:compose_message}</a>
+<a href='{path:compose_message}'>{lang:compose_message}</a>
 </span>
 
 </div>

--- a/system/ee/templates/_themes/forum/default/forum_member/message_menu_rows.html
+++ b/system/ee/templates/_themes/forum/default/forum_member/message_menu_rows.html
@@ -1,5 +1,5 @@
     
 <div class='menuItem'>
-<a href='{link}' onmouseover="window.status='{title}';" onmouseout="window.status='';" >{title}</a>
+<a href='{link}'>{title}</a>
 </div>   
  

--- a/system/ee/templates/_themes/forum/developer/forum_member/message_folder.html
+++ b/system/ee/templates/_themes/forum/developer/forum_member/message_folder.html
@@ -35,7 +35,7 @@
 
 <div class='defaultRight'>
 <span class='defaultBold'>
-<a href='{path:compose_message}'  onmouseover="window.status='{lang:compose_messages}';" onmouseout="window.status='';" >{lang:compose_message}</a>
+<a href='{path:compose_message}'>{lang:compose_message}</a>
 </span>
 
 </div>

--- a/system/ee/templates/_themes/forum/developer/forum_member/message_menu_rows.html
+++ b/system/ee/templates/_themes/forum/developer/forum_member/message_menu_rows.html
@@ -1,5 +1,5 @@
     
 <div class='menuItem'>
-<a href='{link}' onmouseover="window.status='{title}';" onmouseout="window.status='';" >{title}</a>
+<a href='{link}'>{title}</a>
 </div>   
  

--- a/system/ee/templates/_themes/forum/grey/forum_member/message_folder.html
+++ b/system/ee/templates/_themes/forum/grey/forum_member/message_folder.html
@@ -35,7 +35,7 @@
 
 <div class='defaultRight'>
 <span class='defaultBold'>
-<a href='{path:compose_message}'  onmouseover="window.status='{lang:compose_messages}';" onmouseout="window.status='';" >{lang:compose_message}</a>
+<a href='{path:compose_message}'>{lang:compose_message}</a>
 </span>
 
 </div>

--- a/system/ee/templates/_themes/forum/grey/forum_member/message_menu_rows.html
+++ b/system/ee/templates/_themes/forum/grey/forum_member/message_menu_rows.html
@@ -1,5 +1,5 @@
     
 <div class='menuItem'>
-<a href='{link}' onmouseover="window.status='{title}';" onmouseout="window.status='';" >{title}</a>
+<a href='{link}'>{title}</a>
 </div>   
  

--- a/system/ee/templates/_themes/forum/shares/forum_member/message_folder.html
+++ b/system/ee/templates/_themes/forum/shares/forum_member/message_folder.html
@@ -35,7 +35,7 @@
 
 <div class='defaultRight'>
 <span class='defaultBold'>
-<a href='{path:compose_message}'  onmouseover="window.status='{lang:compose_messages}';" onmouseout="window.status='';" >{lang:compose_message}</a>
+<a href='{path:compose_message}'>{lang:compose_message}</a>
 </span>
 
 </div>

--- a/system/ee/templates/_themes/forum/shares/forum_member/message_menu_rows.html
+++ b/system/ee/templates/_themes/forum/shares/forum_member/message_menu_rows.html
@@ -1,5 +1,5 @@
     
 <div class='menuItem'>
-<a href='{link}' onmouseover="window.status='{title}';" onmouseout="window.status='';" >{title}</a>
+<a href='{link}'>{title}</a>
 </div>   
  

--- a/system/ee/templates/_themes/member/default/message_folder.html
+++ b/system/ee/templates/_themes/member/default/message_folder.html
@@ -35,7 +35,7 @@
 
 <div class='defaultRight'>
 <span class='defaultBold'>
-<a href='{path:compose_message}'  onmouseover="window.status='{lang:compose_messages}';" onmouseout="window.status='';" >{lang:compose_message}</a>
+<a href='{path:compose_message}'>{lang:compose_message}</a>
 </span>
 
 </div>

--- a/system/ee/templates/_themes/member/default/message_menu_rows.html
+++ b/system/ee/templates/_themes/member/default/message_menu_rows.html
@@ -1,5 +1,5 @@
     
 <div class='menuItem'>
-<a href='{link}' onmouseover="window.status='{title}';" onmouseout="window.status='';" >{title}</a>
+<a href='{link}'>{title}</a>
 </div>   
  


### PR DESCRIPTION
EECORE-1455

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Removes window.status on forum module.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
