### PR TITLE
Added visual indication when viewing entry version; #1897

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/Edit.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Edit.php
@@ -444,9 +444,20 @@ class Edit extends AbstractPublishController
 
         if ($version_id) {
             $version = $entry->Versions->filter('version_id', $version_id)->first();
-            $version_data = $version->version_data;
-            $vars['version'] = $version->toArray();
-            $entry->set($version_data);
+            if (!is_null($version)) {
+                $version_data = $version->version_data;
+                $vars['version'] = $version->toArray();
+                $i = $entry->Versions->count();
+                $vars['version']['number'] = $i + 1;
+                foreach ($entry->Versions->sortBy('version_date')->reverse() as $listedVersion) {
+                    if ($listedVersion->version_id == $version_id) {
+                        $vars['version']['number'] = $i;
+                        break;
+                    }
+                    $i--;
+                }
+                $entry->set($version_data);
+            }
         }
 
         if (ee('Request')->get('load_autosave') == 'y') {

--- a/system/ee/ExpressionEngine/Controller/Publish/Edit.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Edit.php
@@ -447,15 +447,7 @@ class Edit extends AbstractPublishController
             if (!is_null($version)) {
                 $version_data = $version->version_data;
                 $vars['version'] = $version->toArray();
-                $i = $entry->Versions->count();
-                $vars['version']['number'] = $i + 1;
-                foreach ($entry->Versions->sortBy('version_date')->reverse() as $listedVersion) {
-                    if ($listedVersion->version_id == $version_id) {
-                        $vars['version']['number'] = $i;
-                        break;
-                    }
-                    $i--;
-                }
+                $vars['version']['number'] = $entry->Versions->filter('version_date', '<=', $version->version_date)->count();
                 $entry->set($version_data);
             }
         }

--- a/system/ee/ExpressionEngine/Controller/Publish/Edit.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Edit.php
@@ -449,6 +449,12 @@ class Edit extends AbstractPublishController
                 $vars['version'] = $version->toArray();
                 $vars['version']['number'] = $entry->Versions->filter('version_date', '<=', $version->version_date)->count();
                 $entry->set($version_data);
+
+                ee('CP/Alert')->makeInline('viewing-revision')
+                    ->asWarning()
+                    ->withTitle(lang('viewing_revision'))
+                    ->addToBody(lang('viewing_revision_desc'))
+                    ->now();
             }
         }
 

--- a/system/ee/ExpressionEngine/Controller/Publish/Edit.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Edit.php
@@ -445,6 +445,7 @@ class Edit extends AbstractPublishController
         if ($version_id) {
             $version = $entry->Versions->filter('version_id', $version_id)->first();
             $version_data = $version->version_data;
+            $vars['version'] = $version->toArray();
             $entry->set($version_data);
         }
 

--- a/system/ee/ExpressionEngine/View/publish/partials/publish_form.php
+++ b/system/ee/ExpressionEngine/View/publish/partials/publish_form.php
@@ -5,7 +5,12 @@
     <?php if (!isset($pro_class)) : ?>
     <div class="panel-heading panel-heading__publish">
         <div class="title-bar title-bar--large">
-            <h3 class="title-bar__title"><?=$head['title']?></h3>
+            <h3 class="title-bar__title">
+                <?=$head['title']?>
+                <?php if (isset($version)) {
+                    $this->embed('ee:publish/partials/revision_badge', $version);
+                } ?>
+            </h3>
         </div>
     </div>
     <?php endif; ?>

--- a/system/ee/ExpressionEngine/View/publish/partials/revision_badge.php
+++ b/system/ee/ExpressionEngine/View/publish/partials/revision_badge.php
@@ -1,0 +1,3 @@
+<span class="app-badge ml-s button-group-xsmall">
+    <span class="txt-only button button--default"><b><?=sprintf(lang('version_no'), $version_id)?></b> (<?=ee()->localize->human_time($version_date->format('U'))?>)</span>
+</span>

--- a/system/ee/ExpressionEngine/View/publish/partials/revision_badge.php
+++ b/system/ee/ExpressionEngine/View/publish/partials/revision_badge.php
@@ -1,3 +1,3 @@
 <span class="app-badge ml-s button-group-xsmall">
-    <span class="txt-only button button--default"><b><?=sprintf(lang('version_no'), $version_id)?></b> (<?=ee()->localize->human_time($version_date->format('U'))?>)</span>
+    <span class="txt-only button button--default"><b><?=sprintf(lang('version_no'), $number)?></b> (<?=ee()->localize->human_time($version_date->format('U'))?>)</span>
 </span>

--- a/system/ee/language/english/content_lang.php
+++ b/system/ee/language/english/content_lang.php
@@ -797,6 +797,10 @@ $lang = array(
 
     'view_wider' => 'View Wider',
 
+    'viewing_revision' => 'You Are Viewing a Revision',
+
+    'viewing_revision_desc' => 'Any changes saved will overwrite the newest version of this entry',
+
     'warning' => 'Warning',
 
     'width' => 'Width',

--- a/system/ee/language/english/content_lang.php
+++ b/system/ee/language/english/content_lang.php
@@ -781,6 +781,8 @@ $lang = array(
 
     'version_preview' => 'Revision Number %s',
 
+    'version_no' => 'Revision #%d',
+
     'versioning_enabled' => 'Enable entry revisions?',
 
     'versioning_enabled_desc' => 'When enabled, you can store up to %d revisions of this entry.',


### PR DESCRIPTION
Closes #1897

EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/2358

EECORE-1760