### PR TITLE
fixed button text after search input loses focus, EECORE-1510

### DIFF
--- a/themes/ee/asset/javascript/src/cp/form_validation.js
+++ b/themes/ee/asset/javascript/src/cp/form_validation.js
@@ -367,7 +367,9 @@ EE.cp.formValidation = {
 						if (thisButton.is('input')) {
 							thisButton.attr('value', decodeURIComponent(thisButton.data('submit-text')));
 						} else if (thisButton.is('button')) {
-							thisButton.html(decodeURIComponent(thisButton.data('submit-text')));
+							if (typeof(thisButton.data('submit-text')) != 'undefined') {
+								thisButton.html(decodeURIComponent(thisButton.data('submit-text')));
+							}
 						}
 					}
 				});


### PR DESCRIPTION
fixed issue if the search input is empty and loses focus, the dropdown buttons become `undefined`