### PR TITLE
Resolved #1885 where slideshow was not working on demo templates

### DIFF
--- a/system/ee/installer/site_themes/default/templates/home.group/index.html
+++ b/system/ee/installer/site_themes/default/templates/home.group/index.html
@@ -19,7 +19,7 @@
     		data-cycle-next=".next-slide"
 		>
 			{!-- slideshow images from a specific directory, and category --}
-			{exp:file:entries directory_id='8' dynamic='no' limit='5' disable='pagination' category='not 25'}
+			{exp:file:entries directory_id='7' dynamic='no' limit='5' disable='pagination' category='not 25'}
 				<img src="{file_url}" alt="{file_name:attr_safe}"{if count == 1} class="act"{/if}>
 				{if count == 1}
 					<div class="slide-ctrls">


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

This PR fixes the demo templates slideshow in templates/home.group/index.html.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1885](https://github.com/ExpressionEngine/ExpressionEngine/issues/1885). (edit not 1884)

## Nature of This Change

<!-- Check all that apply: -->

- [x ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security 
