### PR TITLE
Feature/6.dev/sql in empty

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Members.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Members.php
@@ -1016,7 +1016,7 @@ class Members extends CP_Controller
                     $role = ee('Model')->get('Role', $value)->first();
 
                     if ($role) {
-                        $members->filter('member_id', 'IN', array_merge([0], (array) $role->getAllMembers()->pluck('member_id')));
+                        $members->filter('member_id', 'IN', $role->getAllMembers()->pluck('member_id'));
                     }
                 } else {
                     $members->filter($key, $value);

--- a/system/ee/ExpressionEngine/Service/Model/Query/Select.php
+++ b/system/ee/ExpressionEngine/Service/Model/Query/Select.php
@@ -598,6 +598,9 @@ class Select extends Query
         }
 
         if (in_array($fn, array('where_in', 'or_where_in'))) {
+            if (is_null($value)) {
+                $fn = substr($fn, 0, -3);
+            }
             $query->$fn($comparison, $value, $binary);
 
             return;

--- a/system/ee/legacy/database/DB_active_rec.php
+++ b/system/ee/legacy/database/DB_active_rec.php
@@ -660,9 +660,7 @@ class CI_DB_active_record extends CI_DB_driver
             return;
         }
 
-        if (is_array($values) && empty($values)) {
-            $values = 0 - floor(rand(1, 100) * 10000);
-        }
+        $emptyArray = is_array($values) && empty($values);
 
         if (! is_array($values)) {
             $values = array($values);
@@ -679,7 +677,11 @@ class CI_DB_active_record extends CI_DB_driver
 
         $this->ar_empty_group = false;
 
-        $where_in = $boolean_operator_prefix . $binary_prefix . $this->_protect_identifiers($key) . $not . " IN (" . implode(", ", $this->ar_wherein) . ") ";
+        if ($emptyArray) {
+            $where_in = $boolean_operator_prefix . $not . ' 1 = 2 ';
+        } else {
+            $where_in = $boolean_operator_prefix . $binary_prefix . $this->_protect_identifiers($key) . $not . " IN (" . implode(", ", $this->ar_wherein) . ") ";
+        }
 
         $this->ar_where[] = $where_in;
 

--- a/system/ee/legacy/database/DB_active_rec.php
+++ b/system/ee/legacy/database/DB_active_rec.php
@@ -660,6 +660,10 @@ class CI_DB_active_record extends CI_DB_driver
             return;
         }
 
+        if (is_array($values) && empty($values)) {
+            $values = 0 - floor(rand(1, 100) * 10000);
+        }
+
         if (! is_array($values)) {
             $values = array($values);
         }


### PR DESCRIPTION
fix the error when searching by role in CP if no members have this role 

The general reason for the error was that ActiveRecord
did not treat empty arrays well when passing those to `IN` filter.
The fix is to use random negative integer instead,
which assures the resulting query returns no results.

fixes #1460

EECORE-1462
EECORE-1465

-----------------

If null is provided as value to IN filter, use WHERE IS NULL instead

EECORE-1465