### PR TITLE
Sync conditions after removing a condition

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Fields/Fields.php
+++ b/system/ee/ExpressionEngine/Controller/Fields/Fields.php
@@ -386,21 +386,31 @@ class Fields extends AbstractFieldsController
                 // Build an array representing our conditions that we can compare
                 $conditionalsBefore = $this->getConditionArray($field->FieldConditionSets);
 
+                // If request is conditional we need to save those conditionals and sets
                 if (ee('Request')->post('field_is_conditional') == 'y') {
                     $assignedConditionalSetIds = [];
+                    // Loop through all conditional sets, created from POST data
                     foreach ($conditionSets as $i => $conditionSet) {
+                        // Associate the condition set with the field
                         $assignedConditionIds = [];
                         $conditionSet->ChannelFields->getAssociation()->set($field);
                         $conditionSet->save();
+
+                        // Loop through conditions and attach them to the condition sets
                         foreach ($conditions[$i] as $condition) {
                             $condition->condition_set_id = $conditionSet->getId();
                             $condition->save();
                             $assignedConditionIds[] = $condition->getId();
                         }
+
+                        // If a condition was removed lets delete it in the DB
                         $conditionSet->FieldConditions->filter('condition_id', 'NOT IN', $assignedConditionIds)->delete();
                         $assignedConditionalSetIds[$i] = $conditionSet->getId();
                     }
+                    // If a condition set was removed, lets delete it
                     $field->FieldConditionSets->filter('condition_set_id', 'NOT IN', $assignedConditionalSetIds)->delete();
+
+                    // Remove condition sets that were removed
                     foreach (array_keys($conditionSets) as $i) {
                         if (!isset($assignedConditionalSetIds[$i])) {
                             unset($conditionSets[$i]);
@@ -410,8 +420,11 @@ class Fields extends AbstractFieldsController
                     $field->FieldConditionSets->delete();
                 }
 
+                // After saving all that, lets get the field again
+                $fieldAfterSave = ee('Model')->get('ChannelField', $id)->first();
+
                 // Build an array representing our conditions that we can compare
-                $conditionalsAfter = $this->getConditionArray($conditionSets);
+                $conditionalsAfter = $this->getConditionArray($fieldAfterSave->FieldConditionSets);
 
                 $conditionalEntriesRequireSync = ! $this->conditionsAreSame($conditionalsBefore, $conditionalsAfter);
 


### PR DESCRIPTION
EECORE-1794

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Sync conditional entries after removing a condition from a field.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
