### PR TITLE
Resolved #2127 where there was a typo in defintion of Extension model

### DIFF
--- a/system/ee/ExpressionEngine/Model/Addon/Extension.php
+++ b/system/ee/ExpressionEngine/Model/Addon/Extension.php
@@ -21,10 +21,6 @@ class Extension extends Model
     protected static $_primary_key = 'extension_id';
     protected static $_table_name = 'extensions';
 
-    protected static $_validation_rules = array(
-        'csrf_exempt' => 'enum[y,n]'
-    );
-
     protected static $_typed_columns = array(
         'enabled' => 'boolString'
     );


### PR DESCRIPTION
(cherry picked from commit cb0f5ec50640187875bcbeb1c8d1a43b1c8fcfd3)

EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/2249