### PR TITLE
Resolved #1651 where dropdowns in File field were showing the directories that member was not allowed to access

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -142,7 +142,7 @@ class File_ft extends EE_Fieldtype implements ColumnInterface
     {
         $allowed_file_dirs = (isset($this->settings['allowed_directories']) && $this->settings['allowed_directories'] != 'all')
             ? $this->settings['allowed_directories']
-            : '';
+            : 'all';
         $content_type = (isset($this->settings['field_content_type'])) ? $this->settings['field_content_type'] : 'all';
         $existing_limit = (isset($this->settings['num_existing'])) ? $this->settings['num_existing'] : 0;
         $show_existing = (isset($this->settings['show_existing'])) ? $this->settings['show_existing'] : 'n';

--- a/system/ee/ExpressionEngine/Addons/file/views/publish.php
+++ b/system/ee/ExpressionEngine/Addons/file/views/publish.php
@@ -38,6 +38,7 @@
 <?php
 $component = [
     'allowedDirectory' => $allowed_directory,
+	'roleAllowedDirectoryIds' => isset($role_allowed_dirs) ? $role_allowed_dirs : [],
     'contentType' => $content_type,
     'file' => $file,
     'createNewDirectory' => false,

--- a/system/ee/ExpressionEngine/View/_shared/thumb.php
+++ b/system/ee/ExpressionEngine/View/_shared/thumb.php
@@ -58,10 +58,14 @@ if (count($data)) {
 
                 <?php if ($i == 1) : ?>
                     <div class="file-thumbnail__wrapper">
+                        <?php if (isset($row['attrs']['href'])) : ?>
                         <a href="<?=$row['attrs']['href']?>">
+                        <?php endif; ?>
                 <?php endif; ?>
                 <?php if ($i == 2) : ?>
+                        <?php if (isset($row['attrs']['href'])) : ?>
                         </a>
+                        <?php endif; ?>
                     </div>
                     <div class="file-metadata__wrapper">
                 <?php endif; ?>

--- a/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.es6
+++ b/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.es6
@@ -545,6 +545,16 @@ class DragAndDropUpload extends React.Component {
     }
 
     let checkChildren = this.directoryHasChild(this.props.allowedDirectory);
+    let uploadDirectoriesForDropdown = EE.dragAndDrop.uploadDesinations;
+    if (typeof(this.props.roleAllowedDirectoryIds) !== 'undefined' && this.props.roleAllowedDirectoryIds.length > 0) {
+      uploadDirectoriesForDropdown = [];
+      let roleAllowedDirectoryIds = this.props.roleAllowedDirectoryIds;
+      Object.values(EE.dragAndDrop.uploadDesinations).forEach(function (uploadDesination) {
+        if (roleAllowedDirectoryIds.includes(uploadDesination.value)) {
+          uploadDirectoriesForDropdown.push(uploadDesination);
+        }
+      });
+    }
 
     return (
       <React.Fragment>
@@ -582,7 +592,7 @@ class DragAndDropUpload extends React.Component {
                         keepSelectedState={true}
                         title={EE.lang.file_dnd_choose_directory_btn}
                         placeholder={EE.lang.file_dnd_filter_directories}
-                        items={EE.dragAndDrop.uploadDesinations}
+                        items={uploadDirectoriesForDropdown}
                         onSelect={(directory) => this.setDirectory(directory)}
                         buttonClass="button--default button--small"
                         createNewDirectory={this.props.createNewDirectory}
@@ -650,7 +660,7 @@ class DragAndDropUpload extends React.Component {
               keepSelectedState={false}
               title={EE.lang.file_dnd_choose_existing}
               placeholder={EE.lang.file_dnd_filter_directories}
-              items={EE.dragAndDrop.uploadDesinations}
+              items={uploadDirectoriesForDropdown}
               onSelect={(directory) => this.chooseExisting(directory)}
               rel="modal-file"
               itemClass="m-link"
@@ -665,7 +675,7 @@ class DragAndDropUpload extends React.Component {
               keepSelectedState={false}
               title={EE.lang.file_dnd_upload_new}
               placeholder={EE.lang.file_dnd_filter_directories}
-              items={EE.dragAndDrop.uploadDesinations}
+              items={uploadDirectoriesForDropdown}
               onSelect={(directory) => this.uploadNew(directory)}
               buttonClass="button--default button--small"
               createNewDirectory={this.props.createNewDirectory}

--- a/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.es6
+++ b/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.es6
@@ -637,7 +637,41 @@ class DragAndDropUpload extends React.Component {
         </div>
 
         <div className="file-field__buttons">
-        {this.props.showActionButtons && this.props.allowedDirectory != 'all' &&
+        {this.props.showActionButtons && this.props.allowedDirectory != 'all' && 
+          checkChildren && checkChildren.children.length > 0 && (
+            <div className="button-segment">
+            <DropDownButton key={EE.lang.file_dnd_choose_existing}
+              action={true}
+              keepSelectedState={false}
+              title={EE.lang.file_dnd_choose_existing}
+              placeholder={EE.lang.file_dnd_filter_directories}
+              items={[checkChildren]}
+              onSelect={(directory) => this.chooseExisting(directory)}
+              rel="modal-file"
+              itemClass="m-link"
+              buttonClass="button--default button--small"
+              createNewDirectory={false}
+              ignoreChild={true}
+              addInput={false}
+            />
+
+            <DropDownButton key={EE.lang.file_dnd_upload_new}
+              action={true}
+              keepSelectedState={false}
+              title={EE.lang.file_dnd_upload_new}
+              placeholder={EE.lang.file_dnd_filter_directories}
+              items={[checkChildren]}
+              onSelect={(directory) => this.uploadNew(directory)}
+              buttonClass="button--default button--small"
+              createNewDirectory={this.props.createNewDirectory}
+              ignoreChild={false}
+              addInput={true}
+            />
+          </div>
+          )
+        }
+        {this.props.showActionButtons && this.props.allowedDirectory != 'all' && 
+          (!checkChildren || checkChildren.children.length <= 0) && (
           <React.Fragment>
             <div className="button-segment">
             <a href="#" className="button button--default button--small m-link" rel="modal-file" onClick={(e) => {
@@ -652,6 +686,7 @@ class DragAndDropUpload extends React.Component {
             <input type="file" className="f_open-filepicker" style={{display: 'none'}} multiple="multiple"/>
             </div>
           </React.Fragment>
+          )
         }
         {this.props.showActionButtons && this.props.allowedDirectory == 'all' && (
           <div className="button-segment">

--- a/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.js
+++ b/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.js
@@ -27,9 +27,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  * @copyright Copyright (c) 2003-2022, Packet Tide, LLC (https://www.packettide.com)
  * @license   https://expressionengine.com/license
  */
-var DragAndDropUpload =
-/*#__PURE__*/
-function (_React$Component) {
+var DragAndDropUpload = /*#__PURE__*/function (_React$Component) {
   _inherits(DragAndDropUpload, _React$Component);
 
   function DragAndDropUpload(props) {
@@ -490,35 +488,35 @@ function (_React$Component) {
             }
           } // Unexpected error, probably post_max_size is too low
           else if (xhr.readyState == 4 && xhr.status != 200) {
-              file.error = EE.lang.file_dnd_unexpected_error;
+            file.error = EE.lang.file_dnd_unexpected_error;
 
-              try {
-                var response = JSON.parse(xhr.responseText);
+            try {
+              var response = JSON.parse(xhr.responseText);
 
-                if (typeof response.error != 'undefined') {
-                  file.error = response.error;
-                } else if (typeof response.message !== 'undefined') {
-                  file.error = response.message;
-                }
-              } catch (err) {}
-
-              if ($(window.globalDropzone).parents('.field-control').find('.button-segment').length) {
-                $(window.globalDropzone).parents('.field-control').find('.button-segment button.js-dropdown-toggle').each(function () {
-                  $(this).attr('disabled', 'disabled');
-                });
+              if (typeof response.error != 'undefined') {
+                file.error = response.error;
+              } else if (typeof response.message !== 'undefined') {
+                file.error = response.message;
               }
+            } catch (err) {}
 
-              if ($('.title-bar a.upload').length) {
-                $('.title-bar a.upload').addClass('disabled');
-              }
-
-              if ($('.main-nav .main-nav__toolbar .js-dropdown-toggle').length) {
-                $('.main-nav .main-nav__toolbar .js-dropdown-toggle').attr('disabled', 'disabled');
-              }
-
-              console.error(xhr);
-              reject(file);
+            if ($(window.globalDropzone).parents('.field-control').find('.button-segment').length) {
+              $(window.globalDropzone).parents('.field-control').find('.button-segment button.js-dropdown-toggle').each(function () {
+                $(this).attr('disabled', 'disabled');
+              });
             }
+
+            if ($('.title-bar a.upload').length) {
+              $('.title-bar a.upload').addClass('disabled');
+            }
+
+            if ($('.main-nav .main-nav__toolbar .js-dropdown-toggle').length) {
+              $('.main-nav .main-nav__toolbar .js-dropdown-toggle').attr('disabled', 'disabled');
+            }
+
+            console.error(xhr);
+            reject(file);
+          }
 
           _this3.setState({
             files: _this3.state.files
@@ -631,6 +629,18 @@ function (_React$Component) {
       }
 
       var checkChildren = this.directoryHasChild(this.props.allowedDirectory);
+      var uploadDirectoriesForDropdown = EE.dragAndDrop.uploadDesinations;
+
+      if (typeof this.props.roleAllowedDirectoryIds !== 'undefined' && this.props.roleAllowedDirectoryIds.length > 0) {
+        uploadDirectoriesForDropdown = [];
+        var roleAllowedDirectoryIds = this.props.roleAllowedDirectoryIds;
+        Object.values(EE.dragAndDrop.uploadDesinations).forEach(function (uploadDesination) {
+          if (roleAllowedDirectoryIds.includes(uploadDesination.value)) {
+            uploadDirectoriesForDropdown.push(uploadDesination);
+          }
+        });
+      }
+
       return React.createElement(React.Fragment, null, React.createElement("div", {
         className: "file-field" + (this.props.marginTop ? ' mt' : '') + (this.warningsExist() ? ' file-field--warning' : '') + (this.state.error ? ' file-field--invalid' : '')
       }, React.createElement("div", {
@@ -671,7 +681,7 @@ function (_React$Component) {
         keepSelectedState: true,
         title: EE.lang.file_dnd_choose_directory_btn,
         placeholder: EE.lang.file_dnd_filter_directories,
-        items: EE.dragAndDrop.uploadDesinations,
+        items: uploadDirectoriesForDropdown,
         onSelect: function onSelect(directory) {
           return _this5.setDirectory(directory);
         },
@@ -751,7 +761,7 @@ function (_React$Component) {
         keepSelectedState: false,
         title: EE.lang.file_dnd_choose_existing,
         placeholder: EE.lang.file_dnd_filter_directories,
-        items: EE.dragAndDrop.uploadDesinations,
+        items: uploadDirectoriesForDropdown,
         onSelect: function onSelect(directory) {
           return _this5.chooseExisting(directory);
         },
@@ -767,7 +777,7 @@ function (_React$Component) {
         keepSelectedState: false,
         title: EE.lang.file_dnd_upload_new,
         placeholder: EE.lang.file_dnd_filter_directories,
-        items: EE.dragAndDrop.uploadDesinations,
+        items: uploadDirectoriesForDropdown,
         onSelect: function onSelect(directory) {
           return _this5.uploadNew(directory);
         },

--- a/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.js
+++ b/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.js
@@ -727,7 +727,39 @@ var DragAndDropUpload = /*#__PURE__*/function (_React$Component) {
         }
       })), React.createElement("div", {
         className: "file-field__buttons"
-      }, this.props.showActionButtons && this.props.allowedDirectory != 'all' && React.createElement(React.Fragment, null, React.createElement("div", {
+      }, this.props.showActionButtons && this.props.allowedDirectory != 'all' && checkChildren && checkChildren.children.length > 0 && React.createElement("div", {
+        className: "button-segment"
+      }, React.createElement(DropDownButton, {
+        key: EE.lang.file_dnd_choose_existing,
+        action: true,
+        keepSelectedState: false,
+        title: EE.lang.file_dnd_choose_existing,
+        placeholder: EE.lang.file_dnd_filter_directories,
+        items: [checkChildren],
+        onSelect: function onSelect(directory) {
+          return _this5.chooseExisting(directory);
+        },
+        rel: "modal-file",
+        itemClass: "m-link",
+        buttonClass: "button--default button--small",
+        createNewDirectory: false,
+        ignoreChild: true,
+        addInput: false
+      }), React.createElement(DropDownButton, {
+        key: EE.lang.file_dnd_upload_new,
+        action: true,
+        keepSelectedState: false,
+        title: EE.lang.file_dnd_upload_new,
+        placeholder: EE.lang.file_dnd_filter_directories,
+        items: [checkChildren],
+        onSelect: function onSelect(directory) {
+          return _this5.uploadNew(directory);
+        },
+        buttonClass: "button--default button--small",
+        createNewDirectory: this.props.createNewDirectory,
+        ignoreChild: false,
+        addInput: true
+      })), this.props.showActionButtons && this.props.allowedDirectory != 'all' && (!checkChildren || checkChildren.children.length <= 0) && React.createElement(React.Fragment, null, React.createElement("div", {
         className: "button-segment"
       }, React.createElement("a", {
         href: "#",


### PR DESCRIPTION
Resolved #1651 where dropdowns in File field were showing the directories that member was not allowed to access

Testing instructions:
1.
- have a non-superadmin role ("editors") that can access entries and files
- have a file fields that can use all upload directories
- create several upload destinations, allow your role to access few of those, but not all
- login as editor
- the dropdowns in file field should only show the directories editor has access to
- uploading and browsing works

2.
- edit the role so thy can access only one directory
- login as editor
- the file field should not have dropdowns; the only allowed directory is preselected
- uploading and browsing works

3. Test # 2 with the subfolder - there should be dropdown with the only allowed directory and it's subfolderd