### PR TITLE
Resolved issue where MetaWeblog could not post if `channel_id` is not available

### DIFF
--- a/system/ee/ExpressionEngine/Addons/metaweblog_api/mod.metaweblog_api.php
+++ b/system/ee/ExpressionEngine/Addons/metaweblog_api/mod.metaweblog_api.php
@@ -556,7 +556,11 @@ class Metaweblog_api
         /** ---------------------------------------
         /**  Perform Query
         /** ---------------------------------------*/
-        $query = ee('Model')->get('ChannelEntry')->filter('channel_id', $this->channel_id);
+        $query = ee('Model')->get('ChannelEntry');
+
+        if ($entry_id == '') {
+            $query->filter('channel_id', $this->channel_id);
+        }
 
         if (! ee('Permission')->can('edit_other_entries') && ! ee('Permission')->isSuperAdmin()) {
             //$sql .= "AND wt.author_id = '".$this->userdata['member_id']."' ";


### PR DESCRIPTION
## Overview

I'm the developer of MarsEdit (https://redsweater.com/marsedit/), a Mac blogging app that supports the MovableType API. One of our mutual customers discovered that MarsEdit fails to publish new posts to an ExpressionEngine blog after they updated from an older version.

It appears a bug was introduced years ago in the MetaWeblog addon, when migrating to modules. The change at that time caused the query in getRecentPosts to always filter based on the current `channel_id`, but the channel ID is not available or pertinent when the getRecentPosts method is being used to fulfill the functionality of the getPost method, in which case a specific entry ID is supplied and so the channel ID can be, and must be, ignored.

This patch simply pulls apart the creation of the query from the filtering by channel_id, such that the filtering only occurs when no specific `entry_id` has been provided.
 
## Nature of This Change

- [√ ] 🐛 Fixes a bug

## Is this backwards compatible?

- [√ ] Yes
- [ ] No
