### PR TITLE
Added `has_children` variable to category tags, #1726

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -2952,6 +2952,14 @@ class Channel
 
             ee()->load->library('typography');
 
+            $parent_ids = array();
+
+            foreach ($this->cat_array as $val) {
+                if (!empty($val[1]) && !in_array($val[1], $parent_ids)) {
+                    $parent_ids[] = $val[1];
+                }
+            }
+
             foreach ($this->cat_array as $key => $val) {
                 $chunk = ee()->TMPL->tagdata;
 
@@ -2962,6 +2970,7 @@ class Channel
                     'category_image' => (string) $val[5],
                     'category_id' => $val[0],
                     'parent_id' => $val[1],
+                    'has_children' => in_array($val[0], $parent_ids),
                     'active' => ($active_cat == $val[0] || $active_cat == $val[6])
                 );
 
@@ -3343,12 +3352,19 @@ class Channel
 
             if ($query->num_rows() > 0) {
                 $used = array();
+                $parent_ids = array();
 
                 // Get category ID from URL for {if active} conditional
                 ee()->load->helper('segment');
                 $active_cat = parse_category($this->query_string);
 
                 ee()->load->library('typography');
+
+                foreach ($query->result_array() as $row) {
+                    if (!empty($row['parent_id']) && !in_array($row['parent_id'], $parent_ids)) {
+                        $parent_ids[] = $row['parent_id'];
+                    }
+                }
 
                 foreach ($query->result_array() as $row) {
                     // We'll concatenate parsed category and title chunks here for
@@ -3366,6 +3382,7 @@ class Channel
                             'category_image' => (string) $row['cat_image'],
                             'category_id' => $row['cat_id'],
                             'parent_id' => $row['parent_id'],
+                            'has_children' => in_array($row['cat_id'], $parent_ids),
                             'active' => ($active_cat == $row['cat_id'] || $active_cat == $row['cat_url_title'])
                         );
 
@@ -3715,6 +3732,14 @@ class Channel
             ee()->load->helper('segment');
         }
 
+        $parent_ids = array();
+
+        foreach ($this->cat_array as $val) {
+            if (!empty($val[0]) && !in_array($val[0], $parent_ids)) {
+                $parent_ids[] = $val[0];
+            }
+        }
+
         foreach ($this->cat_array as $key => $val) {
             if ($parent_id == $val[0]) {
                 if ($open == 0) {
@@ -3733,6 +3758,7 @@ class Channel
                     'category_image' => (string) $val[2],
                     'category_id' => $key,
                     'parent_id' => $val[0],
+                    'has_children' => in_array($key, $parent_ids),
                     'active' => ($active_cat == $key || $active_cat == $val[4])
                 );
 

--- a/tests/cypress/cypress/integration/channel/categories.ee6.js
+++ b/tests/cypress/cypress/integration/channel/categories.ee6.js
@@ -423,6 +423,29 @@ context('Categories', () => {
         })
     })
 
+    it('check which categories have children', function () {
+        cy.authVisit('admin.php?/cp/categories/edit/1/2');
+		cy.get('#fieldset-parent_id input[type=radio][value=1]').check();
+
+        cy.get('button[name=submit][value=save]').first().click();
+
+        cy.visit('index.php/cats/archive');
+
+        cy.get('#news .has_children').invoke('text').then((text) => {
+            expect(text).equal('This category has children')
+        });
+
+        cy.get('#bands .has_children').should('not.exist');
+
+        cy.visit('index.php/cats/archive-nested');
+
+        cy.get('#news .has_children').invoke('text').then((text) => {
+            expect(text).equal('This category has children')
+        });
+
+        cy.get('#bands .has_children').should('not.exist');
+    });
+
     describe('static usage of category heading tag', function() {
         it('category heading is correct when using category_id', function() {
 

--- a/tests/cypress/support/templates/default_site/cats.group/archive-nested.html
+++ b/tests/cypress/support/templates/default_site/cats.group/archive-nested.html
@@ -10,6 +10,9 @@
             <div class="custom_dropdown">{custom_dropdown}</div>
             <div class="category_image"><img src="{category_image}" /></div>
             <div class="category_image_smaller"><img src="{category_image:smaller}" /></div>
+            {if has_children}
+            <div class="has_children">This category has children</div>
+            {/if}
         </div>
     {/categories}
     {entry_titles}

--- a/tests/cypress/support/templates/default_site/cats.group/archive.html
+++ b/tests/cypress/support/templates/default_site/cats.group/archive.html
@@ -10,6 +10,9 @@
             <div class="custom_dropdown">{custom_dropdown}</div>
             <div class="category_image"><img src="{category_image}" /></div>
             <div class="category_image_smaller"><img src="{category_image:smaller}" /></div>
+            {if has_children}
+            <div class="has_children">This category has children</div>
+            {/if}
         </div>
     {/categories}
     {entry_titles}


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Add `{has_children}` variable to `exp:channel:categories` and `exp:channel:category_archive`.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1726](https://github.com/ExpressionEngine/ExpressionEngine/issues/1726).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/379
