### PR TITLE
Resolved #1808 where `base_` variables from **Query module** aren't parsed

### DIFF
--- a/changelogs/minor.md
+++ b/changelogs/minor.md
@@ -17,6 +17,7 @@ Bullet list below, e.g.
    - Added Sticky entry column to entries table
    - Add channel data to category archives
    - Added `parse_files` parameter on Query Module
+   - Added `parse_bases` parameter on Query Module
 
 
 EOF MARKER: This line helps prevent merge conflicts when things are

--- a/system/ee/ExpressionEngine/Addons/query/mod.query.php
+++ b/system/ee/ExpressionEngine/Addons/query/mod.query.php
@@ -63,7 +63,7 @@ class Query
 
                 $chunk = ee()->TMPL->parse_switch($chunk, $count - 1);
 
-                if (strpos($chunk, '{base_') !== false) {
+                if (strpos($chunk, LD . 'base_') !== false) {
                     $chunk = isset($row['site_id'])
                         ? parse_config_variables(
                             $chunk,
@@ -77,7 +77,7 @@ class Query
             $parsed = ee()->TMPL->parse_variables(ee()->TMPL->tagdata, $results);
         }
 
-        if (get_bool_from_string(ee()->TMPL->fetch_param('parse_files', config_item('parse_variables_query_results_by_default'))) && strpos($parsed, '{filedir_') !== false) {
+        if (get_bool_from_string(ee()->TMPL->fetch_param('parse_files', config_item('parse_variables_query_results_by_default'))) && strpos($parsed, LD . 'filedir_') !== false) {
             ee()->load->library('file_field');
             $parsed = ee()->file_field->parse_string($parsed);
         }

--- a/system/ee/ExpressionEngine/Addons/query/mod.query.php
+++ b/system/ee/ExpressionEngine/Addons/query/mod.query.php
@@ -50,15 +50,38 @@ class Query
             $results = array_slice($results, $pagination->offset, $pagination->per_page);
         }
 
-        $str = ee()->TMPL->parse_variables(ee()->TMPL->tagdata, array_values($results));
+        $parsed = '';
 
-        if (ee()->TMPL->fetch_param('parse_files') === 'yes' && strpos($str, '{filedir_') !== false) {
-            ee()->load->library('file_field');
-            $str = ee()->file_field->parse_string($str);
+        if (get_bool_from_string(ee()->TMPL->fetch_param('parse_bases', config_item('parse_variables_query_results_by_default')))) {
+            $count = 0;
+
+            foreach ($results as $row) {
+                $row['count'] = ++$count;
+                $row['total_results'] = $query->num_rows;
+
+                $chunk = ee()->TMPL->parse_variables_row(ee()->TMPL->tagdata, $row);
+
+                if (strpos($chunk, '{base_') !== false) {
+                    $chunk = isset($row['site_id'])
+                        ? parse_config_variables(
+                            $chunk,
+                            ee()->config->get_cached_site_prefs($row['site_id'])
+                        )
+                        : parse_config_variables($chunk);
+                }
+                $parsed .= $chunk;
+            }
+        } else {
+            $parsed = ee()->TMPL->parse_variables(ee()->TMPL->tagdata, $results);
         }
 
-        $this->return_data = $str;
-        
+        if (get_bool_from_string(ee()->TMPL->fetch_param('parse_files', config_item('parse_variables_query_results_by_default'))) && strpos($parsed, '{filedir_') !== false) {
+            ee()->load->library('file_field');
+            $parsed = ee()->file_field->parse_string($parsed);
+        }
+
+        $this->return_data = $parsed;
+
         if ($pagination->paginate === true) {
             $this->return_data = $pagination->render($this->return_data);
         }

--- a/system/ee/ExpressionEngine/Addons/query/mod.query.php
+++ b/system/ee/ExpressionEngine/Addons/query/mod.query.php
@@ -61,6 +61,8 @@ class Query
 
                 $chunk = ee()->TMPL->parse_variables_row(ee()->TMPL->tagdata, $row);
 
+                $chunk = ee()->TMPL->parse_switch($chunk, $count - 1);
+
                 if (strpos($chunk, '{base_') !== false) {
                     $chunk = isset($row['site_id'])
                         ? parse_config_variables(

--- a/tests/cypress/cypress/integration/addons/query.ee6.js
+++ b/tests/cypress/cypress/integration/addons/query.ee6.js
@@ -34,7 +34,8 @@ context('Request', () => {
         cy.get('.query-results--parsed-files__field_id_3').first().invoke('text').should('eq', "/images/about/ee_banner_120_240.gif")
     })
     it('parse base variables', function(){
-        cy.get('.query-results--parsed-bases__3 .query-results--parsed-bases__url').first().invoke('text').should('eq', "http://localhost:8888/images/avatars/")
+		cy.get('.query-results--parsed-bases__3 .query-results--parsed-bases__url').first().invoke('text').should('contain', "http://localhost:8888/images/avatars/")
+		cy.get('.query-results--parsed-bases__3').first().should('have.class', 'odd')
     })
   })
 })

--- a/tests/cypress/cypress/integration/addons/query.ee6.js
+++ b/tests/cypress/cypress/integration/addons/query.ee6.js
@@ -1,0 +1,40 @@
+/// <reference types="Cypress" />
+
+import AddonManager from '../../elements/pages/addons/AddonManager';
+import SiteForm from '../../elements/pages/site/SiteForm';
+import SiteManager from '../../elements/pages/site/SiteManager';
+
+const addon_manager = new AddonManager;
+const siteManager = new SiteManager;
+const form = new SiteForm;
+
+context('Request', () => {
+
+  before(function(){
+    cy.task('db:seed')
+    cy.eeConfig({ item: 'multiple_sites_enabled', value: 'y' })
+    cy.eeConfig({ item: 'save_tmpl_files', value: 'y' })
+    cy.task('filesystem:copy', { from: 'support/templates/*', to: '../../system/user/templates/default_site/' })
+    cy.auth();
+    addon_manager.load()
+    addon_manager.get('first_party_addons').find('.add-on-card:contains("Query") a').click()
+    cy.authVisit('admin.php?/cp/design')
+    siteManager.load();
+  })
+
+  context('check all tags', function(){
+    before(function() {
+      cy.visit('index.php/query/index')
+    })
+
+    it('return unparsed files', function(){
+        cy.get('.query-results__field_id_3').first().invoke('text').should('eq', "{filedir_2}ee_banner_120_240.gif")
+    })
+    it('parse file paths', function(){
+        cy.get('.query-results--parsed-files__field_id_3').first().invoke('text').should('eq', "/images/about/ee_banner_120_240.gif")
+    })
+    it('parse base variables', function(){
+        cy.get('.query-results--parsed-bases__3 .query-results--parsed-bases__url').first().invoke('text').should('eq', "http://localhost:8888/images/avatars/")
+    })
+  })
+})

--- a/tests/cypress/support/templates/query.group/index.html
+++ b/tests/cypress/support/templates/query.group/index.html
@@ -10,7 +10,7 @@
 		{exp:query
 			sql="SELECT entry_id , site_id , field_id_3 FROM exp_channel_data"
 		}
-			<tr class="query-results query-results__{count}">
+			<tr class="query-results query-results__{count} {switch='odd|even'}">
 				<th class="query-results__entry_id">{entry_id}</th>
 				<td class="query-results__site_id">{site_id}</td>
 				<td class="query-results__field_id_3">{field_id_3}</td>
@@ -33,7 +33,7 @@
 			sql="SELECT entry_id , site_id , field_id_3 FROM exp_channel_data"
 			parse_files="yes"
 		}
-			<tr class="query-results--parsed-files query-results--parsed-files__{count}">
+			<tr class="query-results--parsed-files query-results--parsed-files__{count} {switch='odd|even'}">
 				<th class="query-results--parsed-files__entry_id">{entry_id}</th>
 				<td class="query-results--parsed-files__site_id">{site_id}</td>
 				<td class="query-results--parsed-files__field_id_3">{field_id_3}</td>
@@ -56,7 +56,7 @@
 			sql="SELECT site_id, server_path , url FROM exp_upload_prefs"
 			parse_bases="yes"
 		}
-			<tr class="query-results--parsed-bases query-results--parsed-bases__{count}">
+			<tr class="query-results--parsed-bases query-results--parsed-bases__{count} {switch='odd|even'}">
 				<td class="query-results--parsed-bases__site_id">{site_id}</td>
 				<td class="query-results--parsed-bases__server_path">{server_path}</td>
 				<td class="query-results--parsed-bases__url">{url}</td>

--- a/tests/cypress/support/templates/query.group/index.html
+++ b/tests/cypress/support/templates/query.group/index.html
@@ -1,0 +1,66 @@
+<table>
+	<thead>
+		<tr>
+			<th>entry_id</th>
+			<th>site_id</th>
+			<th>field_id_3</th>
+		</tr>
+	</thead>
+	<tbody>
+		{exp:query
+			sql="SELECT entry_id , site_id , field_id_3 FROM exp_channel_data"
+		}
+			<tr class="query-results query-results__{count}">
+				<th class="query-results__entry_id">{entry_id}</th>
+				<td class="query-results__site_id">{site_id}</td>
+				<td class="query-results__field_id_3">{field_id_3}</td>
+			</tr>
+		{/exp:query}
+	</tbody>
+</table>
+
+<table>
+	<caption>parse_files="yes"</caption>
+	<thead>
+		<tr>
+			<th>entry_id</th>
+			<th>site_id</th>
+			<th>field_id_3</th>
+		</tr>
+	</thead>
+	<tbody>
+		{exp:query
+			sql="SELECT entry_id , site_id , field_id_3 FROM exp_channel_data"
+			parse_files="yes"
+		}
+			<tr class="query-results--parsed-files query-results--parsed-files__{count}">
+				<th class="query-results--parsed-files__entry_id">{entry_id}</th>
+				<td class="query-results--parsed-files__site_id">{site_id}</td>
+				<td class="query-results--parsed-files__field_id_3">{field_id_3}</td>
+			</tr>
+		{/exp:query}
+	</tbody>
+</table>
+
+<table>
+	<caption>parse_bases="yes"</caption>
+	<thead>
+		<tr>
+			<th>site_id</th>
+			<th>server_path</th>
+			<th>url</th>
+		</tr>
+	</thead>
+	<tbody>
+		{exp:query
+			sql="SELECT site_id, server_path , url FROM exp_upload_prefs"
+			parse_bases="yes"
+		}
+			<tr class="query-results--parsed-bases query-results--parsed-bases__{count}">
+				<td class="query-results--parsed-bases__site_id">{site_id}</td>
+				<td class="query-results--parsed-bases__server_path">{server_path}</td>
+				<td class="query-results--parsed-bases__url">{url}</td>
+			</tr>
+		{/exp:query}
+	</tbody>
+</table>


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Parse `{base_` variables on query module and add `parse_variables_query_results_by_default` to config overrides

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1808](https://github.com/ExpressionEngine/ExpressionEngine/issues/1808).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/398