### PR TITLE
fix live preivew for grid and fluids

### DIFF
--- a/system/ee/ExpressionEngine/View/publish/live-preview-modal.php
+++ b/system/ee/ExpressionEngine/View/publish/live-preview-modal.php
@@ -1,6 +1,6 @@
 <div class="live-preview-container">
 	<div class="live-preview live-preview--closed">
-		<div class="live-preview__form">
+		<div id="left" class="live-preview__form">
 			<div class="live-preview__form-header">
 				<?php if (!isset($hide_closer) || !$hide_closer): ?>
 				<h1><a href class="js-close-live-preview"><i class="fas fa-times"></i> <?=lang('close_preview')?></a></h1>
@@ -16,14 +16,19 @@
 
 			</div>
 		</div>
+
 		<div class="live-preview__divider"></div>
-		<div class="live-preview__preview">
+		
+		<div id="right" class="live-preview__preview">
 			<div class="live-preview__preview-loader">
 				<!-- <span><?=lang('refreshing')?></span> -->
 				<span class="pulse-loader"></span>
 			</div>
-
+			
 			<iframe src="" data-url="<?=$preview_url?>" class="live-preview__frame"></iframe>
 		</div>
 	</div>
 </div>
+
+
+

--- a/themes/ee/asset/javascript/src/cp/publish/publish.js
+++ b/themes/ee/asset/javascript/src/cp/publish/publish.js
@@ -294,11 +294,16 @@ $(document).ready(function () {
 		// Get the percentage x position of the mouse
 		var xPos = e.clientX / $(document).width() * 100;
 		// Prevent each side from getting too small
-		xPos = Math.min(Math.max(xPos, 10), 98)
+		xPos = Math.min(Math.max(xPos, 10), 98);
 
 		// Set each sides width
 		$('.live-preview__form').css('flex-basis', xPos + '%')
 		$('.live-preview__preview').css('flex-basis', (100 - xPos) + '%')
+
+		const left = document.getElementById('left');
+		const right = document.getElementById('right');
+		left.style.width = xPos + '%';
+		right.style.width = (100 - xPos) + '%';
 	}
 
 	$(".live-preview__divider").on('mousedown', function(e) { handleDrag(e, 'mouse', onHandleDrag) });


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

In support, complaints that fluid and grid fields were causing the live preview of entries to have the shown result page be too small and the resize dragging was not working for them.  This should fix that.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
