### PR TITLE
Patch/wrong validation of category fields 

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -417,7 +417,9 @@ class Channel
                 return;
             }
 
-            $sql .= implode(',', array_unique(array_filter($categories))) . ')';
+            $sql .= empty($categories)
+                ? implode(',', array_unique(array_filter($categories))) . ')'
+                : '0)';
 
             $sql .= " ORDER BY c.group_id, c.parent_id, c.cat_order";
 

--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -2965,10 +2965,11 @@ class Channel
                     'active' => ($active_cat == $val[0] || $active_cat == $val[6])
                 );
 
-                // add custom fields for conditionals prep
-
+                // add custom fields for conditionals prep and parsing
                 foreach ($this->catfields as $v) {
-                    $cat_vars[$v['field_name']] = (! isset($val['field_id_' . $v['field_id']])) ? '' : $val['field_id_' . $v['field_id']];
+                    if (empty($cat_vars[$v['field_name']])) {
+                        $cat_vars[$v['field_name']] = (!isset($val['field_id_' . $v['field_id']])) ? '' : $val['field_id_' . $v['field_id']];
+                    }
                 }
 
                 $cat_vars['count'] = ++$this->category_count;
@@ -3369,8 +3370,11 @@ class Channel
                             'active' => ($active_cat == $row['cat_id'] || $active_cat == $row['cat_url_title'])
                         );
 
+                        // add custom fields for conditionals prep and parsing
                         foreach ($this->catfields as $v) {
-                            $cat_vars[$v['field_name']] = (! isset($row['field_id_' . $v['field_id']])) ? '' : $row['field_id_' . $v['field_id']];
+                            if (empty($cat_vars[$v['field_name']])) {
+                                $cat_vars[$v['field_name']] = (!isset($row['field_id_' . $v['field_id']])) ? '' : $row['field_id_' . $v['field_id']];
+                            }
                         }
 
                         $chunk = ee()->functions->prep_conditionals($chunk, $cat_vars);
@@ -3736,9 +3740,11 @@ class Channel
                     'active' => ($active_cat == $key || $active_cat == $val[4])
                 );
 
-                // add custom fields for conditionals prep
+                // add custom fields for conditionals prep and parsing
                 foreach ($this->catfields as $v) {
-                    $cat_vars[$v['field_name']] = (! isset($val['field_id_' . $v['field_id']])) ? '' : $val['field_id_' . $v['field_id']];
+                    if (empty($cat_vars[$v['field_name']])) {
+                        $cat_vars[$v['field_name']] = (!isset($val['field_id_' . $v['field_id']])) ? '' : $val['field_id_' . $v['field_id']];
+                    }
                 }
 
                 $cat_vars['count'] = ++$this->category_count;
@@ -4189,9 +4195,11 @@ class Channel
             'parent_id' => $query->row('parent_id')
         );
 
-        // add custom fields for conditionals prep
+        // add custom fields for conditionals prep and parsing
         foreach ($this->catfields as $v) {
-            $cat_vars[$v['field_name']] = ($query->row('field_id_' . $v['field_id'])) ? $query->row('field_id_' . $v['field_id']) : '';
+            if (empty($cat_vars[$v['field_name']])) {
+                $cat_vars[$v['field_name']] = ($query->row('field_id_' . $v['field_id'])) ? $query->row('field_id_' . $v['field_id']) : '';
+            }
         }
 
         ee()->TMPL->tagdata = ee()->functions->prep_conditionals(ee()->TMPL->tagdata, $cat_vars);

--- a/system/ee/ExpressionEngine/Model/Category/CategoryField.php
+++ b/system/ee/ExpressionEngine/Model/Category/CategoryField.php
@@ -45,7 +45,7 @@ class CategoryField extends FieldModel
     protected static $_validation_rules = array(
         'field_type' => 'required|enum[text,textarea,select]',
         'field_label' => 'required|xss|noHtml|maxLength[50]',
-        'field_name' => 'required|alphaDash|unique[site_id]|validateNameIsNotReserved|maxLength[32]',
+        'field_name' => 'required|alphaDash|unique[group_id]|validateNameIsNotReserved|maxLength[32]',
         'field_ta_rows' => 'integer',
         'field_maxl' => 'integer',
         'field_required' => 'enum[y,n]',

--- a/system/ee/ExpressionEngine/Model/Content/FieldModel.php
+++ b/system/ee/ExpressionEngine/Model/Content/FieldModel.php
@@ -500,14 +500,14 @@ abstract class FieldModel extends Model
             ));
         }
         if ($tag) {
-            return str_replace(LD . $tag . RD, $data, $tagdata);
+            return str_replace(LD . $tag . RD, ($data ?: ''), $tagdata);
         }
         $tag = $this->field_name;
         if ($modifier) {
             $tag = $tag . ':' . $modifier;
         }
 
-        return str_replace(LD . $tag . RD, $data, $tagdata);
+        return str_replace(LD . $tag . RD, ($data ?: ''), $tagdata);
     }
 
     public function getCompatibleFieldtypes()


### PR DESCRIPTION
Followup of #1672

## Overview

When creating a category field, the validation of its name checks against previously created fields of the entire site, instead of the same category group only.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1277](https://github.com/ExpressionEngine/ExpressionEngine/issues/1277).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
