### PR TITLE
Update field.php - $attrs could be overwritten

### DIFF
--- a/system/ee/ExpressionEngine/View/_shared/form/field.php
+++ b/system/ee/ExpressionEngine/View/_shared/form/field.php
@@ -21,7 +21,7 @@ if (is_string($value)) {
 }
 $attrs = (isset($field['attrs'])) ? $field['attrs'] : '';
 if (isset($field['disabled']) && $field['disabled'] == true) {
-    $attrs = ' disabled="disabled"';
+    $attrs .= ' disabled="disabled"';
 }
 // This is to handle showing and hiding certain parts
 // of the form when a form element changes


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

This PR fixes a concatenation issue. The `$attrs` value is first set as either an empty string or the value of 'attrs' from the array passed to the field loop.

Currently written, the developer's inputted `$attrs` would be overwritten/ignored/reset if the field is disabled and then afterwards the remaining values are appended like normal.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
