### PR TITLE
Refactor role statistic update on member create

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Members.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Members.php
@@ -1456,6 +1456,9 @@ class Members extends CP_Controller
 
                 $member->save();
 
+                // Get a fresh copy of this member model and update statistics for its roles
+                ee('Model')->get('Member')->filter('member_id', $member->getId())->first()->updateRoleTotalMembers();
+
                 // -------------------------------------------
                 // 'cp_members_member_create' hook.
                 //  - Additional processing when a member is created through the CP

--- a/system/ee/ExpressionEngine/Controller/Members/Members.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Members.php
@@ -1457,7 +1457,9 @@ class Members extends CP_Controller
                 $member->save();
 
                 // Get a fresh copy of this member model and update statistics for its roles
-                ee('Model')->get('Member')->filter('member_id', $member->getId())->first()->updateRoleTotalMembers();
+                if (!bool_config_item('ignore_member_stats')) { 
+                    ee('Model')->get('Member')->filter('member_id', $member->getId())->first()->updateRoleTotalMembers();
+                }
 
                 // -------------------------------------------
                 // 'cp_members_member_create' hook.

--- a/system/ee/ExpressionEngine/Model/Member/Member.php
+++ b/system/ee/ExpressionEngine/Model/Member/Member.php
@@ -427,20 +427,14 @@ class Member extends ContentModel
         ee()->cache->file->delete('jumpmenu/' . md5($this->member_id));
     }
 
-    public function onAfterInsert()
-    {
-        parent::onAfterInsert();
-        if (! bool_config_item('ignore_member_stats')) {
-            foreach ($this->getAllRoles() as $role) {
-                $role->total_members = null;
-                $role->save();
-            }
-        }
-    }
-
     public function onAfterDelete()
     {
-        if (! bool_config_item('ignore_member_stats')) {
+        $this->updateRoleTotalMembers();
+    }
+
+    public function updateRoleTotalMembers()
+    {
+        if (!bool_config_item('ignore_member_stats')) {
             foreach ($this->getAllRoles() as $role) {
                 $role->total_members = null;
                 $role->save();


### PR DESCRIPTION
## Overview

These statistics must be recalculated on the role model after the associations have been saved.

EECORE-1516

fixes #1467

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->
