### PR TITLE
usage detecting single files in addon fields now

### DIFF
--- a/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
+++ b/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
@@ -730,7 +730,7 @@ class ChannelEntry extends ContentModel
                 }
             }
             if (! empty($dirUrlsMatches)) {
-                $item = str_replace(array_keys($dirUrlsMatches), $dirUrlsMatches, $item);
+                $item = str_replace( $dirUrlsMatches,array_keys($dirUrlsMatches), $item);
             }
             if (strpos($item, '{filedir_') !== false) {
                 if (preg_match_all('/{filedir_(\d+)}(.*)\"/', $item, $matches, PREG_SET_ORDER)) {
@@ -743,6 +743,8 @@ class ChannelEntry extends ContentModel
                         ->fields('file_id', 'upload_location_id', 'file_name');
                     $files->filterGroup();
                     foreach ($dirsAndFiles as $dir_id => $file_names) {
+                        //file_names is an array of the files in this index. Ideally we need to loop here? not sure yet? Is still putting them all on one string though
+                        $file_names = strtok($file_names[0],  '"');
                         $files->orFilterGroup()
                             ->filter('upload_location_id', $dir_id)
                             ->filter('file_name', 'IN', $file_names)


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

swapped paramater one and two here ^^ I think that we are wanting to replace the url with the filedir_ here and then after that we are looking for that swap out is what was intended? but not sure.  Wygwam, RTE both now working where they did not before.  This is the place that is likely needing attention for usage places.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
