### PR TITLE
EECORE-1661 Update channel entry query entry_date check

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -1132,7 +1132,7 @@ class Channel
         $timestamp = ee()->localize->now;
 
         if (ee()->TMPL->fetch_param('show_future_entries') != 'yes') {
-            $sql .= " AND t.entry_date < " . $timestamp . " ";
+            $sql .= " AND t.entry_date <= " . $timestamp . " ";
         }
 
         if (ee()->TMPL->fetch_param('show_expired') == 'only') {


### PR DESCRIPTION
When checking whether an entry date is current or in the future, we were using 

```$sql .= " AND t.entry_date < " . $timestamp . " ";```

But logically it should be <=.  This could cause issues if redirecting a channel form submission to a page with a channel entry tag on it to show the just submitted post.  If it was a very fast return, the channel entry tag wouldn't show the new entry because the entry date was exactly 'now' on the new page load.  