### PR TITLE
Resolved issue where modal pop-ups were not visible in Live Preview mode

### DIFF
--- a/cp-styles/app/styles/components/_live-preview.scss
+++ b/cp-styles/app/styles/components/_live-preview.scss
@@ -11,6 +11,10 @@ $ease: cubic-bezier(0.165, 0.84, 0.44, 1);
 	z-index: 250;
 	max-width: 100vw;
 	display: none;
+
+    ~ .modal-wrap {
+        z-index: 251;
+    }
 }
 
 .live-preview {

--- a/themes/ee/cp/css/common.min.css
+++ b/themes/ee/cp/css/common.min.css
@@ -20308,6 +20308,9 @@ table .field-no-results {
   max-width: 100vw;
   display: none;
 }
+.live-preview-container ~ .modal-wrap {
+  z-index: 251;
+}
 
 .live-preview {
   display: flex;


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Update styles to prevent any modals from being hidden during live preview

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

