### PR TITLE
Resolved issue when PHP error was shown for non-existing addons

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/ExpressionEngine/Controller/Addons/Addons.php
@@ -729,6 +729,11 @@ class Addons extends CP_Controller
     public function settings($addon, $method = null)
     {
         $this->assertUserHasAccess($addon);
+		$info = ee('Addon')->get($addon);
+		
+		if (empty($info)) {
+            show_404();			
+		}	
 
         ee()->view->cp_page_title = lang('addon_manager');
 
@@ -741,7 +746,6 @@ class Addons extends CP_Controller
             $method = (ee()->input->get_post('method') !== false) ? ee()->input->get_post('method') : 'index';
         }
 
-        $info = ee('Addon')->get($addon);
         $licenseResponse = $info->checkCachedLicenseResponse();
         $licenseStatusBadge = '';
         switch ($licenseResponse) {
@@ -1016,6 +1020,10 @@ class Addons extends CP_Controller
             show_404();
         }
 
+		if (empty($info)) {
+            show_404();			
+		}		
+
         if (! $info->hasModule()) {
             return array();
         }
@@ -1085,6 +1093,10 @@ class Addons extends CP_Controller
         } catch (\Exception $e) {
             show_404();
         }
+		
+		if (empty($info)) {
+            show_404();			
+		}			
 
         if (! $info->hasPlugin()) {
             return array();
@@ -1136,6 +1148,10 @@ class Addons extends CP_Controller
         } catch (\Exception $e) {
             show_404();
         }
+		
+		if (empty($info)) {
+            show_404();			
+		}		
 
         if (! $info->hasFieldtype()) {
             return array();
@@ -1193,6 +1209,10 @@ class Addons extends CP_Controller
         } catch (\Exception $e) {
             show_404();
         }
+		
+		if (empty($info)) {
+            show_404();			
+		}
 
         if (! $info->hasJumpMenu()) {
             return array();
@@ -1229,6 +1249,10 @@ class Addons extends CP_Controller
         } catch (\Exception $e) {
             show_404();
         }
+		
+		if (empty($info)) {
+            show_404();			
+		}
 
         if (! $info->hasExtension()) {
             return array();


### PR DESCRIPTION
Better to throw a 404 than show an error (which was confusing).

We were getting a 'Call to a member function checkCachedLicenseResponse() on null' in Controller/Addons/Addons.php line 745 when we had a malformed add-on url.  Tossed the other 404s in as well since they just made sense to me, but probably not needed.
