### PR TITLE
Resolved #2126 where "add field" button was present for field groups that are not saved yet

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Fields/Groups.php
+++ b/system/ee/ExpressionEngine/Controller/Fields/Groups.php
@@ -356,7 +356,7 @@ class Groups extends AbstractFieldsController
 
         // If it's an AJAX request, we're probably in a modal; we currently
         // can't open a modal from a modal, lest inception
-        $should_allow_field_creation = ! AJAX_REQUEST;
+        $should_allow_field_creation = ! AJAX_REQUEST && ! $field_group->isNew();
 
         $add_fields_button = null;
         if ($should_allow_field_creation) {


### PR DESCRIPTION
…that are not saved yet

(cherry picked from commit 3c3f3c4a09f952b005dac4094c81d1a2f2d0ac8d)

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/2236