### PR TITLE
rebuild dropdown file to fix building conflict

### DIFF
--- a/themes/ee/asset/javascript/src/fields/dropdown/dropdown.es6
+++ b/themes/ee/asset/javascript/src/fields/dropdown/dropdown.es6
@@ -87,8 +87,8 @@ class Dropdown extends React.Component {
     const selected = this.state.selected
 
     return (
-      <div className={"select" + (tooMany ? ' select--resizable' : '') + (this.state.open ? ' select--open' : '')}>
-        <div className={"select__button"} onClick={this.toggleOpen}>
+      <div className={"select button-segment" + (tooMany ? ' select--resizable' : '') + (this.state.open ? ' select--open' : '')}>
+        <div className={"select__button js-dropdown-toggle"} onClick={this.toggleOpen}>
           <label className={'select__button-label' + (this.state.selected ? ' act' : '')}>
             {selected &&
               <span>{selected.sectionLabel ? selected.sectionLabel + ' / ' : ''}<span dangerouslySetInnerHTML={{__html: selected.label}}></span></span>
@@ -103,7 +103,7 @@ class Dropdown extends React.Component {
           </label>
         </div>
 
-        <div className="select__dropdown">
+        <div className="select__dropdown dropdown">
           {this.props.initialCount > this.props.tooMany &&
             <div className="select__dropdown-search">
             <FieldTools>


### PR DESCRIPTION
In task EECORE-1235 I fixed Select `dropdown fields `within `grid` and added code only to the `dropdown.js `file and it created a conflict in the process of building files
Now I recreate code in `dropdown.es6` file, rebuild all js (old and new) and CSS, to prevent other conflicts.

Old PR - https://github.com/ExpressionEngine/ExpressionEngine/pull/1387
Old task - https://packettide.atlassian.net/browse/EECORE-1235
