### PR TITLE
Fixed php 8.1 error in custom HTML buttons

### DIFF
--- a/system/ee/ExpressionEngine/Model/Member/HTMLButton.php
+++ b/system/ee/ExpressionEngine/Model/Member/HTMLButton.php
@@ -59,7 +59,7 @@ class HTMLButton extends Model
 
     public function prepForJSON()
     {
-        if (strpos($this->classname, 'markItUpSeparator') !== false) {
+        if (! empty($this->classname) && strpos($this->classname, 'markItUpSeparator') !== false) {
             // separators are purely presentational
             $button_js = array('separator' => '---');
         } else {


### PR DESCRIPTION
Deprecated STRPOS(): PASSING NULL TO PARAMETER #1 ($HAYSTACK) OF TYPE STRING IS DEPRECATED ee/ExpressionEngine/Model/Member/HTMLButton.php, line 62

