### PR TITLE
fix the error when addon header is empty

### DIFF
--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -33,7 +33,6 @@ jobs:
             with:
               repository: EllisLab/ExpressionEngine-Pro
               token: ${{ secrets.ORG_ACCESS_TOKEN }}
-              ref: bug/1.x/encode-email
               path: __pro
 
           - name: Setup asdf

--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -32,6 +32,7 @@ jobs:
             with:
               repository: EllisLab/ExpressionEngine-Pro
               token: ${{ secrets.ORG_ACCESS_TOKEN }}
+              ref: bug/1.x/encode-email
               path: __pro
 
         #  - name: Move Pro into core

--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -28,6 +28,7 @@ jobs:
             uses: actions/checkout@v2
 
           - name: Checkout Pro
+            if: github.event.pull_request.head.repo.full_name == github.repository
             uses: actions/checkout@v2
             with:
               repository: EllisLab/ExpressionEngine-Pro
@@ -83,7 +84,7 @@ jobs:
               ls -latr build-tools/builds/ExpressionEngine
 
     cypress-minimal-pro:
-        if: github.event.pull_request.draft == false
+        if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
         needs: [cancel-running-tests, build-for-testing]
         runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -1,7 +1,7 @@
 name: Tests (minimal)
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 6.dev
@@ -34,14 +34,6 @@ jobs:
               token: ${{ secrets.ORG_ACCESS_TOKEN }}
               ref: bug/1.x/encode-email
               path: __pro
-
-        #  - name: Move Pro into core
-        #    run: |
-        #      mv __pro/system/ee/ExpressionEngine/Addons/pro system/ee/ExpressionEngine/Addons/pro
-        #      mv __pro/themes/ee/pro themes/ee/pro
-        #      mv __pro/tests/cypress/cypress/integration/pro tests/cypress/cypress/integration/pro
-        #      mv __pro/tests/cypress/support/templates/* tests/cypress/support/templates/
-        #      rm -rf __pro
 
           - name: Setup asdf
             uses: asdf-vm/actions/setup@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - feature/6.x/unit-tests
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 6.dev

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+                  extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, php_fileinfo, , php_fileinfo.dll
                   coverage: none
 
             - name: Copy config.php

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,10 @@ jobs:
             fail-fast: false
             matrix:
                 php: [7.3, 7.4, 8.0]
-                os: [ubuntu-latest, windows-latest]
+                os: [ubuntu-latest]
+                include:
+                  - php: 8,0
+                    os: windows-latest
 
         name: PHPUnit, php${{ matrix.php }} - ${{ matrix.os }}
 
@@ -50,7 +53,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo, php_fileinfo, , php_fileinfo.dll
+                  extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
                   coverage: none
 
             - name: Copy config.php

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,7 +31,7 @@ jobs:
                 php: [7.3, 7.4, 8.0]
                 os: [ubuntu-latest]
                 include:
-                  - php: 8,0
+                  - php: 8.0
                     os: windows-latest
 
         name: PHPUnit, php${{ matrix.php }} - ${{ matrix.os }}

--- a/system/ee/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/ExpressionEngine/Controller/Addons/Addons.php
@@ -749,7 +749,7 @@ class Addons extends CP_Controller
         if (! empty($module) && $module['installed'] === true) {
             $data = $this->getModuleSettings($addon, $method, array_slice(func_get_args(), 2));
 
-            $addon_header = (isset(ee()->cp->header)) ? ee()->cp->header : ee()->view->header;
+            $addon_header = (isset(ee()->cp->header)) ? ee()->cp->header : (isset(ee()->view->header) ? ee()->view->header : []);
             $header = array_merge($addon_header, array('title' => $module['name'] . ' ' . $licenseStatusBadge));
 
             ee()->view->header = $header;

--- a/tests/cypress/cypress/integration/addons/addon_rte_settings.ee6.js
+++ b/tests/cypress/cypress/integration/addons/addon_rte_settings.ee6.js
@@ -11,25 +11,22 @@ context('RTE Settings', () => {
         cy.task('db:load', '../../support/sql/rte-settings/tool_sets.sql')
     })
 
-    beforeEach(function() {
-        cy.intercept('**/check').as('check')
-        cy.intercept('**/license/handleAccessResponse').as('license')
-
-        cy.authVisit(page.url);
-        page.get('title').contains('Rich Text Editor')
-        
-        cy.wait('@check')
-        cy.wait('@license')
-    })
-
     describe('Settings', function() {
 
         it('shows the RTE Settings page', function() {
+            cy.intercept('**/check').as('check')
+            cy.intercept('**/license/handleAccessResponse').as('license')
+            cy.authVisit(page.url);
+            page.get('title').contains('Rich Text Editor')
+            cy.wait('@check')
+            cy.wait('@license')
+
             page.get('default_tool_set').first().should('be.checked')
             page.get('tool_set_names').first().parent().should('have.class', 'default')
         })
 
         it.skip('can navigate back to the add-on manager via the breadcrumb', function() {
+            cy.authVisit(page.url);
             page.get('breadcrumb').contains('Add-ons').click()
             cy.hasNoErrors()
 
@@ -37,6 +34,7 @@ context('RTE Settings', () => {
         })
 
         it('cannot set a default tool set to an nonexistent tool set', function() {
+            cy.authVisit(page.url);
             page.get('default_tool_set').eq(0).invoke('attr', 'value', '99999')
             page.get('default_tool_set').eq(0).check()
             page.get('save_settings_button').eq(0).click()
@@ -47,6 +45,7 @@ context('RTE Settings', () => {
 
 
         it('displays an itemized modal when trying to remove 5 or less tool sets', function() {
+            cy.authVisit(page.url);
             let tool_set_name = page.$('tool_set_names').eq(1).text()
 
             // Header at 0, first "real" row is 1
@@ -61,6 +60,7 @@ context('RTE Settings', () => {
         })
 
         it('displays a bulk confirmation modal when trying to remove more than 5 tool sets', function() {
+            cy.authVisit(page.url);
             page.get('checkbox_header').find('input[type="checkbox"]:enabled').check()
             page.get('bulk_action').select("Delete")
             page.get('action_submit_button').click()
@@ -71,6 +71,7 @@ context('RTE Settings', () => {
         })
 
         it('cannot remove the default tool set', function() {
+            cy.authVisit(page.url);
             let tool_set_name = page.$('tool_set_names').eq(0).text()
 
             // This populates the modal with a hidden input so we can modify it later
@@ -94,6 +95,7 @@ context('RTE Settings', () => {
         })
 
         it('can reverse sort tool sets by name', function() {
+            cy.authVisit(page.url);
             let toolsets = [...page.$('tool_set_names').map(function(index, el) { return $(el).text(); })];
 
             page.get('tool_set_name_header').find('a.column-sort').click().then(function() {
@@ -107,6 +109,7 @@ context('RTE Settings', () => {
         })
 
         it('can change the default tool set', function() {
+            cy.authVisit(page.url);
             page.get('default_tool_set').last().check()
             page.get('save_settings_button').eq(0).click()
             cy.hasNoErrors()
@@ -121,6 +124,7 @@ context('RTE Settings', () => {
         })
 
         it('can edit a tool set', function() {
+            cy.authVisit(page.url);
             page.get('tool_sets').eq(1).find('a').first().click()
 
             page.get('tool_set_name').clear().type('Cypress Edited')
@@ -134,6 +138,7 @@ context('RTE Settings', () => {
         })
 
         it('can remove a tool set', function() {
+            cy.authVisit(page.url);
             page.get('tool_sets').eq(3).find('input[type="checkbox"]').check()
             page.get('bulk_action').select("remove")
             page.get('action_submit_button').click()
@@ -149,6 +154,7 @@ context('RTE Settings', () => {
         })
 
         it('can bulk remove tool sets', function() {
+            cy.authVisit(page.url);
             page.get('checkbox_header').find('input[type="checkbox"]').check()
 
             // Uncheck the Default tool set
@@ -174,6 +180,8 @@ context('RTE Settings', () => {
 
     describe('Toolsets', function() {
         beforeEach(function() {
+            cy.authVisit(page.url);
+            page.get('title').contains('Rich Text Editor')
             cy.get('a').contains('Create New').filter(':visible').first().click({force:true})
         })
 

--- a/tests/cypress/cypress/integration/addons/addon_rte_settings.ee6.js
+++ b/tests/cypress/cypress/integration/addons/addon_rte_settings.ee6.js
@@ -12,9 +12,14 @@ context('RTE Settings', () => {
     })
 
     beforeEach(function() {
-        cy.authVisit(page.url);
+        cy.intercept('**/check').as('check')
+        cy.intercept('**/license/handleAccessResponse').as('license')
 
+        cy.authVisit(page.url);
         page.get('title').contains('Rich Text Editor')
+        
+        cy.wait('@check')
+        cy.wait('@license')
     })
 
     describe('Settings', function() {

--- a/tests/cypress/cypress/integration/addons/block_and_allow.ee6.js
+++ b/tests/cypress/cypress/integration/addons/block_and_allow.ee6.js
@@ -10,6 +10,8 @@ context('Block and Allow', () => {
 
   before(function(){
     cy.task('db:seed')
+    cy.intercept('**/check').as('check')
+    cy.intercept('**/license/handleAccessResponse').as('license')
 
     cy.auth();
 
@@ -17,6 +19,9 @@ context('Block and Allow', () => {
     addon_manager.load()
     cy.hasNoErrors()
     addon_manager.get('first_party_addons').find('.add-on-card:contains("Block and Allow") a').click()
+
+    cy.wait('@check')
+    cy.wait('@license')
   })
 
   beforeEach(function() {

--- a/tests/cypress/cypress/integration/addons/block_and_allow.ee6.js
+++ b/tests/cypress/cypress/integration/addons/block_and_allow.ee6.js
@@ -15,7 +15,7 @@ context('Block and Allow', () => {
 
     cy.auth();
 
-    // Install Pages
+    // Install Block and Allow
     addon_manager.load()
     cy.hasNoErrors()
     addon_manager.get('first_party_addons').find('.add-on-card:contains("Block and Allow") a').click()

--- a/tests/cypress/cypress/integration/spam/spam_trap.ee6.js
+++ b/tests/cypress/cypress/integration/spam/spam_trap.ee6.js
@@ -15,11 +15,17 @@ context('Spam Module', () => {
   context('Installation', () => {
 
     it('can install from addon manager', () => {
+      cy.intercept('**/check').as('check')
+      cy.intercept('**/license/handleAccessResponse').as('license')
+      
       cy.auth();
       addon_manager.load()
       const spam_row = addon_manager.get('wrap').find('a[data-post-url*="cp/addons/install/spam"]').click()
 
       cy.hasNoErrors()
+
+      cy.wait('@check')
+      cy.wait('@license')
     })
   })
 


### PR DESCRIPTION
This PR is fixing a bug that was introduced to Addons controller

It is also switching the tests to run on `pull_request` event again - it appears when using `pull_request_target` it is using the existing codebase and not the one PRed, so we were not able to catch the errors in time