### PR TITLE
Added support for table alias in SQL joins when using Active Record, #2096

### DIFF
--- a/system/ee/legacy/database/DB_active_rec.php
+++ b/system/ee/legacy/database/DB_active_rec.php
@@ -303,7 +303,7 @@ class CI_DB_active_record extends CI_DB_driver
         $this->_track_aliases($table);
 
         // Strip apart the condition and protect the identifiers
-        if (preg_match('/([\w\.]+)([\W\s]+)(.+)/', $cond, $match) && !$alias) {
+        if (is_empty($alias) && preg_match('/([\w\.]+)([\W\s]+)(.+)/', $cond, $match)) {
             $match[1] = $this->_protect_identifiers($match[1]);
             $match[3] = $this->_protect_identifiers($match[3]);
 
@@ -312,8 +312,8 @@ class CI_DB_active_record extends CI_DB_driver
 
         // If a join alias specified, extract it now
         $join_alias = '';
-        if ($alias) {
-            $join_alias = ' '.$alias.' ';
+        if (! is_empty($alias)) {
+            $join_alias = ' ' . $alias . ' ';
         }
 
         // Assemble the JOIN statement

--- a/system/ee/legacy/database/DB_active_rec.php
+++ b/system/ee/legacy/database/DB_active_rec.php
@@ -283,9 +283,10 @@ class CI_DB_active_record extends CI_DB_driver
      * @param	string $table The table to join
      * @param	string $cond The condition to join on
      * @param	string $type the type of join (left, right, outer, inner, left outer, right outer)
+     * @param	string $alias give the join an alias
      * @return	CI_DB_active_record The active record object
      */
-    public function join($table, $cond, $type = '')
+    public function join($table, $cond, $type = '', $alias = '')
     {
         if ($type != '') {
             $type = strtoupper(trim($type));
@@ -302,15 +303,21 @@ class CI_DB_active_record extends CI_DB_driver
         $this->_track_aliases($table);
 
         // Strip apart the condition and protect the identifiers
-        if (preg_match('/([\w\.]+)([\W\s]+)(.+)/', $cond, $match)) {
+        if (preg_match('/([\w\.]+)([\W\s]+)(.+)/', $cond, $match) && !$alias) {
             $match[1] = $this->_protect_identifiers($match[1]);
             $match[3] = $this->_protect_identifiers($match[3]);
 
             $cond = $match[1] . $match[2] . $match[3];
         }
 
+        // If a join alias specified, extract it now
+        $join_alias = '';
+        if ($alias) {
+            $join_alias = ' '.$alias.' ';
+        }
+
         // Assemble the JOIN statement
-        $join = $type . 'JOIN ' . $this->_protect_identifiers($table, true, null, false) . ' ON ' . $cond;
+        $join = $type . 'JOIN ' . $this->_protect_identifiers($table, true, null, false) . $join_alias . ' ON ' . $cond;
 
         $this->ar_join[] = $join;
         if ($this->ar_caching === true) {

--- a/system/ee/legacy/database/DB_active_rec.php
+++ b/system/ee/legacy/database/DB_active_rec.php
@@ -303,7 +303,7 @@ class CI_DB_active_record extends CI_DB_driver
         $this->_track_aliases($table);
 
         // Strip apart the condition and protect the identifiers
-        if (is_empty($alias) && preg_match('/([\w\.]+)([\W\s]+)(.+)/', $cond, $match)) {
+        if (empty($alias) && preg_match('/([\w\.]+)([\W\s]+)(.+)/', $cond, $match)) {
             $match[1] = $this->_protect_identifiers($match[1]);
             $match[3] = $this->_protect_identifiers($match[3]);
 
@@ -312,7 +312,7 @@ class CI_DB_active_record extends CI_DB_driver
 
         // If a join alias specified, extract it now
         $join_alias = '';
-        if (! is_empty($alias)) {
+        if (! empty($alias)) {
             $join_alias = ' ' . $alias . ' ';
         }
 


### PR DESCRIPTION
## Small modification to AR join() method to support use of join aliases

Adds optional fourth parameter to specify an alias for a join (no previous fourth parameter so backward compatible etc).
If an alias is specified it disables `_protect_identifiers` processing on condition in case alias is referenced in condition (identifier protection applied in that case would break the JOIN statement by prefixing the alias with the EE table prefix).

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#2096](https://github.com/ExpressionEngine/ExpressionEngine/issues/2096).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [X] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [X] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/458

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
