### PR TITLE
Allow loading application core outside of request run

### DIFF
--- a/system/ee/ExpressionEngine/Core/Core.php
+++ b/system/ee/ExpressionEngine/Core/Core.php
@@ -26,7 +26,7 @@ abstract class Core
     protected $booted = false;
 
     /**
-     * @var bool Application instance
+     * @var \ExpressionEngine\Core\Application Application instance
      */
     protected $application = null;
 
@@ -313,7 +313,7 @@ abstract class Core
      */
     public function loadApplicationCore()
     {
-        if ($this->application) {
+        if (!is_null($this->application)) {
             return $this->application;
         }
 

--- a/system/ee/ExpressionEngine/Core/Core.php
+++ b/system/ee/ExpressionEngine/Core/Core.php
@@ -26,6 +26,11 @@ abstract class Core
     protected $booted = false;
 
     /**
+     * @var bool Application instance
+     */
+    protected $application = null;
+
+    /**
      * @var bool Application started?
      */
     protected $running = false;
@@ -306,8 +311,12 @@ abstract class Core
     /**
      * Setup the application with the default provider
      */
-    protected function loadApplicationCore()
+    public function loadApplicationCore()
     {
+        if ($this->application) {
+            return $this->application;
+        }
+
         $autoloader = Autoloader::getInstance();
         $dependencies = new InjectionContainer();
         $providers = new ProviderRegistry($dependencies);
@@ -330,6 +339,7 @@ abstract class Core
         });
 
         $this->legacy->getFacade()->set('di', $dependencies);
+        $this->application = $application;
 
         return $application;
     }


### PR DESCRIPTION
This change allows calling `loadApplicationCore()` outside of the `run()` method.  It also caches the loaded `$application` so that it does not break any future calls to `run()`.