### PR TITLE
Feature/regex fixes

### DIFF
--- a/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
@@ -264,7 +264,7 @@ class LegacyParser
             // date variables
             elseif (strpos($val, 'format') !== false && preg_match("/.+?\s+?format/", $val)) {
                 $var_single[$val] = $this->extractDateFormat($val);
-            } else {  // single variables
+            } elseif (!is_numeric($val)) {  // single variables
                 $var_single[$val] = $val;
             }
         }

--- a/system/ee/ExpressionEngine/Service/Validation/Validator.php
+++ b/system/ee/ExpressionEngine/Service/Validation/Validator.php
@@ -295,7 +295,7 @@ class Validator
      */
     protected function parseRuleString($string)
     {
-        if (preg_match("/(.*?)\[(.*?)\]/", $string, $match)) {
+        if (preg_match("/(.*?)\[(.*?)\]$/", $string, $match)) {
             $rule_name = $match[1];
             $parameters = $match[2];
 


### PR DESCRIPTION
fix the error when `[]` could not be used in `regex` validation rule
fixes #1522
EECORE-1790

 
fix the issue when HTML form validation could cause PHP notices from channel entries parser
fixes #1852
fixes #1083
EECORE-1791