### PR TITLE
Fixed bad path to native plugins

### DIFF
--- a/changelogs/patch.md
+++ b/changelogs/patch.md
@@ -55,6 +55,7 @@ Bullet list below, e.g.
    - Fix #1195 improves `template_post_parse` hook when fired after sub or layout (i.e. partial) template parse completes
    - Fix WEBP Mime type detection
    - Fix channels being ignored on search module
+   - Fixed a bad path to the plugin folder that could cause an error on the frontend.
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/legacy/libraries/Typography.php
+++ b/system/ee/legacy/libraries/Typography.php
@@ -800,7 +800,7 @@ class EE_Typography
 
         if (! class_exists($plugin)) {
             if (in_array($this->text_format, ee()->core->native_plugins)) {
-                require_once PATH_ADDONS . 'pi.' . $this->text_format . '.php';
+                require_once PATH_ADDONS . $this->text_format . '/pi.' . $this->text_format . '.php';
             } else {
                 require_once PATH_THIRD . $this->text_format . '/pi.' . $this->text_format . '.php';
             }


### PR DESCRIPTION
After updates, frontend throws
```
require_once(ee/ExpressionEngine/Addons/pi.xml_encode.php): failed to open stream: No such file or directory

```
Why this wasn't happening to everyone, not entirely sure.  I've had exactly one report of it.  But that's an old legacy path from when plugins weren't in folders.
