### PR TITLE
templates for matrix getting warnings from here

### DIFF
--- a/system/ee/legacy/libraries/channel_entries_parser/components/Custom_field.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Custom_field.php
@@ -158,7 +158,7 @@ class EE_Channel_custom_field_parser implements EE_Channel_parser_component
                 }
 
                 // prevent accidental parsing of other channel variables in custom field data
-                if (strpos($entry, '{') !== false) {
+                if ($entry !== null && strpos($entry, '{') !== false) {
                     $entry = str_replace(
                         array('{', '}'),
                         array(unique_marker('channel_bracket_open'), unique_marker('channel_bracket_close')),
@@ -180,8 +180,9 @@ class EE_Channel_custom_field_parser implements EE_Channel_parser_component
                                 echo '<hr>';
                   }
                         }*/
-
-                $tagdata = str_replace(LD . $tag . RD, $entry, $tagdata);
+                if ($entry !== null){
+                    $tagdata = str_replace(LD . $tag . RD, $entry, $tagdata);
+                }
             }
 
             $tagdata = str_replace(LD . $tag . RD, '', $tagdata);


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Matrix templates in php 8.1 complain about these if there is not information in them such as just a hanging empty matrix opener. Not big deal but others may run into same type of issue from not checking nulls first here.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
