### PR TITLE
support `separator` parameter for Request plugin calls

### DIFF
--- a/system/ee/ExpressionEngine/Addons/request/pi.request.php
+++ b/system/ee/ExpressionEngine/Addons/request/pi.request.php
@@ -109,7 +109,9 @@ class Request
             if (!empty(ee()->TMPL->tagdata)) {
                 $tagdata = ee()->TMPL->tagdata;
             } else {
-                $tagdata = "{item}\n";
+                $separator = ee()->TMPL->fetch_param('separator', '|');
+                ee()->TMPL->tagparams['backspace'] = strlen($separator);
+                $tagdata = "{item}" . $separator;
             }
             $chunk = '';
             $vars = [];


### PR DESCRIPTION
docs: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/blob/36fc2b1f4f3a616d42d50c089f65dfdba7ce210e/docs/add-ons/request.md