### PR TITLE
reset category field validation back to original

### DIFF
--- a/system/ee/ExpressionEngine/Model/Category/CategoryField.php
+++ b/system/ee/ExpressionEngine/Model/Category/CategoryField.php
@@ -45,7 +45,7 @@ class CategoryField extends FieldModel
     protected static $_validation_rules = array(
         'field_type' => 'required|enum[text,textarea,select]',
         'field_label' => 'required|xss|noHtml|maxLength[50]',
-        'field_name' => 'required|alphaDash|unique[group_id]|validateNameIsNotReserved|maxLength[32]',
+        'field_name' => 'required|alphaDash|unique[site_id]|validateNameIsNotReserved|maxLength[32]',
         'field_ta_rows' => 'integer',
         'field_maxl' => 'integer',
         'field_required' => 'enum[y,n]',


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Replace this paragraph with a description of your changes and reasoning. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [ ] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
