### PR TITLE
Add is_frontedit GET parameter

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -48,7 +48,7 @@ Bullet list below, e.g.
    - Added CLI commands for generating Prolets and Widgets
    - Fixed a CLI bug where it didnt ask for the migration location if not specified
    - Fix white screen on first access to a group template which exists on files, but not yet on database
-
+   - Add ?is_frontedit=y query parameter when performing Frontedit requests
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -602,7 +602,11 @@ class Cp
         }
 
         if (ee()->extensions->active_hook('cp_js_end') === true) {
-            $str .= '<script type="text/javascript" src="' . BASE . AMP . 'C=javascript' . AMP . 'M=load' . AMP . 'file=ext_scripts"></script>';
+            if (ee()->input->get('is_frontedit') === 'y') {
+                $str .= '<script type="text/javascript" src="' . BASE . AMP . 'C=javascript' . AMP . 'M=load' . AMP . 'file=ext_scripts' . AMP . 'is_frontedit=y"></script>';
+            } else {
+                $str .= '<script type="text/javascript" src="' . BASE . AMP . 'C=javascript' . AMP . 'M=load' . AMP . 'file=ext_scripts"></script>';
+            }
         }
 
         return $str;


### PR DESCRIPTION
## Overview

Let add-on developers easily distinquish what is a Frontedit request and not a Frontedit request to change behaviors. Currently the only way to accurately test for this is something like this, which is a bit excessive. Having a single value to check would be easier, and also passing that value through the cp_js_end hook to those Ajax requests know their origin.

```
public function isFrontEditRequest(): bool
    {
        return !empty(ee()->input->get('entry_ids')) && ee()->input->get('modal_form') === 'y' && ee()->input->get('field_id') !== '';
    }
```

This change also requires a small update in the FrontEdit.php service file when creating the url:

```
$fieldEditUrl = ee('CP/URL')->make(
    'publish/edit/entry/ENTRY_ID',
    [
        'entry_ids' => ['ENTRY_ID'],
        'field_id' => 'FIELD_ID',
        'hide_closer' => 'y',
        'site_id' => 'SITE_ID',
        'modal_form' => 'y',
        'is_frontedit' => 'y',
        'return' => urlencode(ee()->functions->fetch_current_uri())
    ],
    ee()->config->item('cp_url')
);
```

I can't seem to make this change though because the Pro module is not in Github :(

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation

Not sure this requires a documentation update? Though I would consider adding something to the `cp_js_end` hook informing developers if they're using this hook to examine what they're doing because the Frontedit requests are not full control panel loads, so if they are adding JS to the page to modify something that isn't in the Frontedit modal, they could be adding excessive and unnecessary JS to the page load.

