### PR TITLE
Fix wrong Last-Modified header for CSS requests

### DIFF
--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -56,7 +56,8 @@ jobs:
               content=`node -pe 'JSON.parse(process.argv[1]).tag' "$(cat build.json)"`
               echo "::set-output name=BUILD_VERSION::$content"
 
-          - name: Run build process
+          - name: Run build process (with Pro)
+            if: github.event.pull_request.head.repo.full_name == github.repository
             working-directory: build-tools
             env:
               RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
@@ -64,6 +65,16 @@ jobs:
               APP_REPO_PATH: ${{ github.workspace }}
               PRO_REPO_PATH: ${{ github.workspace }}/__pro
             run: gulp build-app --local --nogit --head --skip-lint --version=${{ steps.build_json.outputs.BUILD_VERSION }}
+
+          - name: Run build process (without Pro)
+            if: github.event.pull_request.head.repo.full_name != github.repository
+            working-directory: build-tools
+            env:
+              RELEASE_KEY: ${{ secrets.RELEASE_KEY }}
+              RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+              APP_REPO_PATH: ${{ github.workspace }}
+              PRO_REPO_PATH: ${{ github.workspace }}/__pro
+            run: gulp build-app --local --nogit --head --skip-lint --skip-pro --version=${{ steps.build_json.outputs.BUILD_VERSION }}
 
           - name: Rename build directory
             working-directory: build-tools/builds

--- a/build-tools/gulpfile.js
+++ b/build-tools/gulpfile.js
@@ -155,7 +155,11 @@ gulp.task('_archive_app', ['_build_directories'], function (cb) {
 });
 
 gulp.task('_archive_pro', function (cb) {
-	archive_repo('pro', cb);
+	if (process.argv.indexOf('--skip-pro') > -1) {
+		cb();
+	} else {
+		archive_repo('pro', cb);
+	}
 });
 
 /**

--- a/system/ee/legacy/libraries/Stylesheet.php
+++ b/system/ee/legacy/libraries/Stylesheet.php
@@ -78,6 +78,7 @@ class EE_Stylesheet
 
                 $str = read_file($basepath);
                 $row['template_data'] = ($str !== false) ? $str : $row['template_data'];
+                $row['edit_date'] = ($str !== false) ? filemtime($basepath) : $row['edit_date'];
             }
 
             $this->style_cache[$stylesheet] = str_replace(LD . 'site_url' . RD, stripslashes(ee()->config->item('site_url')), $row['template_data']);


### PR DESCRIPTION
The header is being get from database row no matter if the template is on database or file

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Replace this paragraph with a description of your changes and reasoning. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
