### PR TITLE
Replace instances of the noun "backup" with the verb "back up" in the default language files

### DIFF
--- a/system/ee/language/english/admin_lang.php
+++ b/system/ee/language/english/admin_lang.php
@@ -170,7 +170,7 @@ $lang = array(
 
     'avatar_url' => 'URL to Avatar Folder',
 
-    'backup_info' => 'Use this form to backup your database.',
+    'backup_info' => 'Use this form to back up your database.',
 
     'banish_masked_ips' => 'Deny Access if No IP Address is Present',
 
@@ -766,7 +766,7 @@ $lang = array(
 
     'search_and_replace' => 'Find and Replace',
 
-    'search_replace_disclaimer' => 'Depending on the syntax used, this function can produce undesired results. Consult the manual and backup your database.',
+    'search_replace_disclaimer' => 'Depending on the syntax used, this function can produce undesired results. Consult the manual and back up your database.',
 
     'search_term' => 'Search for this text',
 

--- a/system/ee/language/english/tools_lang.php
+++ b/system/ee/language/english/tools_lang.php
@@ -48,7 +48,7 @@ $lang = array(
 
     'search_and_replace' => 'Search and Replace',
 
-    'search_replace_disclaimer' => 'Depending on the syntax used, this function can produce undesired results. Consult the manual and backup your database.',
+    'search_replace_disclaimer' => 'Depending on the syntax used, this function can produce undesired results. Consult the manual and back up your database.',
 
     'search_results' => 'Search Results',
 

--- a/system/ee/language/english/utilities_lang.php
+++ b/system/ee/language/english/utilities_lang.php
@@ -6,7 +6,7 @@ $lang = array(
 
     /* Menu */
 
-    'backup_database' => 'Backup Database',
+    'backup_database' => 'Back Up Database',
 
     'cache_manager' => 'Cache Manager',
 
@@ -191,7 +191,7 @@ $lang = array(
 
     'sandr_search_text' => 'Search for this text',
 
-    'sandr_warning' => '<p><b>Warning</b>: <b class="no">Advanced users only.</b> Please be very careful with using this feature.</p><p>Depending on the syntax used, this function can produce undesired results. Consult the user guide and backup your database.</p>',
+    'sandr_warning' => '<p><b>Warning</b>: <b class="no">Advanced users only.</b> Please be very careful with using this feature.</p><p>Depending on the syntax used, this function can produce undesired results. Consult the user guide and back up your database.</p>',
 
     'site_preferences' => 'Site Preferences',
 
@@ -354,17 +354,17 @@ $lang = array(
     /* Database Backup Utility */
     'backing_up' => 'Backing up...',
 
-    'backup_database' => 'Backup Database',
+    'backup_database' => 'Back Up Database',
 
     'backup_error' => 'Cannot Make Backup',
 
     'backup_out_of_memory' => 'Your server ran out of memory while trying to export your database. Try setting the <a href="%s" rel="external noreferrer"><code>db_backup_row_limit</code></a> config to a lower number.',
 
-    'backup_success' => 'Backup Succeeded',
+    'backup_success' => 'Back Up Succeeded',
 
     'backup_success_desc' => 'Your backup has been stored in your system folder at: <b>%s</b>',
 
-    'backup_tables' => 'Backup tables',
+    'backup_tables' => 'Back up tables',
 
     'cache_path_not_writable' => 'Your cache path is not writable. This folder must be writable to write your backup.',
 
@@ -407,7 +407,7 @@ $lang = array(
 
     'sql_query_to_run' => 'Query to run',
 
-    'sql_warning' => '<p><b>Warning</b>: <b class="no">Advanced users only.</b> Please be very careful with using this feature.</p><p>Depending on the syntax used, this function can produce undesired results. Consult the user guide and backup your database.</p>',
+    'sql_warning' => '<p><b>Warning</b>: <b class="no">Advanced users only.</b> Please be very careful with using this feature.</p><p>Depending on the syntax used, this function can produce undesired results. Consult the user guide and back up your database.</p>',
 
     'total_results' => 'Total Results',
 

--- a/tests/cypress/cypress/integration/member_roles/member_roles_utilities.ee6.js
+++ b/tests/cypress/cypress/integration/member_roles/member_roles_utilities.ee6.js
@@ -56,7 +56,7 @@ context('Test Member roles Utilities ', () => {
 	   cy.get('.box').contains('File Converter')
 	   cy.get('.box').contains('Member Import')
 
-	   cy.get('.box').contains('Backup Database')
+	   cy.get('.box').contains('Back Up Database')
 	   cy.get('.box').contains('SQL Manager')
 	   cy.get('.box').contains('Query Form')
 
@@ -100,7 +100,7 @@ context('Test Member roles Utilities ', () => {
 	   cy.get('.box').contains('File Converter')
 	   cy.get('.box').contains('Member Import')
 
-	   cy.get('.box').contains('Backup Database')
+	   cy.get('.box').contains('Back Up Database')
 	   cy.get('.box').contains('SQL Manager')
 	   cy.get('.box').contains('Query Form')
 
@@ -147,7 +147,7 @@ context('Test Member roles Utilities ', () => {
 	   cy.get('.box').contains('File Converter')
 	   cy.get('.box').contains('Member Import')
 
-	   cy.get('.box').contains('Backup Database')
+	   cy.get('.box').contains('Back Up Database')
 	   cy.get('.box').contains('SQL Manager')
 	   cy.get('.box').contains('Query Form')
 
@@ -195,7 +195,7 @@ context('Test Member roles Utilities ', () => {
 
 
 
-	   cy.get('.box').contains('Backup Database')
+	   cy.get('.box').contains('Back Up Database')
 	   cy.get('.box').contains('SQL Manager')
 	   cy.get('.box').contains('Query Form')
 
@@ -259,7 +259,7 @@ context('Test Member roles Utilities ', () => {
 	   cy.get('.box').should('not.contain','CP Translations')
 	   cy.get('.box').should('not.contain','File Converter')
 	   cy.get('.box').should('not.contain','Member Import')
-	   cy.get('.box').should('not.contain','Backup Database')
+	   cy.get('.box').should('not.contain','Back Up Database')
 	   cy.get('.box').should('not.contain','SQL Manager')
 	   cy.get('.box').should('not.contain','Query Form')
 


### PR DESCRIPTION
## Overview

Simple language changes to fix a minor grammatical issue. The word "backup" is a noun and not a verb.

- [x] 🐛 Fixes a bug


## Is this backwards compatible?

- [x] Yes
- [ ] No

