### PR TITLE
Resolved issue when sometimes avatar could not be uploaded on frontend

### DIFF
--- a/system/ee/legacy/libraries/Filemanager.php
+++ b/system/ee/legacy/libraries/Filemanager.php
@@ -479,7 +479,7 @@ class Filemanager
 
             // We need to reset some prefs
             if ($new_image) {
-                ee()->load->helper('number');
+                ee()->load->helper('file');
                 $f_size = get_file_info($file_path);
                 $prefs['file_height'] = $new_image['height'];
                 $prefs['file_width'] = $new_image['width'];
@@ -574,7 +574,7 @@ class Filemanager
 
         // We need to reset some prefs
         if ($new_image) {
-            ee()->load->helper('number');
+            ee()->load->helper('file');
             $f_size = get_file_info($file_path);
 
             $prefs['file_size'] = ($f_size) ? $f_size['size'] : 0;


### PR DESCRIPTION
Call to undefined function get_file_info()
ee/legacy/libraries/Filemanager.php:578

Didn't spot where we were using the number helper in those spots, so replaced rather than added.  Tested out for user running into the problem- was uploading avatars on the frontend.

