### PR TITLE
Resolved issue where PHP notices were shown on Entry Manager page with saved views when migrating from EE6 to EE7

### DIFF
--- a/system/ee/ExpressionEngine/Model/EntryManager/View.php
+++ b/system/ee/ExpressionEngine/Model/EntryManager/View.php
@@ -25,7 +25,7 @@ class View extends Model
         'member_id' => 'int',
         'channel_id' => 'int',
         'name' => 'string',
-        'columns' => 'serialized'
+        'columns' => 'json'
     ];
 
     protected static $_relationships = [

--- a/system/ee/installer/updates/ud_7_01_00.php
+++ b/system/ee/installer/updates/ud_7_01_00.php
@@ -28,6 +28,7 @@ class Updater
         $steps = new \ProgressIterator(
             [
                 'modifyCpHomepageChannelColumnOnMembers',
+                'jsonifyEntryManagerViews',
             ]
         );
 
@@ -50,6 +51,18 @@ class Updater
                 ]
             ]
         );
+    }
+
+    private function jsonifyEntryManagerViews()
+    {
+        $viewsQuery = ee('db')->select('view_id, columns')->from('entry_manager_views')->get();
+        if (!empty($viewsQuery)) {
+            foreach ($viewsQuery->result_array() as $row) {
+                if (strpos($row['columns'], 's:') === 0) {
+                    ee('db')->where('view_id', $row['view_id'])->update('entry_manager_views', ['columns' => json_encode(unserialize($row['columns']))]);
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #2292
EECORE-2095
