### PR TITLE
Resolved #2063, where outdated resources could be served

### DIFF
--- a/system/ee/ExpressionEngine/Library/Resource/Request.php
+++ b/system/ee/ExpressionEngine/Library/Resource/Request.php
@@ -39,7 +39,7 @@ class Request
         $resource = ''; // with group, like `group/styles`
         $group = '';
         $name = '';
-        $site = '';
+        $site_name = '';
         $template_version = 0;
 
         if (in_array(ee()->uri->segment(1), ee()->uri->reserved) && false !== ee()->uri->segment(2)) {
@@ -83,7 +83,7 @@ class Request
 
         if (false !== strpos($group, ':')) {
             // if there's a site, let's get it and redefine $group
-            list($site, $group) = array_map('trim', explode(':', $group, 2));
+            list($site_name, $group) = array_map('trim', explode(':', $group, 2));
         }
 
         $cache_path = $this->_cache_path($resource);
@@ -96,8 +96,8 @@ class Request
                 ->filter('template_type', $this->type)
                 ->with('TemplateGroup')->filter('TemplateGroup.group_name', $group);
 
-            $template = !empty($site)
-                ? $template->with('Site')->filter('Site.site_name', $site)
+            $template = !empty($site_name)
+                ? $template->with('Site')->filter('Site.site_name', $site_name)
                 : $template->filter('site_id', ee()->config->item('site_id'));
 
             $template = $template
@@ -121,7 +121,7 @@ class Request
         /** -----------------------------------------*/
         if (bool_config_item('save_tmpl_files')) {
             ee()->load->helper('file');
-            $filepath = PATH_TMPL . (isset($site) ? $site : ee()->config->item('site_short_name')) . '/';
+            $filepath = PATH_TMPL . (isset($site_name) ? $site_name : ee()->config->item('site_short_name')) . '/';
             $filepath .= $group . '.group/' . $name . '.' . $this->type;
             $file_edit_date = filemtime($filepath);
 

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3125,7 +3125,7 @@ class EE_Template
                             $asset_versions[$row['site_name'] . ':' . $version_key] = $row['edit_date'];
 
                         if (ee()->config->item('save_tmpl_files') == 'y') {
-                            $basepath = PATH_TMPL . ee()->config->item('site_short_name') . '/';
+                            $basepath = PATH_TMPL . $row['site_name'] . '/';
                             $basepath .= $row['group_name'] . '.group/' . $row['template_name'] . '.' . $row['template_type'];
 
                             if (is_file($basepath)) {

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3117,12 +3117,16 @@ class EE_Template
                 if ($asset_query->num_rows() > 0) {
                     foreach ($asset_query->result_array() as $row) {
                         $version_key = $row['group_name'] . '/' . $row['template_name'];
+
                         // there's no way to know if the result follows the order on template.
                         // So, let's create TWO keys and keep the compatibility with old links,
-                        // the ones without the site short name: `/?css=default_site:site/styles`
+                        // the ones without the site short name: `/?css=group/styles`
+                        if (ee()->config->item('site_short_name') === $row['site_name']) {
+                            $asset_versions[$version_key] = $row['edit_date'];
+                        }
 
-                        $asset_versions[$version_key] =
-                            $asset_versions[$row['site_name'] . ':' . $version_key] = $row['edit_date'];
+                        // and the ones with the site short name: `/?css=default_site:group/styles`
+                        $asset_versions[$row['site_name'] . ':' . $version_key] = $row['edit_date'];
 
                         if (ee()->config->item('save_tmpl_files') == 'y') {
                             $basepath = PATH_TMPL . $row['site_name'] . '/';
@@ -3130,8 +3134,11 @@ class EE_Template
 
                             if (is_file($basepath)) {
                                 if (filemtime($basepath) > $row['edit_date']) {
-                                    $asset_versions[$version_key] =
-                                        $asset_versions[$row['site_name'] . ':' . $version_key] = filemtime($basepath);
+                                    $asset_versions[$row['site_name'] . ':' . $version_key] = filemtime($basepath);
+
+                                    if (ee()->config->item('site_short_name') === $row['site_name']) {
+                                        $asset_versions[$version_key] = filemtime($basepath);
+                                    }
                                 }
                             }
                         }

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3129,8 +3129,10 @@ class EE_Template
                             $basepath .= $row['group_name'] . '.group/' . $row['template_name'] . '.' . $row['template_type'];
 
                             if (is_file($basepath)) {
-                                $asset_versions[$version_key] =
-                                    $asset_versions[$row['site_name'] . ':' . $version_key] = filemtime($basepath);
+                                if (filemtime($basepath) > $row['edit_date']) {
+                                    $asset_versions[$version_key] =
+                                        $asset_versions[$row['site_name'] . ':' . $version_key] = filemtime($basepath);
+                                }
                             }
                         }
                     }

--- a/tests/cypress/cypress/integration/design/template_of_resources.ee6.js
+++ b/tests/cypress/cypress/integration/design/template_of_resources.ee6.js
@@ -71,7 +71,7 @@ context('Design', () => {
 		})
 	})
 
-  describe.only('loading of resources from updated templates', function () {
+  describe('loading of resources from updated templates', function () {
     before(function () {
       const files = [
         '../../system/user/templates/default_site/resources.group/style.css',

--- a/tests/cypress/cypress/integration/design/template_of_resources.ee6.js
+++ b/tests/cypress/cypress/integration/design/template_of_resources.ee6.js
@@ -36,6 +36,8 @@ context('Design', () => {
 	})
 
 	after(function () {
+		cy.task('filesystem:delete', '../../system/user/templates/default_site/resources.group')
+		cy.task('filesystem:delete', '../../system/user/templates/second_site/resources.group')
 	})
 
 	beforeEach(function () {
@@ -68,4 +70,45 @@ context('Design', () => {
 			cy.get("#fourth").should('have.css', 'color', 'rgb(255, 255, 255)')
 		})
 	})
+
+  describe.only('loading of resources from updated templates', function () {
+    before(function () {
+      const files = [
+        '../../system/user/templates/default_site/resources.group/style.css',
+        '../../system/user/templates/default_site/resources.group/script.js',
+        '../../system/user/templates/second_site/resources.group/style.css',
+      ]
+      const replaceColors = {
+        'cyan': 'red',
+        'magenta': 'lime',
+        'yellow': 'blue',
+      }
+
+      files.forEach((file) => {
+        cy.readFile(file, (err, data) => {
+          if (err) {
+            return console.error(err);
+          };
+        }).then((data) => {
+          Object.keys(replaceColors).forEach((x)=> {
+            data = data.replace(x, replaceColors[x]);
+          })
+          cy.writeFile(file, data);
+        })
+      })
+    })
+
+    it('loads stylesheet resource template from the current site', function () {
+      cy.logFrontendPerformance()
+      cy.get("#first").should('have.css', 'background-color', 'rgb(255, 0, 0)')
+    })
+
+    it('loads script resource template from the current site', function () {
+      cy.get("#second").should('have.css', 'background-color', 'rgb(0, 255, 0)')
+    })
+
+    it('loads stylesheet resource template from a different MSM site', function () {
+      cy.get("#third").should('have.css', 'background-color', 'rgb(0, 0, 255)')
+    })
+  })
 })

--- a/tests/cypress/cypress/integration/design/template_of_resources.ee6.js
+++ b/tests/cypress/cypress/integration/design/template_of_resources.ee6.js
@@ -3,6 +3,17 @@
 import SiteForm from '../../elements/pages/site/SiteForm';
 import SiteManager from '../../elements/pages/site/SiteManager';
 
+const files = [
+	'../../system/user/templates/default_site/resources.group/style.css',
+	'../../system/user/templates/default_site/resources.group/script.js',
+	'../../system/user/templates/second_site/resources.group/style.css',
+]
+const replaceColors = {
+	'cyan': 'red',
+	'magenta': 'lime',
+	'yellow': 'blue',
+}
+
 context('Design', () => {
 	before(function () {
 		cy.task('db:seed')
@@ -71,44 +82,79 @@ context('Design', () => {
 		})
 	})
 
-  describe('loading of resources from updated templates', function () {
-    before(function () {
-      const files = [
-        '../../system/user/templates/default_site/resources.group/style.css',
-        '../../system/user/templates/default_site/resources.group/script.js',
-        '../../system/user/templates/second_site/resources.group/style.css',
-      ]
-      const replaceColors = {
-        'cyan': 'red',
-        'magenta': 'lime',
-        'yellow': 'blue',
-      }
+	describe('loading of resources from updated templates', function () {
+		before(function () {
+			files.forEach((file) => {
+				cy.readFile(file, (err, data) => {
+					if (err) {
+					return console.error(err);
+					};
+				}).then((data) => {
+					Object.keys(replaceColors).forEach((x)=> {
+					data = data.replace(x, replaceColors[x]);
+					})
+					cy.writeFile(file, data);
+				})
+			})
+		})
 
-      files.forEach((file) => {
-        cy.readFile(file, (err, data) => {
-          if (err) {
-            return console.error(err);
-          };
-        }).then((data) => {
-          Object.keys(replaceColors).forEach((x)=> {
-            data = data.replace(x, replaceColors[x]);
-          })
-          cy.writeFile(file, data);
-        })
-      })
-    })
+		it('loads stylesheet resource template from the current site', function () {
+			cy.logFrontendPerformance()
+			cy.get("#first").should('have.css', 'background-color', 'rgb(255, 0, 0)')
+		})
 
-    it('loads stylesheet resource template from the current site', function () {
-      cy.logFrontendPerformance()
-      cy.get("#first").should('have.css', 'background-color', 'rgb(255, 0, 0)')
-    })
+		it('loads script resource template from the current site', function () {
+			cy.get("#second").should('have.css', 'background-color', 'rgb(0, 255, 0)')
+		})
 
-    it('loads script resource template from the current site', function () {
-      cy.get("#second").should('have.css', 'background-color', 'rgb(0, 255, 0)')
-    })
+		it('loads stylesheet resource template from a different MSM site', function () {
+			cy.get("#third").should('have.css', 'background-color', 'rgb(0, 0, 255)')
+		})
+	})
 
-    it('loads stylesheet resource template from a different MSM site', function () {
-      cy.get("#third").should('have.css', 'background-color', 'rgb(0, 0, 255)')
-    })
-  })
+	describe('loading of resources on a cached HTML template', function () {
+		before(function () {
+			cy.authVisit('admin.php?/cp/design/manager/resources')
+
+			cy.get('.app-listing__row a').contains('index').click()
+
+			cy.get('.js-tab-button.tab-bar__tab').contains('Settings').click()
+			cy.get('[data-toggle-for="cache"][data-state="off"]').click()
+			cy.get('button').contains('Save').click()
+
+			// visit the page to save a cached version
+			cy.visit('index.php/resources/index')
+		})
+
+		beforeEach(function () {
+			cy.visit('index.php/resources/index')
+		})
+
+		it('respects the saved styles', function () {
+			cy.get("#first").should('have.css', 'background-color', 'rgb(255, 0, 0)')
+			cy.get("#second").should('have.css', 'background-color', 'rgb(0, 255, 0)')
+			cy.get("#third").should('have.css', 'background-color', 'rgb(0, 0, 255)')
+		})
+
+		it('serves new styles', function () {
+			files.forEach((file) => {
+				cy.readFile(file, (err, data) => {
+					if (err) {
+						return console.error(err);
+					};
+				}).then((data) => {
+					Object.keys(replaceColors).forEach((x) => {
+						data = data.replace(replaceColors[x], x);
+					})
+					cy.writeFile(file, data);
+				})
+			})
+
+			cy.get("#first").should('have.css', 'background-color', 'rgb(0, 255, 255)')
+
+			cy.get("#second").should('have.css', 'background-color', 'rgb(255, 0, 255)')
+
+			cy.get("#third").should('have.css', 'background-color', 'rgb(255, 255, 0)')
+		})
+	})
 })

--- a/tests/cypress/support/templates/default_site/resources.group/index.html
+++ b/tests/cypress/support/templates/default_site/resources.group/index.html
@@ -29,19 +29,46 @@ body > div {
 
 <link rel="stylesheet" href="/index.php/css/resources/trigger/" />
 
+<link rel="stylesheet" href="{stylesheet='style'}" />
+
 {/layout:set}
 
 <div id="first">
-	<p>Set by <var>default_site/resources/style.css</var></p>
+	<p>Set by <var>default_site/resources.group/style.css</var>:</p>
+	<pre>
+	<code>
+		{stylesheet='resources/style'}
+	</code>
+	</pre>
 </div>
 <div id="second">
-	<p>Set by <var>default_site/resources/script.js</var></p>
+	<p>Set by <var>default_site/resources.group/script.js</var>:</p>
+	<pre>
+	<code>
+		{script='resources/script'}
+	</code>
+	</pre>
 </div>
 <div id="third">
-	<p>Set by <var>second_site/resources/style.css</var></p>
+	<p>Set by <var>second_site/resources.group/style.css</var>:</p>
+	<pre>
+	<code>
+		{stylesheet='second_site:resources/style'}
+	</code>
+	</pre>
 </div>
 <div id="fourth">
-	<p>Set by <var>second_site/resources/script.js</var></p>
+	<p>Set by:</p>
+	<ul>
+		<li><var>second_site/resources.group/script.js</var></li>
+		<li><var>/index.php/css/resources/trigger/</var></li>
+	</ul>
+	<pre>
+	<code>
+		{script='second_site:resources/script'}
+	</code>
+	</pre>
+</div>
 </div>
 
 <script src="{script='resources/script'}"></script>


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

- requests of resources with version suffixes, like `/index.php?css=resources/style.v.1652145060`, wasn't clearing the cache;
- resources on MSM sites where messing the checking of each other's modification / edition times;
- serve of fresh resources on cached pages wasn't being tested.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#2063](https://github.com/ExpressionEngine/ExpressionEngine/issues/2063).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [x] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

