### PR TITLE
Fix for subtitle on Auto Save tab

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Profile/Date.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Profile/Date.php
@@ -65,7 +65,7 @@ class Date extends Settings
                         ),
                         'time_format' => array(
                             'type' => 'radio',
-                            'choices' => array(12 => '12 hour', 24 => '24 hour'),
+                            'choices' => array(12 => lang('12_hour'), 24 => lang('24_hour')),
                             'value' => $this->member->time_format
                         )
                     )

--- a/system/ee/ExpressionEngine/View/publish/partials/publish_form.php
+++ b/system/ee/ExpressionEngine/View/publish/partials/publish_form.php
@@ -118,7 +118,7 @@
 			<fieldset>
 				<div class="field-instruct<?=$field_class?>">
 					<label><span class="ico sub-arrow js-toggle-field"></span><?=lang('autosaved_versions')?></label>
-					<em><?=lang('autosaved_versions')?></em>
+					<em><?=lang('autosaved_versions_desc')?></em>
 				</div>
 				<div class="field-control">
 					<?=$autosaves?>


### PR DESCRIPTION
The title and subtitle at Auto Save tab in the entry publish are the same - "Auto-saved versions". This fixed subtitle lang('autosaved_versions_desc') translation string.

![ee-entry-auto-save-tab](https://user-images.githubusercontent.com/2806752/139271252-1e6ccb43-a59e-4bcd-a656-63074f872f2d.png)