### PR TITLE
PHP 8.1 error with custom buttons

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Settings/Buttons.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Buttons.php
@@ -55,7 +55,7 @@ class Buttons extends Settings
             ->all();
 
         foreach ($buttons as $button) {
-            $name = (strpos($button->classname, 'html-') !== 0) ? htmlentities($button->tag_name) : '';
+            $name = (empty($button->classname) || strpos($button->classname, 'html-') !== 0) ? htmlentities($button->tag_name) : '';
 
             $preview = array('toolbar_items' => array(
                 $button->classname => array(


### PR DESCRIPTION
strpos(): Passing null to parameter #1 Buttons.php 61

@intoeetive can you double check this one.  I don't know why the conditional for applying htmlentities even exists at all.

But with the custom buttons, $button->classname is always empty, so it was throwing a deprecation warning in 8.1 trying to search it.  

This definitely fixes it, but like I say- what would you NOT want to stick in htmlentities?  IDK and I dislike not knowing.  Figure it's worth an extra set of eyeballs looking at it when you pull it in.