### PR TITLE
exclude regex quantifiers when parsing the template

### DIFF
--- a/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
@@ -170,7 +170,8 @@ class LegacyParser
         $temp_misc = [];
 
         foreach ($matches[1] as $key => $val) {
-            if (strncmp($val, 'if ', 3) !== 0 &&
+            if (!is_numeric($val) &&
+                strncmp($val, 'if ', 3) !== 0 &&
                 strncmp($val, 'if:', 3) !== 0 &&
                 substr($val, 0, 3) != '/if') {
                 if (strpos($val, '{') !== false) {


### PR DESCRIPTION
fixes #1495

EECORE-1496
