### PR TITLE
Fix issue with CLI List command in PHP 5.6

### DIFF
--- a/system/ee/ExpressionEngine/Cli/Commands/CommandListCommands.php
+++ b/system/ee/ExpressionEngine/Cli/Commands/CommandListCommands.php
@@ -82,7 +82,8 @@ class CommandListCommands extends Cli
             $availableHydratedClass = new $availableClass();
 
             // Get the command header
-            $header = (explode(':', $availableCommand))[0];
+            $commandSegments = explode(':', $availableCommand);
+            $header = $commandSegments[0];
 
             // If this is a new header, we print a new line and then print the command header
             if (!in_array($header, $headers)) {


### PR DESCRIPTION
EECORE-1688

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fixes a bug in the CLI list command when running on PHP 5.6

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves EECORE-1688

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
