### PR TITLE
Resolved issue where notices could be shown by Template library when called by add-on in PHP 8.1

### DIFF
--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -1846,7 +1846,7 @@ class EE_Template
      */
     public function swap_var_single($search, $replace, $source)
     {
-        return str_replace(LD . $search . RD, $replace, $source);
+        return str_replace(LD . $search . RD, (string) $replace, $source);
     }
 
     /**


### PR DESCRIPTION
The change already exists in EE7

fix the issue where warning could be generating when trying to use `swap_var_single` with PHP 8.1