### PR TITLE
Bring back default order field

### DIFF
--- a/changelogs/minor.md
+++ b/changelogs/minor.md
@@ -8,6 +8,7 @@ Bullet list below, e.g.
    - Added Google reCAPTCHA as an option for system wide CAPTCHA
    - Added ability to disable Live Preview on a per channel basis
    - Added extension hooks for Fluid Fields
+   - Added back default field order, because to have to edit layouts one by one is too much work
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/ExpressionEngine/Controller/Fields/Fields.php
+++ b/system/ee/ExpressionEngine/Controller/Fields/Fields.php
@@ -541,6 +541,16 @@ class Fields extends AbstractFieldsController
                         )
                     )
                 ),
+                array(
+                    'title' => 'field_order',
+                    'desc' => 'global_sort_order',
+                    'fields' => array(
+                        'field_order' => array(
+                            'type' => 'text',
+                            'value' => $field->field_order,
+                        )
+                    )
+                ),
             ),
         );
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Because to have to edit layouts one by one is too much work. It isn't a fancy drag and reorder thing, but is much better than to have to open layouts again, again and again for every channel.

Maybe the field description needs an update.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1258](https://github.com/ExpressionEngine/ExpressionEngine/issues/1258).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN


