### PR TITLE
Increase the allowed size of the page_uri

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pages/tab.pages.php
+++ b/system/ee/ExpressionEngine/Addons/pages/tab.pages.php
@@ -90,7 +90,7 @@ class Pages_tab
                 'field_required' => 'n',
                 'field_data' => $pages_uri,
                 'field_text_direction' => 'ltr',
-                'field_maxl' => 100,
+                'field_maxl' => 200,
                 'field_instructions' => '',
                 'field_placeholder' => lang('example_uri')
             ),


### PR DESCRIPTION
The url_title limit is 200, but the current page_uri in the pages module is only 100 due to the max size setting on the form.  Bumping it up per a request and for consistency.  It's saved in an array, so no need for db change.

