### PR TITLE
Properly encode urls created by the filesystem

### DIFF
--- a/system/ee/ExpressionEngine/Service/File/Directory.php
+++ b/system/ee/ExpressionEngine/Service/File/Directory.php
@@ -70,7 +70,7 @@ class Directory extends Filesystem
         // }
 
         // URL Encode everything except the forward slashes
-        return $url . implode('/', array_map('rawurlencode', explode('/', ltrim($filename, '/'))));
+        return $url . str_replace("%2F", "/", rawurlencode(ltrim($filename, '/')));
     }
 
     public function getPath($path)

--- a/system/ee/ExpressionEngine/Service/File/Directory.php
+++ b/system/ee/ExpressionEngine/Service/File/Directory.php
@@ -70,7 +70,7 @@ class Directory extends Filesystem
         // }
 
         // URL Encode everything except the forward slashes
-        return implode('/', array_map('rawurlencode', explode('/', $url . ltrim($filename, '/'))));
+        return $url . implode('/', array_map('rawurlencode', explode('/', ltrim($filename, '/'))));
     }
 
     public function getPath($path)

--- a/system/ee/ExpressionEngine/Service/File/Directory.php
+++ b/system/ee/ExpressionEngine/Service/File/Directory.php
@@ -69,7 +69,8 @@ class Directory extends Filesystem
         //     throw new \Exception('File does not exist.');
         // }
 
-        return  $url . ltrim($filename, '/');
+        // URL Encode everything except the forward slashes
+        return implode('/', array_map('rawurlencode', explode('/', $url . ltrim($filename, '/'))));
     }
 
     public function getPath($path)


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Add url encoding for urls created by the filesystem/directory object

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No