### PR TITLE
Added possibility to defer initialization of Relationship field

### DIFF
--- a/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
+++ b/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
@@ -787,6 +787,7 @@ class Relationship_ft extends EE_Fieldtype implements ColumnInterface
         // Boolstring conversion
         $save['allow_multiple'] = get_bool_from_string($save['allow_multiple']);
         $save['display_entry_id'] = get_bool_from_string($save['display_entry_id']);
+        $save['deferred_loading'] = get_bool_from_string($save['deferred_loading']);
 
         foreach ($save as $field => $value) {
             if (is_array($value) && count($value)) {

--- a/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
+++ b/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
@@ -509,6 +509,7 @@ class Relationship_ft extends EE_Fieldtype implements ColumnInterface
         }
 
         return ee('View')->make('relationship:publish')->render([
+            'deferred' =>  isset($this->settings['deferred_loading']) ? $this->settings['deferred_loading'] : false,
             'field_name' => $field_name,
             'choices' => $choices,
             'selected' => $selected,
@@ -744,6 +745,16 @@ class Relationship_ft extends EE_Fieldtype implements ColumnInterface
                         'value' => ($values['display_entry_id']) ? 'y' : 'n'
                     )
                 )
+            ),
+            array(
+                'title' => 'rel_ft_deferred',
+                'desc' => 'rel_ft_deferred_desc',
+                'fields' => array(
+                    'relationship_deferred_loading' => array(
+                        'type' => 'yes_no',
+                        'value' => ($values['deferred_loading']) ? 'y' : 'n'
+                    )
+                )
             )
         );
 
@@ -812,6 +823,7 @@ class Relationship_ft extends EE_Fieldtype implements ColumnInterface
             'order_field' => 'title',
             'order_dir' => 'asc',
             'display_entry_id' => false,
+            'deferred_loading' => false,
             'allow_multiple' => 'y',
             'rel_min' => 0,
             'rel_max' => ''
@@ -828,8 +840,9 @@ class Relationship_ft extends EE_Fieldtype implements ColumnInterface
 
         // any default values that are not the empty ones
         $default_values = array(
+            'allow_multiple' => true,
+            'deferred_loading' => false,
             'display_entry_id' => false,
-            'allow_multiple' => true
         );
 
         $form = $util->form($field_empty_values, $prefix);

--- a/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
+++ b/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
@@ -509,7 +509,7 @@ class Relationship_ft extends EE_Fieldtype implements ColumnInterface
         }
 
         return ee('View')->make('relationship:publish')->render([
-            'deferred' =>  isset($this->settings['deferred_loading']) ? $this->settings['deferred_loading'] : false,
+            'deferred' => isset($this->settings['deferred_loading']) ? $this->settings['deferred_loading'] : false,
             'field_name' => $field_name,
             'choices' => $choices,
             'selected' => $selected,

--- a/system/ee/ExpressionEngine/Addons/relationship/views/publish.php
+++ b/system/ee/ExpressionEngine/Addons/relationship/views/publish.php
@@ -20,7 +20,7 @@ $component = [
     'rel_max' => $rel_max,
 ];
 
-$placeholder = '<label class="field-loading">' . lang('loading') .'<span></span></label>';
+$placeholder = '<label class="field-loading">' . lang('loading') . '<span></span></label>';
 
 if ($deferred) {
     echo '<div class="react-deferred-loading--relationship">';

--- a/system/ee/ExpressionEngine/Addons/relationship/views/publish.php
+++ b/system/ee/ExpressionEngine/Addons/relationship/views/publish.php
@@ -19,13 +19,53 @@ $component = [
     'rel_min' => $rel_min,
     'rel_max' => $rel_max,
 ];
+
+$placeholder = '<label class="field-loading">' . lang('loading') .'<span></span></label>';
+
+if ($deferred) {
+    echo '<div class="react-deferred-loading--relationship">';
+
+    $template = '<li class="list-item">
+            <div class="list-item__content">
+                <div class="list-item__title">%s</div>
+                <div class="list-item__secondary">%s</div>
+            </div>
+            <input type="hidden" name="%s" value="%d">
+        </li>';
+
+    $items = [];
+    $placeholder = '';
+
+    foreach ($selected as $relatedEntry) {
+        $items[] = sprintf(
+            $template,
+            $relatedEntry['label'],
+            $relatedEntry['instructions'],
+            $field_name . ($multi ? '[]' : ''),
+            $relatedEntry['value']
+        );
+    }
+
+    if (!empty($items)) {
+        $placeholder .= '<ul class="list-group list-group--connected mb-s ui-sortable">' . implode("\n", $items) . '</ul>';
+    }
+
+    $placeholder .= '
+        <button type="button" class="js-dropdown-toggle button button--default">
+            <i class="fas fa-edit icon-left"></i>' . lang('relate_entry_deferred') . '
+        </button>
+    ';
+}
 ?>
-<div data-relationship-react="<?=base64_encode(json_encode($component))?>" data-input-value="<?=$field_name?>">
-	<div class="fields-select">
-		<div class="field-inputs">
-			<label class="field-loading">
-				<?=lang('loading')?><span></span>
-			</label>
-		</div>
-	</div>
+<div data-relationship-react="<?=base64_encode(json_encode($component))?>" data-input-value="<?=$field_name?>" <?php echo ($deferred ? 'class="react-deferred-loading"' : '') ?>>
+    <div class="fields-select">
+        <div class="field-inputs">
+            <?php echo $placeholder ?>
+        </div>
+    </div>
 </div>
+<?php
+if ($deferred) {
+    echo '</div>';
+}
+?>

--- a/system/ee/language/english/fieldtypes_lang.php
+++ b/system/ee/language/english/fieldtypes_lang.php
@@ -29,6 +29,8 @@ $lang = array(
 
     'relate_entry' => 'Relate Entry',
 
+    'relate_entry_deferred' => 'Edit Relationships',
+
     'rel_ft_allow_multi' => 'Allow multiple relationships?',
 
     'rel_ft_allow_multi_desc' => 'When enabled, authors will be allowed to create multiple relationships.',
@@ -80,6 +82,10 @@ $lang = array(
     'rel_ft_display_entry_id' => 'Display Entry IDs?',
 
     'rel_ft_display_entry_id_desc' => 'When enabled, entry IDs will be displayed together with entry title inside the field.',
+
+    'rel_ft_deferred' => 'Defer field initialization?',
+
+    'rel_ft_deferred_desc' => 'When enabled, this field won’t initialize until the Edit Relationships button is clicked on. This can result in faster control panel page load times.',
 
     'rel_ft_max' => 'Maximum number of related entries',
 

--- a/tests/cypress/cypress/integration/publish/relationship.ee6.js
+++ b/tests/cypress/cypress/integration/publish/relationship.ee6.js
@@ -229,6 +229,104 @@ context('Relationship field - Edit', () => {
 			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
 			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
 		})
+
+		// default, defer field initialization Off
+		it('defer field initialization off', () => {
+			cy.visit('admin.php?/cp/publish/edit/entry/1')
+			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
+			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
+			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+
+			cy.visit('admin.php?/cp/fields/edit/8');
+			cy.get('[data-toggle-for="relationship_allow_multiple"]').should('have.class', 'on')
+			cy.get('[name="rel_min"]').should('be.visible');
+			cy.get('[name="rel_max"]').should('be.visible');
+			cy.get('[name="rel_max"]').clear().type('2')
+			cy.get('[data-toggle-for="relationship_deferred_loading"]').should('have.class', 'off')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.hasNoErrors()
+
+			cy.visit('admin.php?/cp/publish/edit/entry/1')
+			cy.get('button:contains("Relate Entry")').first().click()
+			cy.get('a.dropdown__link:contains("Welcome to the Example Site!")').first().click();
+			cy.get('a.dropdown__link:contains("Band Title")').first().click();
+			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.hasNoErrors()
+
+			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.hasNoErrors()
+
+			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').should('not.exist')
+			cy.get('button:contains("Relate Entry")').should('be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('button:contains("Relate Entry")').should('be.visible')
+			cy.hasNoErrors()
+
+			cy.get('button:contains("Relate Entry")').first().click()
+			cy.get('a.dropdown__link:contains("Band Title")').first().click();
+			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.hasNoErrors()
+
+			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('not.exist')
+			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').should('not.exist')
+			cy.hasNoErrors()
+		})
+
+		// default, defer field initialization On
+		it('defer field initialization on', () => {
+			cy.visit('admin.php?/cp/fields/edit/8');
+			cy.get('[data-toggle-for="relationship_allow_multiple"]').should('have.class', 'on')
+			cy.get('[name="rel_min"]').should('be.visible')
+			cy.get('[name="rel_max"]').should('be.visible')
+			cy.get('[name="rel_max"]').clear().type('2')
+			cy.get('[data-toggle-for="relationship_deferred_loading"]').click()
+			cy.get('[data-toggle-for="relationship_deferred_loading"]').should('have.class', 'on')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.hasNoErrors()
+
+			cy.visit('admin.php?/cp/publish/edit/entry/1')
+			cy.get('button:contains("Edit Relationships")').first().click()
+			cy.get('button:contains("Relate Entry")').should('be.visible')
+			cy.get('button:contains("Relate Entry")').first().click()
+			cy.get('a.dropdown__link:contains("Welcome to the Example Site!")').first().click();
+			cy.get('a.dropdown__link:contains("Band Title")').first().click();
+			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.get('button:contains("Edit Relationships")').should('not.exist')
+			cy.hasNoErrors()
+
+			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('button:contains("Relate Entry")').should('not.be.visible')
+			cy.hasNoErrors()
+
+			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('not.exist')
+			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').should('not.exist')
+			cy.get('button:contains("Edit Relationships")').should('be.visible')
+			cy.hasNoErrors()
+		})
 	})
 
 	context('when using fluid fields', () => {
@@ -426,6 +524,66 @@ context('Relationship field - Edit', () => {
 			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
 			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
 			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('be.visible')
+		})
+
+		// default, defer field initialization On
+		it('check relationship field with defer on in grid', () => {
+			cy.visit('admin.php?/cp/fields/edit/19');
+			cy.get('.fields-grid-item:last-child .fields-grid-tool-expand').first().click()
+			cy.get('[data-toggle-for="relationship_deferred_loading"]').first().click()
+			cy.get('[data-toggle-for="relationship_deferred_loading"]').should('have.class', 'on')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+
+			cy.visit('admin.php?/cp/publish/edit/entry/1')
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('not.exist')
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').should('not.exist')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('[name=title]').invoke('val').should('eq', "Getting to Know ExpressionEngine")
+			cy.get('[name=field_id_1]').invoke('val').should('contain', "Thank you for choosing ExpressionEngine!")
+			cy.get('[name=field_id_3]').invoke('val').should('eq', "{filedir_2}ee_banner_120_240.gif");
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] button:contains("Edit Relationships")').should('be.visible')
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] button:contains("Edit Relationships")').first().click()
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] button:contains("Edit Relationships")').should('not.exist')
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] button:contains("Relate Entry")').should('be.visible')
+
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').first().click()
+
+			cy.get('.grid-field tr:not(.hidden) a.dropdown__link:contains("Welcome to the Example Site!")').first().click({force: true});
+			cy.get('.grid-field tr:not(.hidden) a.dropdown__link:contains("Band Title")').first().click({force: true});
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated')
+			cy.get('[name=title]').invoke('val').should('eq', "Getting to Know ExpressionEngine")
+			cy.get('[name=field_id_1]').invoke('val').should('contain', "Thank you for choosing ExpressionEngine!")
+			cy.get('[name=field_id_3]').invoke('val').should('eq', "{filedir_2}ee_banner_120_240.gif");
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
+		})
+
+		// default, defer field initialization Off
+		it('check relationship field with defer off in grid', () => {
+			cy.visit('admin.php?/cp/fields/edit/19');
+			cy.get('.fields-grid-item:last-child .fields-grid-tool-expand').first().click()
+			cy.get('[data-toggle-for="relationship_deferred_loading"]').first().click()
+			cy.get('[data-toggle-for="relationship_deferred_loading"]').should('have.class', 'off')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+
+			cy.visit('admin.php?/cp/publish/edit/entry/1')
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('not.exist')
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').should('not.exist')
+			cy.get('body').type('{ctrl}', {release: false}).type('s')
+			cy.get('.app-notice---success').contains('Entry Updated');
+			cy.get('[name=title]').invoke('val').should('eq', "Getting to Know ExpressionEngine")
+			cy.get('[name=field_id_1]').invoke('val').should('contain', "Thank you for choosing ExpressionEngine!")
+			cy.get('[name=field_id_3]').invoke('val').should('eq', "{filedir_2}ee_banner_120_240.gif");
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] button:contains("Edit Relationships")').should('not.exist')
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] button:contains("Relate Entry")').should('be.visible')
 		})
 	})
 })

--- a/tests/cypress/cypress/integration/publish/relationship.ee6.js
+++ b/tests/cypress/cypress/integration/publish/relationship.ee6.js
@@ -309,15 +309,13 @@ context('Relationship field - Edit', () => {
 			cy.get('button:contains("Relate Entry")').should('not.be.visible')
 			cy.get('body').type('{ctrl}', {release: false}).type('s')
 			cy.get('.app-notice---success').contains('Entry Updated');
-			cy.get('button:contains("Relate Entry")').should('not.be.visible')
-			cy.get('button:contains("Edit Relationships")').should('not.exist')
+			cy.get('button:contains("Relate Entry")').should('not.exist')
+			cy.get('button:contains("Edit Relationships")').should('be.visible')
 			cy.hasNoErrors()
 
+			cy.get('button:contains("Edit Relationships")').first().click()
+			cy.get('button:contains("Edit Relationships")').should('not.exist')
 			cy.get('button:contains("Relate Entry")').should('not.be.visible')
-			cy.get('body').type('{ctrl}', {release: false}).type('s')
-			cy.get('.app-notice---success').contains('Entry Updated');
-			cy.get('button:contains("Relate Entry")').should('not.be.visible')
-			cy.hasNoErrors()
 
 			cy.get('[data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').closest('.list-item').find('[title="Remove"]').click()
 			cy.get('[data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
@@ -536,6 +534,10 @@ context('Relationship field - Edit', () => {
 
 			cy.visit('admin.php?/cp/publish/edit/entry/1')
 			cy.wait(5000)
+			cy.get('.grid-field tr:not(.hidden) button:contains("Relate Entry")').should('not.exist')
+			cy.get('.grid-field tr:not(.hidden) button:contains("Edit Relationships")').should('be.visible')
+			cy.get('.grid-field tr:not(.hidden) button:contains("Edit Relationships")').first().click()
+			cy.get('.grid-field tr:not(.hidden) button:contains("Edit Relationships")').should('not.exist')
 			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').closest('.list-item').find('[title="Remove"]').click()
 			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('not.exist')
 			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()

--- a/tests/cypress/cypress/integration/publish/relationship.ee6.js
+++ b/tests/cypress/cypress/integration/publish/relationship.ee6.js
@@ -535,10 +535,11 @@ context('Relationship field - Edit', () => {
 			cy.get('body').type('{ctrl}', {release: false}).type('s')
 
 			cy.visit('admin.php?/cp/publish/edit/entry/1')
-			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').closest('.list-item').find('[title="Remove"]').click()
-			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('not.exist')
-			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
-			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').should('not.exist')
+			cy.wait(5000)
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('not.exist')
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Band Title")').closest('.list-item').find('[title="Remove"]').click()
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Band Title")').should('not.exist')
 			cy.get('body').type('{ctrl}', {release: false}).type('s')
 			cy.get('.app-notice---success').contains('Entry Updated');
 			cy.get('[name=title]').invoke('val').should('eq', "Getting to Know ExpressionEngine")
@@ -553,15 +554,15 @@ context('Relationship field - Edit', () => {
 
 			cy.get('.grid-field tr:not(.hidden) a.dropdown__link:contains("Welcome to the Example Site!")').first().click({force: true});
 			cy.get('.grid-field tr:not(.hidden) a.dropdown__link:contains("Band Title")').first().click({force: true});
-			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
-			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
 			cy.get('body').type('{ctrl}', {release: false}).type('s')
 			cy.get('.app-notice---success').contains('Entry Updated')
 			cy.get('[name=title]').invoke('val').should('eq', "Getting to Know ExpressionEngine")
 			cy.get('[name=field_id_1]').invoke('val').should('contain', "Thank you for choosing ExpressionEngine!")
 			cy.get('[name=field_id_3]').invoke('val').should('eq', "{filedir_2}ee_banner_120_240.gif");
-			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
-			cy.get('.grid-field [data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Welcome to the Example Site!")').should('exist')
+			cy.get('.grid-field tr:not(.hidden) [data-relationship-react] .list-item__title:contains("Band Title")').should('exist')
 		})
 
 		// default, defer field initialization Off

--- a/themes/ee/cp/js/build/components/relationship.js
+++ b/themes/ee/cp/js/build/components/relationship.js
@@ -473,10 +473,22 @@ function (_React$Component) {
   }], [{
     key: "renderFields",
     value: function renderFields(context) {
-      $('div[data-relationship-react]', context).each(function () {
+      $('div[data-relationship-react]:not(.react-deferred-loading)', context).each(function () {
         var props = JSON.parse(window.atob($(this).data('relationshipReact')));
         props.name = $(this).data('inputValue');
         ReactDOM.render(React.createElement(Relationship, props, null), this);
+      });
+      $('.react-deferred-loading--relationship', context).each(function () {
+        var $wrapper = $(this);
+        var $button = $wrapper.find('.js-dropdown-toggle');
+
+        $button.on('click', function () {
+          $('div[data-relationship-react]', $wrapper).each(function () {
+            var props = JSON.parse(window.atob($(this).data('relationshipReact')));
+            props.name = $(this).data('inputValue');
+            ReactDOM.render(React.createElement(Relationship, props, null), this);
+          });
+        });
       });
     }
   }]);

--- a/themes/ee/cp/js/build/components/relationship.js
+++ b/themes/ee/cp/js/build/components/relationship.js
@@ -481,7 +481,6 @@ function (_React$Component) {
       $('.react-deferred-loading--relationship', context).each(function () {
         var $wrapper = $(this);
         var $button = $wrapper.find('.js-dropdown-toggle');
-
         $button.on('click', function () {
           $('div[data-relationship-react]', $wrapper).each(function () {
             var props = JSON.parse(window.atob($(this).data('relationshipReact')));
@@ -490,6 +489,15 @@ function (_React$Component) {
           });
         });
       });
+
+      if ($('.react-deferred-loading--relationship ul.list-group').length) {
+        var $wrapper = $('.react-deferred-loading--relationship ul.list-group').parents('.react-deferred-loading');
+        $($wrapper, context).each(function () {
+          var props = JSON.parse(window.atob($(this).data('relationshipReact')));
+          props.name = $(this).data('inputValue');
+          ReactDOM.render(React.createElement(Relationship, props, null), this);
+        });
+      }
     }
   }]);
 

--- a/themes/ee/cp/js/build/components/relationship.js
+++ b/themes/ee/cp/js/build/components/relationship.js
@@ -489,15 +489,6 @@ function (_React$Component) {
           });
         });
       });
-
-      if ($('.react-deferred-loading--relationship ul.list-group').length) {
-        var $wrapper = $('.react-deferred-loading--relationship ul.list-group').parents('.react-deferred-loading');
-        $($wrapper, context).each(function () {
-          var props = JSON.parse(window.atob($(this).data('relationshipReact')));
-          props.name = $(this).data('inputValue');
-          ReactDOM.render(React.createElement(Relationship, props, null), this);
-        });
-      }
     }
   }]);
 

--- a/themes/ee/cp/js/src/components/relationship.jsx
+++ b/themes/ee/cp/js/src/components/relationship.jsx
@@ -45,6 +45,16 @@ class Relationship extends React.Component {
                 });
             });
         });
+
+        if ( $('.react-deferred-loading--relationship ul.list-group').length ) {
+             var $wrapper = $('.react-deferred-loading--relationship ul.list-group').parents('.react-deferred-loading');
+             
+            $($wrapper, context).each(function () {
+                var props = JSON.parse(window.atob($(this).data('relationshipReact')));
+                props.name = $(this).data('inputValue');
+                ReactDOM.render(React.createElement(Relationship, props, null), this);
+            });
+        }
     }
 
     componentDidMount() {

--- a/themes/ee/cp/js/src/components/relationship.jsx
+++ b/themes/ee/cp/js/src/components/relationship.jsx
@@ -26,18 +26,31 @@ class Relationship extends React.Component {
     }
 
     static renderFields(context) {
-        $('div[data-relationship-react]', context).each(function () {
+        $('div[data-relationship-react]:not(.react-deferred-loading)', context).each(function () {
             let props = JSON.parse(window.atob($(this).data('relationshipReact')))
             props.name = $(this).data('inputValue')
 
             ReactDOM.render(React.createElement(Relationship, props, null), this)
-        })
-	}
+        });
 
-	componentDidMount() {
+        $('.react-deferred-loading--relationship', context).each(function () {
+            var $wrapper = $(this);
+            var $button = $wrapper.find('.js-dropdown-toggle');
+
+            $button.on('click', function () {
+                $('div[data-relationship-react]', $wrapper).each(function () {
+                    var props = JSON.parse(window.atob($(this).data('relationshipReact')));
+                    props.name = $(this).data('inputValue');
+                    ReactDOM.render(React.createElement(Relationship, props, null), this);
+                });
+            });
+        });
+    }
+
+    componentDidMount() {
         this.bindSortable()
         EE.cp.formValidation.bindInputs(ReactDOM.findDOMNode(this).parentNode);
-	}
+    }
 
     componentDidUpdate(prevProps, prevState) {
         if (this.state.selected !== prevState.selected) {
@@ -328,7 +341,7 @@ class Relationship extends React.Component {
                                         <input type="text" class="search-input__input input--small" onChange={(handleSearchItem) => this.filterChange('search', handleSearchItem.target.value)} placeholder={EE.relationship.lang.search} />
                                     </div>
                                 </div>
-                                {props.channels.length > 1 && 
+                                {props.channels.length > 1 &&
                                 <div className="filter-bar__item">
                                     <DropDownButton
                                         keepSelectedState={true}

--- a/themes/ee/cp/js/src/components/relationship.jsx
+++ b/themes/ee/cp/js/src/components/relationship.jsx
@@ -45,16 +45,6 @@ class Relationship extends React.Component {
                 });
             });
         });
-
-        if ( $('.react-deferred-loading--relationship ul.list-group').length ) {
-             var $wrapper = $('.react-deferred-loading--relationship ul.list-group').parents('.react-deferred-loading');
-             
-            $($wrapper, context).each(function () {
-                var props = JSON.parse(window.atob($(this).data('relationshipReact')));
-                props.name = $(this).data('inputValue');
-                ReactDOM.render(React.createElement(Relationship, props, null), this);
-            });
-        }
     }
 
     componentDidMount() {


### PR DESCRIPTION
## Overview

Creates new “Edit Relationships” button, which when clicked, will instantiate the React component on the field, thus deferring the initial React bootup on page load. When many Relationship fields are in an entry, it can cause the page to “hang” and create a delayed time to interaction for the user. This greatly decreases the time to interaction because it removes nearly all the JS events and interactions for every Relationship field until the user chooses to interact with it.

See screenshots and video in #1882 for the result of this PR.

Resolves [#1882](https://github.com/ExpressionEngine/ExpressionEngine/issues/1882).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security

## Is this backwards compatible?

- [x] Yes
- [ ] No

