### PR TITLE
Fix deprecation notices for str_replace with null value in php 8.1

### DIFF
--- a/system/ee/ExpressionEngine/Addons/fluid_field/Service/Tag.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/Service/Tag.php
@@ -233,7 +233,7 @@ class Tag
 
         foreach ($meta as $name => $value) {
             $tag = LD . $name . RD;
-            $tagdata = str_replace($tag, $value, $tagdata);
+            $tagdata = str_replace($tag, (string) $value, $tagdata);
         }
 
         return $tagdata;

--- a/system/ee/legacy/libraries/Grid_parser.php
+++ b/system/ee/legacy/libraries/Grid_parser.php
@@ -494,7 +494,7 @@ class Grid_parser
             // Finally, do the replacement
             $grid_row = str_replace(
                 $match[0],
-                $replace_data,
+                (string) $replace_data,
                 $grid_row
             );
         }


### PR DESCRIPTION
## Overview

Resolve deprecation notices in php 8.1 by properly casting replacement values to a string inside `str_replace`

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1833](https://github.com/ExpressionEngine/ExpressionEngine/issues/1833).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No


