### PR TITLE
support PHP & EE version check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,7 +87,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [5.6, 7.1, 7.2, 7.4, 8.0]
+                php: [7.1, 7.2, 7.4, 8.0]
                 os: [ubuntu-18.04]
                 include:
                   - php: 7.3

--- a/system/ee/ExpressionEngine/Controller/Members/Roles/Roles.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Roles/Roles.php
@@ -662,11 +662,24 @@ class Roles extends AbstractRolesController
                     'fields' => [
                         'require_mfa' => [
                             'type' => 'yes_no',
+                            'disabled' => version_compare(PHP_VERSION, 7.1, '<'),
                             'value' => $role->RoleSettings->filter('site_id', ee()->config->item('site_id'))->first()->require_mfa,
                         ]
                     ]
                 ],
             ]);
+            if (version_compare(PHP_VERSION, 7.1, '<')) {
+                ee()->lang->load('addons');
+                $section = array_merge($section, [
+                    ee('CP/Alert')->makeInline('mfa_not_available')
+                        ->asWarning()
+                        ->withTitle(lang('mfa_not_available'))
+                        ->addToBody(sprintf(lang('version_required'), 'PHP', 7.1))
+                        ->cannotClose()
+                        ->render()
+                        . form_hidden('require_mfa', 'n')
+                ]);
+            }
         }
 
         if ($role->getId() != Member::SUPERADMIN) {

--- a/system/ee/ExpressionEngine/Core/Provider.php
+++ b/system/ee/ExpressionEngine/Core/Provider.php
@@ -389,7 +389,7 @@ class Provider extends InjectionBindingDecorator
                             ee()->lang->loadfile($cookieParams['cookie_provider'], $cookieParams['cookie_provider'], false);
                             break;
                     }
-                    
+
                     $cookieSettings->cookie_title = (lang('cookie_' . $cookie_name) != 'cookie_' . $cookie_name) ? lang('cookie_' . $cookie_name) : lang($cookie_name);
                     if (!empty($builtinCookieSettings) && isset($builtinCookieSettings[$cookie_name])) {
                         if (isset($builtinCookieSettings[$cookie_name]['description'])) {

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -59,6 +59,8 @@ $lang = array(
 
     'addons_not_installed' => 'Add-Ons Not Installed',
 
+    'addon_not_fully_functional' => '%s is not fully functional',
+
     'existing_consent_request' => 'The following add-on(s) could not be installed due to an existing Consent Request which the add-on(s) are trying to create:',
 
     'contact_developer' => 'Please contact the add-on developer(s) for assistance.',
@@ -181,6 +183,8 @@ $lang = array(
     'specific_page' => 'Specific Page?',
 
     'version' => 'Version',
+
+    'version_required' => '%s version %s or higher is required.',
 
     /* License */
 


### PR DESCRIPTION
EEPRO-280

Pro branch: https://github.com/EllisLab/ExpressionEngine-Pro/tree/feature/2FA

This adds support for 
```
    'requires'       => [
        'php'   => '7.1',
        'ee'    => '6.2.0'
    ],
```
in `addon.setup.php` so that add-on that does not meet the requirements cannot be installed