### PR TITLE
Emit more events on model association manipulations

### DIFF
--- a/system/ee/ExpressionEngine/Service/Model/Model.php
+++ b/system/ee/ExpressionEngine/Service/Model/Model.php
@@ -380,6 +380,8 @@ class Model extends SerializableEntity implements Subscriber, ValidationAware
             }
         }
 
+        $this->emit('afterAssociationsSave');
+
         return $this;
     }
 

--- a/system/ee/ExpressionEngine/Service/Model/Query/Delete.php
+++ b/system/ee/ExpressionEngine/Service/Model/Query/Delete.php
@@ -31,6 +31,9 @@ class Delete extends Query
             return;
         }
 
+        $mainClass = $this->store->getMetaDataReader($from)->getClass();
+        $mainClass::emitStatic('beforeAssociationsBulkDelete', $parent_ids);
+
         $from_alias = 'CurrentlyDeleting';
 
         $delete_list = $this->getDeleteList($from, $from_alias);
@@ -90,6 +93,7 @@ class Delete extends Query
                 $delete_ids = $this->deleteCollection($delete_models, $to_meta);
             } while (count($delete_ids) == $batch_size);
         }
+        $mainClass::emitStatic('afterAssociationsBulkDelete', $parent_ids);
     }
 
     /**


### PR DESCRIPTION
This code already exists in EE7

 'afterAssociationsSave',
 'beforeAssociationsBulkDelete',
 'afterAssociationsBulkDelete'

EECORE-1894
