### PR TITLE
Enable including database views into backups

### DIFF
--- a/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
+++ b/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
@@ -10,6 +10,7 @@
 
 namespace ExpressionEngine\Service\Database\Backup;
 
+use Exception;
 use ExpressionEngine\Library\Filesystem\Filesystem;
 
 /**
@@ -222,8 +223,18 @@ class Backup
 
         $this->writeSeparator('Create tables and their structure');
 
-        foreach ($tables as $table) {
-            $create = $this->query->getCreateForTable($table);
+        foreach ($tables as $structure) {
+            switch ($structure['type']) {
+                case Query::TABLE_STRUCTURE:
+                    $create = $this->query->getCreateForTable($structure);
+                    break;
+                case Query::VIEW_STRUCTURE:
+                    $create = $this->query->getCreateForView($structure);
+                    break;
+                default:
+                    throw new Exception("There is no implementation of 'get create' for type {$structure['type']}.");
+                /** @see Query::getTables() */
+            }
 
             // Add an extra linebreak if not a compact file
             if (! $this->compact_file) {

--- a/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
+++ b/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
@@ -213,26 +213,26 @@ class Backup
      */
     public function writeDropAndCreateStatements()
     {
-        $tables = $this->getTables();
+        $tables = $this->query->getTables();
 
         $this->writeSeparator('Drop old tables if exists');
 
-        foreach ($tables as $table) {
-            $this->writeChunk($this->query->getDropStatement($table));
+        foreach ($tables as $tableName => $table) {
+            $this->writeChunk($this->query->getDropStatement($tableName));
         }
 
         $this->writeSeparator('Create tables and their structure');
 
-        foreach ($tables as $structure) {
+        foreach ($tables as $name => $structure) {
             switch ($structure['type']) {
                 case Query::TABLE_STRUCTURE:
-                    $create = $this->query->getCreateForTable($structure);
+                    $create = $this->query->getCreateForTable($name);
                     break;
                 case Query::VIEW_STRUCTURE:
-                    $create = $this->query->getCreateForView($structure);
+                    $create = $this->query->getCreateForView($name);
                     break;
                 default:
-                    throw new Exception("There is no implementation of 'get create' for type {$structure['type']}.");
+                    throw new Exception("There is no implementation of 'get create' for type {$structure['type']}. Name: $name");
                 /** @see Query::getTables() */
             }
 

--- a/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
+++ b/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
@@ -120,6 +120,27 @@ class Backup
     }
 
     /**
+     * Gets an array of tables to backup (with some information data)
+     *
+     * @see Backup::getTables()
+     * @return array Array of tables data
+     */
+    protected function getTablesInformation()
+    {
+        $tablesInformation = $this->query->getTables();
+        if (empty($this->tables_to_backup)) {
+            return $tablesInformation;
+        }
+        $tablesNames = array_keys($tablesInformation);
+
+        //make sure we only try to backup existing tables
+        $this->tables_to_backup = array_intersect($this->tables_to_backup, $tablesNames);
+        $tablesInformation = array_intersect_key($tablesInformation, array_flip($this->tables_to_backup));
+
+        return $tablesInformation;
+    }
+
+    /**
      * Class will write a file with comments and helpful whitespace formatting
      */
     public function makePrettyFile()
@@ -213,7 +234,7 @@ class Backup
      */
     public function writeDropAndCreateStatements()
     {
-        $tables = $this->query->getTables();
+        $tables = $this->getTablesInformation();
 
         $this->writeSeparator('Drop old tables if exists');
 

--- a/system/ee/ExpressionEngine/Service/Database/Backup/Query.php
+++ b/system/ee/ExpressionEngine/Service/Database/Backup/Query.php
@@ -96,7 +96,7 @@ class Query
      *		'table' => [
      *			'rows' => 123,
      *			'size' => 123456,
-     *          'type' => self::TABLE_STRUCTURE
+     *          'type' => self::TABLE_STRUCTURE,
      *		],
      *		...
      *	]


### PR DESCRIPTION
EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/2448

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fix backup for database views - previously it throws exception, because "CREATE TABLE" for "view" structure is incorrect.
https://dev.mysql.com/doc/refman/8.0/en/show-table-status.html

> For views, most columns displayed by [SHOW TABLE STATUS](https://dev.mysql.com/doc/refman/8.0/en/show-table-status.html) are 0 or NULL except that Name indicates the view name, Create_time indicates the creation time, and **Comment says VIEW**

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
