### PR TITLE
Improve `search_no_stopwords` message

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -5,6 +5,7 @@ ExpressionEngine uses semantic versioning. This file contains changes to Express
 ## Patch Release
 
 Bullet list below, e.g.
+   - Fix `search_no_stopwords` unclear message
    - Added <new feature>
    - Changed how the Toggle field renders in a column in the Entry Manager
    - Fixed a bug (#<linked issue number>) where <bug behavior>.

--- a/system/ee/language/english/search_lang.php
+++ b/system/ee/language/english/search_lang.php
@@ -104,7 +104,7 @@ $lang = array(
 
     'search_no_result' => 'Your search did not return any results.',
 
-    'search_no_stopwords' => 'Your search term included common words that are not allowed to be searched.',
+    'search_no_stopwords' => 'Your search term included only common words that are not allowed to be searched.',
 
     'search_not_allowed' => 'You are not permitted to use the search engine.',
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

`search_no_stopwords` is unclear:

> Your search term included common words that are not allowed to be searched.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1602](https://github.com/ExpressionEngine/ExpressionEngine/issues/1602).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
