### PR TITLE
Resolved #2136 where formatters for duration field set to hours type were not parsed properly

### DIFF
--- a/system/ee/ExpressionEngine/Addons/duration/Traits/DurationTrait.php
+++ b/system/ee/ExpressionEngine/Addons/duration/Traits/DurationTrait.php
@@ -89,7 +89,7 @@ trait DurationTrait
         if (strpos($duration, ':')) {
             $duration = $this->convertFromColonNotation($duration, $units);
         } else {
-            $duration = $this->applyMultiplier($duration);
+            $duration = $this->applyMultiplier($duration, $units);
         }
 
         return $duration;


### PR DESCRIPTION
…were not parsed properly

EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/2238