### PR TITLE
Fix Consent Module not respecting `disable_csrf_protection` config ov…

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -55,7 +55,7 @@ Bullet list below, e.g.
    - Fix #1195 improves `template_post_parse` hook when fired after sub or layout (i.e. partial) template parse completes
    - Fix WEBP Mime type detection
    - Fix channels being ignored on search module
-
+   - Fix Consent Module not respecting `disable_csrf_protection` config override
 
 EOF MARKER: This line helps prevent merge conflicts when things are
 added on the bottoms of lists

--- a/system/ee/ExpressionEngine/Addons/consent/mod.consent.php
+++ b/system/ee/ExpressionEngine/Addons/consent/mod.consent.php
@@ -318,6 +318,10 @@ class Consent
      */
     private function validateGetCsrf()
     {
+        if (ee('Config')->getFile()->getBoolean('disable_csrf_protection')) {
+            return;
+        }
+
         $token = ee()->input->get('token');
 
         if ($token != CSRF_TOKEN) {


### PR DESCRIPTION
## Overview

Fix Consent Module not respecting `disable_csrf_protection` config override

Resolves [#1766](https://github.com/ExpressionEngine/ExpressionEngine/issues/1766).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
