### PR TITLE
Resolved issue where MetaWeblog could not post if channel_id is not available

### DIFF
--- a/system/ee/ExpressionEngine/Addons/metaweblog_api/mod.metaweblog_api.php
+++ b/system/ee/ExpressionEngine/Addons/metaweblog_api/mod.metaweblog_api.php
@@ -556,7 +556,11 @@ class Metaweblog_api
         /** ---------------------------------------
         /**  Perform Query
         /** ---------------------------------------*/
-        $query = ee('Model')->get('ChannelEntry')->filter('channel_id', $this->channel_id);
+        $query = ee('Model')->get('ChannelEntry');
+
+        if ($entry_id == '') {
+            $query->filter('channel_id', $this->channel_id);
+        }
 
         if (! ee('Permission')->can('edit_other_entries') && ! ee('Permission')->isSuperAdmin()) {
             //$sql .= "AND wt.author_id = '".$this->userdata['member_id']."' ";


### PR DESCRIPTION
EE6 version approved: https://github.com/ExpressionEngine/ExpressionEngine/pull/2083

Don't filter the getRecentPosts query on channel when we've been prov…ided a specific post ID to fetch. This fixes a problem that prevented getPost from working as expected. Without this fix the getPost call would always return an empty string unless the default channel ID happened to be the same as the channel for the post ID being requested.

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Replace this paragraph with a description of your changes and reasoning. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [ ] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
