### PR TITLE
fixed relationship field to show Add button if max value is empty, EECORE-1614

### DIFF
--- a/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
+++ b/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
@@ -80,17 +80,6 @@ class Relationship_ft extends EE_Fieldtype implements ColumnInterface
 
         $validator = ee('Validation')->make($rules);
 
-        $validator->defineRule('gtLimit', function ($key, $value, $parameters, $rule) use ($data) {
-            if (
-                ((isset($data['allow_multiple']) && $data['allow_multiple'] == true) || (isset($data['relationship_allow_multiple']) && $data['relationship_allow_multiple'] == 'y'))
-                && $data['limit'] < $data['rel_min']
-            ) {
-                    $rule->stop();
-                    return lang('rel_ft_min_settings_error');
-            }
-            return true;
-        });
-
         $this->errors = $validator->validate($data);
 
         return $this->errors;

--- a/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
+++ b/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
@@ -74,7 +74,7 @@ class Relationship_ft extends EE_Fieldtype implements ColumnInterface
     public function validate_settings($data)
     {
         $rules = [
-            'rel_min' => 'isNatural|gtLimit',
+            'rel_min' => 'isNatural',
             'rel_max' => 'isNaturalNoZero'
         ];
 

--- a/system/ee/language/english/fieldtypes_lang.php
+++ b/system/ee/language/english/fieldtypes_lang.php
@@ -47,9 +47,9 @@ $lang = array(
 
     'rel_ft_include_future' => 'Future entries',
 
-    'rel_ft_limit' => 'Maximum entries',
+    'rel_ft_limit' => 'Maximum number of available entries',
 
-    'rel_ft_limit_desc' => 'Maximum entries displayed in dropdown. <br><i>Leave blank to allow all entries.</i>',
+    'rel_ft_limit_desc' => 'Sets the number of entries displayed in the field\'s dropdown.<br><i>Leave blank to allow all entries.</i>',
 
     'rel_ft_order' => 'Order by',
 
@@ -75,19 +75,17 @@ $lang = array(
 
     'rel_ft_display_entry_id_desc' => 'When enabled, entry IDs will be displayed together with entry title inside the field.',
 
-    'rel_ft_max' => 'Maximum relationship',
+    'rel_ft_max' => 'Maximum number of related entries',
 
     'rel_ft_max_desc' => 'Sets the maximum number of entries this field can be used to relate.',
 
     'rel_ft_max_error' => 'You can select no more than %d entries.',
 
-    'rel_ft_min' => 'Minimum relationship',
+    'rel_ft_min' => 'Minimum number of related entries',
 
-    'rel_ft_min_desc' => 'Sets the minimum number of entries this field can be used to relate',
+    'rel_ft_min_desc' => 'Sets the minimum number of entries this field should be used to relate.',
 
     'rel_ft_min_error' => 'You need to select at least %d entries.',
-
-    'rel_ft_min_settings_error' => 'The minimum relationship cannot be set to number less than maximum entries to be shown',
 
     /* Duration */
     'duration_ft_hh' => 'hh',

--- a/system/ee/language/english/fieldtypes_lang.php
+++ b/system/ee/language/english/fieldtypes_lang.php
@@ -49,7 +49,7 @@ $lang = array(
 
     'rel_ft_limit' => 'Maximum entries',
 
-    'rel_ft_limit_desc' => 'Maximum number of entries to show in relationship field.<br><i>Leave blank to allow all entries.</i>',
+    'rel_ft_limit_desc' => 'Maximum entries displayed in dropdown. <br><i>Leave blank to allow all entries.</i>',
 
     'rel_ft_order' => 'Order by',
 
@@ -75,19 +75,19 @@ $lang = array(
 
     'rel_ft_display_entry_id_desc' => 'When enabled, entry IDs will be displayed together with entry title inside the field.',
 
-    'rel_ft_max' => 'Maximum selection',
+    'rel_ft_max' => 'Maximum relationship',
 
     'rel_ft_max_desc' => 'Sets the maximum number of entries this field can be used to relate.',
 
     'rel_ft_max_error' => 'You can select no more than %d entries.',
 
-    'rel_ft_min' => 'Minimum selection',
+    'rel_ft_min' => 'Minimum relationship',
 
     'rel_ft_min_desc' => 'Sets the minimum number of entries this field can be used to relate',
 
     'rel_ft_min_error' => 'You need to select at least %d entries.',
 
-    'rel_ft_min_settings_error' => 'The minimum selection cannot be set to number less than maximum entries to be shown',
+    'rel_ft_min_settings_error' => 'The minimum relationship cannot be set to number less than maximum entries to be shown',
 
     /* Duration */
     'duration_ft_hh' => 'hh',

--- a/tests/cypress/cypress/integration/publish/relationship.ee6.js
+++ b/tests/cypress/cypress/integration/publish/relationship.ee6.js
@@ -24,7 +24,7 @@ context('Relationship field - Edit', () => {
 	context('relationship field', () => {
 
 			// default, display_entry_id is Off, items haven't been added 
-			it('saves relationship field', () => {
+		it('saves relationship field', () => {
 			cy.visit('admin.php?/cp/publish/edit/entry/1')
 			cy.get('button:contains("Relate Entry")').first().click()
 			cy.get('a.dropdown__link:contains("Welcome to the Example Site!")').first().click();
@@ -88,6 +88,46 @@ context('Relationship field - Edit', () => {
 			cy.get('body').type('{ctrl}', {release: false}).type('s')
 			cy.get('.app-notice---success').contains('Entry Updated');
 			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.hasNoErrors()
+
+		})
+
+		it('add button is visible when rel max is empty', () => {
+			cy.visit('admin.php?/cp/fields/edit/8');
+			cy.get('[data-toggle-for="relationship_allow_multiple"]').should('have.class', 'on')
+			cy.get('[name="rel_min"]').should('be.visible');
+			cy.get('[name="rel_max"]').should('be.visible');
+			cy.get('[name="rel_max"]').clear()
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.hasNoErrors()
+
+			cy.visit('admin.php?/cp/publish/edit/entry/1')
+			cy.get('button:contains("Relate Entry")').should('be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('button:contains("Relate Entry")').should('be.visible')
+			cy.hasNoErrors()
+
+			cy.get('button:contains("Relate Entry")').should('be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('button:contains("Relate Entry")').should('be.visible')
+			cy.hasNoErrors()
+
+			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').should('not.exist')
+			cy.get('button:contains("Relate Entry")').should('be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('button:contains("Relate Entry")').should('be.visible')
+			cy.hasNoErrors()
+
+			cy.get('button:contains("Relate Entry")').first().click()
+			cy.get('a.dropdown__link:contains("Band Title")').first().click();
+			cy.get('button:contains("Relate Entry")').should('be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('button:contains("Relate Entry")').should('be.visible')
 			cy.hasNoErrors()
 
 		})
@@ -186,7 +226,6 @@ context('Relationship field - Edit', () => {
 			cy.get('[name=title]').invoke('val').should('eq', "Getting to Know ExpressionEngine")
 			cy.get('[name=field_id_1]').invoke('val').should('contain', "Thank you for choosing ExpressionEngine!")
 			cy.get('[name=field_id_3]').invoke('val').should('eq', "{filedir_2}ee_banner_120_240.gif");
-			cy.get('button:contains("Relate Entry")').should('not.be.visible')
 			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
 			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
 		})
@@ -251,7 +290,6 @@ context('Relationship field - Edit', () => {
 			cy.get('[name=title]').invoke('val').should('eq', "Getting to Know ExpressionEngine")
 			cy.get('[name=field_id_1]').invoke('val').should('contain', "Thank you for choosing ExpressionEngine!")
 			cy.get('[name=field_id_3]').invoke('val').should('eq', "{filedir_2}ee_banner_120_240.gif");
-			//cy.get('button:contains("Relate Entry")').should('not.be.visible')
 			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
 			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
 		})
@@ -303,6 +341,53 @@ context('Relationship field - Edit', () => {
 
 		})
 
+		it('add button is not visible when rel max is empty for grid', () => {
+			cy.visit('admin.php?/cp/fields/edit/19');
+			cy.get('[data-field-name=col_id_3] .fields-grid-tool-expand').first().click()
+			cy.get('[data-toggle-for="relationship_allow_multiple"]').should('have.class', 'on')
+			cy.get('[name="grid[cols][col_id_3][col_settings][rel_min]"]').should('be.visible');
+			cy.get('[name="grid[cols][col_id_3][col_settings][rel_max]"]').should('be.visible');
+			cy.get('[name="grid[cols][col_id_3][col_settings][rel_max]"]').clear()
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+
+			cy.visit('admin.php?/cp/publish/edit/entry/1')
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('.grid-field tr:not(.hidden) .list-item__title:contains("Welcome to the Example Site!")').closest('.list-item').find('[title="Remove"]').click()
+
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('not.exist')
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title!")').should('not.exist')
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('be.visible')
+			cy.hasNoErrors()
+
+			cy.get('.grid-field tr:not(.hidden) a.dropdown__link:contains("Welcome to the Example Site!")').first().click({force: true});
+			cy.get('.grid-field tr:not(.hidden) a.dropdown__link:contains("Band Title")').first().click({force: true});
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('be.visible')
+			cy.hasNoErrors()
+
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Band Title")').should('not.exist')
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('be.visible')
+			cy.hasNoErrors()
+
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').first().click()
+			cy.get('.grid-field tr:not(.hidden) a.dropdown__link:contains("Band Title")').first().click({force: true});
+			cy.get('.grid-field button:contains("Relate Entry")').should('be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('.grid-field button:contains("Relate Entry")').should('be.visible')
+			cy.hasNoErrors()
+
+		})
+
 		//	display_entry_id On, items have been added
 		it('check relationship field with display entry id in grid', () => {
 			cy.visit('admin.php?/cp/fields/edit/19');
@@ -320,7 +405,7 @@ context('Relationship field - Edit', () => {
 			cy.get('[name=field_id_3]').invoke('val').should('eq', "{filedir_2}ee_banner_120_240.gif");
 			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
 			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
-			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('not.be.visible')
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('be.visible')
 		})
 
 		//  display_entry_id Off, items have been added
@@ -340,7 +425,7 @@ context('Relationship field - Edit', () => {
 			cy.get('[name=field_id_3]').invoke('val').should('eq', "{filedir_2}ee_banner_120_240.gif");
 			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
 			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
-			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('not.be.visible')
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('be.visible')
 		})
 	})
 })

--- a/themes/ee/cp/js/build/components/relationship.js
+++ b/themes/ee/cp/js/build/components/relationship.js
@@ -342,8 +342,7 @@ var Relationship = /*#__PURE__*/function (_React$Component) {
         });
         return notInSelected && allowedChannel && filterName;
       });
-      var maxItems = this.props.rel_max ? this.props.rel_max : this.props.limit;
-      var showAddButton = maxItems > this.state.selected.length && (this.props.multi || this.state.selected.length == 0) && this.props.items.length > this.state.selected.length;
+      var showAddButton = (this.props.multi || this.state.selected.length == 0) && (this.props.rel_max == 0 || this.props.rel_max > this.state.selected.length);
       var channelFilterItems = props.channels.map(function (channel) {
         return {
           label: channel.title,

--- a/themes/ee/cp/js/src/components/relationship.jsx
+++ b/themes/ee/cp/js/src/components/relationship.jsx
@@ -270,9 +270,7 @@ class Relationship extends React.Component {
             return notInSelected && allowedChannel && filterName
         })
 
-        let maxItems = this.props.rel_max ? this.props.rel_max : this.props.limit
-
-        let showAddButton = ((maxItems > this.state.selected.length) && (this.props.multi || this.state.selected.length==0) && (this.props.items.length > this.state.selected.length))
+        let showAddButton = ( (this.props.multi || this.state.selected.length==0) && ( this.props.rel_max == 0 || this.props.rel_max > this.state.selected.length) );
 
         let channelFilterItems = props.channels.map((channel) => {
             return { label: channel.title, value: channel.id}


### PR DESCRIPTION
fixes #1717 
EECORE-1614

1. Changed description text to` Maximum entries displayed in dropdown`, `Minimum selection` to  `Minimum relationships`, and `Maximum section` to `Maximum relationships`. 
2. Fixed behavior for Relate Entry button to show it if `Maximum relationships` is empty