### PR TITLE
Update default filesystem to use root of system path

### DIFF
--- a/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
@@ -983,6 +983,10 @@ class Filesystem
     public function createTempFile()
     {
         $file = tmpfile();
+        if($file === false) {
+            throw new \Exception('Cannot create temp file at "'.sys_get_temp_dir().'"');
+        }
+        
         $path = stream_get_meta_data($file)['uri'];
 
         return compact('file', 'path');

--- a/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
@@ -23,8 +23,11 @@ class Filesystem
     public function __construct(?Flysystem\AdapterInterface $adapter = null, $config = [])
     {
         if (is_null($adapter)) {
+            // Normalize the System Path and then find the root 
+            $syspath = str_replace('\\', '/', SYSPATH);
+            $syspathRoot = realpath($syspath . str_repeat('../', substr_count($syspath, '/') - 1));
             $adapter = new Adapter\Local([
-                'path' => $this->normalizeAbsolutePath(realpath(SYSPATH . '../'))
+                'path' => $this->normalizeAbsolutePath($syspathRoot)
             ]);
         }else{
             // Fix prefixes
@@ -1063,7 +1066,7 @@ class Filesystem
     protected function removePathPrefix($path)
     {
         $prefix = $this->getPathPrefix();
-        return (!empty($prefix) && strpos($path, $prefix) === 0) ? str_replace($prefix, '', $path) : $path;
+        return (!empty($prefix) && strpos($path, $prefix) === 0) ? substr_replace($path, '', 0, strlen($prefix)) : $path;
     }
 
     /**

--- a/system/ee/legacy/libraries/Upload.php
+++ b/system/ee/legacy/libraries/Upload.php
@@ -927,7 +927,9 @@ class EE_Upload
                 return false;
             }
 
-            if (function_exists('realpath') && @realpath($this->upload_path) !== false) {
+            // If realpath() is available and expands the upload_path into a
+            // path that exists within the filesystem we'll use that instead
+            if (function_exists('realpath') && @realpath($this->upload_path) !== false && $fs->exists(realpath($this->upload_path))) {
                 $this->upload_path = str_replace("\\", "/", realpath($this->upload_path));
             }
         }

--- a/system/ee/legacy/libraries/Upload.php
+++ b/system/ee/legacy/libraries/Upload.php
@@ -938,7 +938,7 @@ class EE_Upload
         //     return false;
         // }
 
-        if (! $fs->isWritable()) {
+        if (! $fs->isWritable($this->upload_path)) {
             $this->set_error('upload_not_writable');
 
             return false;


### PR DESCRIPTION
## Overview

Update the path used by default filesystem instance to be the root of SYSPATH.  This is more in line with what previous versions of ExpressionEngine allowed and should resolve issues where an installation is spread out across a volume.

Resolves EECORE-2093

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

