### PR TITLE
Skip validation for custom fields hidden by conditional logic

### DIFF
--- a/system/ee/ExpressionEngine/Model/Content/ContentModel.php
+++ b/system/ee/ExpressionEngine/Model/Content/ContentModel.php
@@ -258,7 +258,9 @@ abstract class ContentModel extends VariableColumnModel
         $facades = $this->getCustomFields();
 
         foreach ($facades as $name => $facade) {
-            if (! $this->isNew() && ! $this->isDirty($name)) {
+            // If this field is hidden by conditional logic or it is being 
+            // edited but has not changed then we are not concerned with validation
+            if (get_bool_from_string($facade->getHidden()) || (!$this->isNew() && !$this->isDirty($name))) {
                 continue;
             }
 
@@ -268,7 +270,7 @@ abstract class ContentModel extends VariableColumnModel
                 $rules[$name] .= '|';
             }
 
-            if ($facade->isRequired() && get_bool_from_string($facade->getHidden()) === false) {
+            if ($facade->isRequired()) {
                 $rules[$name] .= 'required|';
             }
 


### PR DESCRIPTION
## Overview

Before this fix it was possible to get validation errors due to validation rules on a custom field that was not visible due to conditional logic.  This fix just moves the check for whether or not the field is hidden by conditional logic to before any validation rules are added for the field.

The example where this bug was found involves setting up a Grid field with conditional logic and `Minimum Rows: 1` and at least one column that is **Required**.  Even if the Grid field is not visible due to the conditional logic it will throw a validation error because the required column fails validation.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

