### PR TITLE
Feature/6.x/module removal checks

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Profile/Access.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Profile/Access.php
@@ -158,13 +158,15 @@ class Access extends Profile
 
                 foreach ($role->AssignedModules as $module) {
                     $addon = ee('Addon')->get(strtolower($module->module_name));
-                    $key = 'access_to_add_on_id_' . $module->getId() . ':' . $addon->getName();
+                    if ($addon) {
+                        $key = 'access_to_add_on_id_' . $module->getId() . ':' . $addon->getName(); 
 
-                    if (! array_key_exists($key, $permissions)) {
-                        $permissions[$key] = [];
+                        if (! array_key_exists($key, $permissions)) {
+                            $permissions[$key] = [];
+                        }
+
+                        $permissions[$key][] = $display;
                     }
-
-                    $permissions[$key][] = $display;
                 }
             }
         }

--- a/system/ee/ExpressionEngine/Controller/Utilities/DebugTools.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/DebugTools.php
@@ -48,6 +48,9 @@ class DebugTools extends Utilities
         $ftAdvisor = new Advisor\FieldtypeAdvisor();
         $vars['missing_fieldtype_count'] = $ftAdvisor->getMissingFieldtypeCount();
 
+        $ftAdvisor = new Advisor\AddonAdvisor();
+        $vars['missing_addons_count'] = $ftAdvisor->getMissingAddonsCount();
+
         ee()->view->cp_breadcrumbs = array(
             '' => lang('debug_tools')
         );
@@ -141,6 +144,25 @@ class DebugTools extends Utilities
         );
 
         return ee()->cp->render('utilities/debug-tools/missing_fieldtypes', $vars);
+    }
+
+    public function debugAddons()
+    {
+        ee()->lang->loadfile('addons');
+        
+        ee()->view->cp_page_title = lang('debug_tools_addons');
+
+        $addonAdvisor = new Advisor\AddonAdvisor();
+
+        $vars = [];
+        $vars['missing_addons'] = $addonAdvisor->getMissingAddons();
+
+        ee()->view->cp_breadcrumbs = array(
+            ee('CP/URL')->make('utilities/debug-tools')->compile() => lang('debug_tools'),
+            '' => lang('debug_tools_addons')
+        );
+
+        return ee()->cp->render('utilities/debug-tools/missing_addons', $vars);
     }
 }
 // END CLASS

--- a/system/ee/ExpressionEngine/Controller/Utilities/Utilities.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/Utilities.php
@@ -84,6 +84,7 @@ class Utilities extends CP_Controller
             $debug_tools->addItem(lang('debug_tools_overview'), ee('CP/URL')->make('utilities/debug-tools'));
             $debug_tools->addItem(lang('debug_tools_debug_tags'), ee('CP/URL')->make('utilities/debug-tools/debug-tags'));
             $debug_tools->addItem(lang('debug_tools_fieldtypes'), ee('CP/URL')->make('utilities/debug-tools/debug-fieldtypes'));
+            $debug_tools->addItem(lang('debug_tools_addons'), ee('CP/URL')->make('utilities/debug-tools/debug-addons'));
         }
 
         if (ee('Permission')->hasAny('can_access_import', 'can_access_members')) {

--- a/system/ee/ExpressionEngine/Library/Advisor/AddonAdvisor.php
+++ b/system/ee/ExpressionEngine/Library/Advisor/AddonAdvisor.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2021, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Library\Advisor;
+
+class AddonAdvisor
+{
+    public function getMissingAddons()
+    {
+        $data = [];
+        $modules = ee('Model')->get('Module')->all();
+        foreach ($modules as $module) {
+            $name = strtolower($module->module_name);
+            $addon = ee('Addon')->get($name);
+            if (empty($addon) || !$addon->hasModule()) {
+                if (!isset($data[$name])) {
+                    $data[$name] = [];
+                }
+                $data[$name][] = 'module';
+            }
+        }
+
+        $plugins = ee('Model')->get('Plugin')->all();
+        foreach ($plugins as $plugin) {
+            $name = strtolower($plugin->plugin_name);
+            $addon = ee('Addon')->get($name);
+            if (empty($addon) || !$addon->hasPlugin()) {
+                if (!isset($data[$name])) {
+                    $data[$name] = [];
+                }
+                $data[$name][] = 'plugin';
+            }
+        }
+
+        $extensions = ee('Model')->get('Extension')->all();
+        foreach ($extensions as $extension) {
+            $name = substr(strtolower($extension->class), 0, -4);
+            $addon = ee('Addon')->get($name);
+            if (empty($addon) || !$addon->hasExtension()) {
+                if (!isset($data[$name])) {
+                    $data[$name] = [];
+                }
+                $data[$name][] = 'extension';
+            }
+        }
+
+        $fieldtypes = ee('Model')->get('Fieldtype')->all();
+        $all_fieldtypes = [];
+        foreach (ee('Addon')->installed() as $addon) {
+            if ($addon->hasFieldtype()) {
+                $all_fieldtypes = array_merge($all_fieldtypes, $addon->getFieldtypeNames());
+            }
+        }
+        foreach ($fieldtypes as $fieldtype) {
+            $name = strtolower($fieldtype->name);
+            $addon = ee('Addon')->get($name);
+            if (empty($addon) && !array_key_exists($name, $all_fieldtypes)) {
+                if (!isset($data[$name])) {
+                    $data[$name] = [];
+                }
+                $data[$name][] = 'fieldtype';
+            }
+        }
+
+        return $data;
+    }
+
+    public function getMissingAddonsCount()
+    {
+        return count($this->getMissingAddons());
+    }
+}
+
+// EOF

--- a/system/ee/ExpressionEngine/Library/Advisor/Advisor.php
+++ b/system/ee/ExpressionEngine/Library/Advisor/Advisor.php
@@ -31,6 +31,12 @@ class Advisor
             $messages[] = sprintf(lang('debug_tools_found_missing_fieldtypes'), $missing_fieldtype_count);
         }
 
+        $addonAdvisor = new \ExpressionEngine\Library\Advisor\AddonAdvisor();
+        $missing_addons_count = $addonAdvisor->getMissingAddonsCount();
+        if ($missing_addons_count > 0) {
+            $messages[] = sprintf(lang('debug_tools_found_missing_addons'), $missing_addons_count);
+        }
+
         return $messages;
     }
 }

--- a/system/ee/ExpressionEngine/View/utilities/debug-tools/index.php
+++ b/system/ee/ExpressionEngine/View/utilities/debug-tools/index.php
@@ -32,6 +32,16 @@
             $alerts[1]->asImportant();
         }
 
+        $alerts[2] = ee('CP/Alert')
+            ->makeInline()
+            ->withTitle(lang('debug_tools_addons'))
+            ->addToBody(sprintf(lang('debug_tools_found_missing_addons'), $missing_addons_count) . '<br><a href="' . ee('CP/URL')->make('utilities/debug-tools/debug-addons') . '">' . lang('debug_tools_show_missing_addons') . '</a>');
+        if ($missing_addons_count == 0) {
+            $alerts[2]->asSuccess();
+        } else {
+            $alerts[2]->asImportant();
+        }
+
         foreach ($alerts as $alert) {
             $alert->cannotClose();
             echo $alert->render();

--- a/system/ee/ExpressionEngine/View/utilities/debug-tools/missing_addons.php
+++ b/system/ee/ExpressionEngine/View/utilities/debug-tools/missing_addons.php
@@ -1,0 +1,41 @@
+<?php $this->extend('_templates/default-nav', array(), 'outer_box'); ?>
+
+<div class="panel">
+
+	<div class="panel-heading">
+		<div class="title-bar">
+			<h2 class="title-bar__title"><?=lang('debug_tools_missing_addons')?></h2>
+		</div>
+	</div>
+
+	<div class="panel-body">
+        <?php
+        if (count($missing_addons) > 0) :
+            foreach ($missing_addons as $addon => $files) :
+                $fts = '';
+                foreach ($files as $file) :
+                    $fts .= '<li class="last">' . lang($file) . '</li>';
+                endforeach;
+                echo ee('CP/Alert')
+                    ->makeInline()
+                    ->withTitle(ucfirst($addon))
+                    ->addToBody(sprintf(lang('debug_tools_missing_addon'), ucfirst($addon)))
+                    ->addToBody('<ul>' . $fts . '</ul>')
+                    ->asImportant()
+                    ->render();
+                
+            endforeach;
+        else:
+            echo ee('CP/Alert')
+                ->makeInline()
+                ->withTitle(lang('debug_tools_no_missing_addons_desc'))
+                ->asSuccess()
+                ->cannotClose()
+                ->render();
+        endif;
+
+        ?>
+
+	</div>
+
+</div>

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -170,6 +170,8 @@ $lang = array(
 
     'page_assignment' => 'Assigned Pages',
 
+    'plugin' => 'Plugin',
+
     'plugins' => 'Plugins',
 
     'plugins_not_available' => 'Plugin Feed Disabled in Beta Version.',

--- a/system/ee/language/english/utilities_lang.php
+++ b/system/ee/language/english/utilities_lang.php
@@ -573,6 +573,18 @@ $lang = array(
 
     'debug_tools_members' => 'Debug Members',
 
+    'debug_tools_addons' => 'Debug Add-ons',
+
+    'debug_tools_missing_addons' => 'Missing Add-on files',
+
+    'debug_tools_found_missing_addons' => 'We found %s missing add-ons.',
+
+    'debug_tools_show_missing_addons' => 'Show missing add-ons',
+
+    'debug_tools_missing_addon' => 'The %s add-on is registered in the database, but the following files are missing for it.',
+
+    'debug_tools_no_missing_addons_desc' => 'There are no add-ons missing the files.',
+
 );
 
 // EOF


### PR DESCRIPTION
avoid error on Access Overview page when module files are not present 
fixes #1459

This PR is fixing the error shown if you remove the files for some add-on without doing uninstall to it, and then go to Access Overview page.

I also added the check for missing add-on files as part or post-upgrade check as well as an Utility.
If this can't got into this version semantically, I can move it to next release and just have the bug fix in here, since these are separate commits

EECORE-1463