### PR TITLE
Adds Ajax Login Validation

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/addon.setup.php
+++ b/system/ee/ExpressionEngine/Addons/member/addon.setup.php
@@ -5,7 +5,7 @@ return array(
     'author_url' => 'https://expressionengine.com/',
     'name' => 'Member',
     'description' => '',
-    'version' => '2.3.0',
+    'version' => '2.3.1',
     'namespace' => 'ExpressionEngine\Addons\Member',
     'settings_exist' => false,
     'built_in' => true

--- a/system/ee/ExpressionEngine/Addons/member/mod.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member.php
@@ -1614,9 +1614,9 @@ class Member
             $reasons = ee()->auth->errors;
         }
 
-        echo json_encode([
-            'result' => ($verify ? 'success' : 'fail'),
-            'reason' => $reasons,
+        ee()->output->send_ajax_response([
+            'messageType' => ($verify ? 'success' : 'error'),
+            'messages' => $reasons,
             'username' => ee()->input->get('username'),
         ]);
     }

--- a/system/ee/ExpressionEngine/Addons/member/mod.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member.php
@@ -1602,6 +1602,26 @@ class Member
     }
 
     /**
+     * Allows for validation of username and password using Ajax
+     * @return void
+     */
+    public function login_validate()
+    {
+        ee()->load->library('Auth');
+        $verify = ee()->auth->verify();
+        $reasons = [];
+        if(!$verify) {
+            $reasons = ee()->auth->errors;
+        }
+
+        echo json_encode([
+            'result' => ($verify ? 'success' : 'fail'),
+            'reason' => $reasons,
+            'username' => ee()->input->get('username'),
+        ]);
+    }
+
+    /**
      * Username/password update
      */
     public function unpw_update()

--- a/system/ee/ExpressionEngine/Addons/member/upd.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/upd.member.php
@@ -83,7 +83,7 @@ class Member_upd extends Installer
             ee()->db->update('actions', ['method' => 'do_member_search']);
         }
 
-        if (version_compare($current, '6.3.4', '<')) {
+        if (version_compare($current, '2.3.0', '<')) {
             $data = ['class' => 'Member', 'method' => 'login_validate', 'csrf_exempt' => 0];
             ee()->db->insert('actions', $data);
         }

--- a/system/ee/ExpressionEngine/Addons/member/upd.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/upd.member.php
@@ -65,6 +65,9 @@ class Member_upd extends Installer
         ],
         [
             'method' => 'validate'
+        ],
+        [
+            'method' => 'login_validate'
         ]
     ];
 
@@ -78,6 +81,11 @@ class Member_upd extends Installer
         if (version_compare($current, '2.2.1', '<')) {
             ee()->db->where('method', 'member_search');
             ee()->db->update('actions', ['method' => 'do_member_search']);
+        }
+
+        if (version_compare($current, '6.3.4', '<')) {
+            $data = ['class' => 'Member', 'method' => 'login_validate', 'csrf_exempt' => 0];
+            ee()->db->insert('actions', $data);
         }
 
         return true;


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Adds an Action to validate a username and password pair, ideally within an Ajax request prior to login form submission. 

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#1993](https://github.com/ExpressionEngine/ExpressionEngine/issues/1993).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
