### PR TITLE
Resolved #185 anchor "name" attribute was getting incorrect prefix in third-party textareas inside Grid

### DIFF
--- a/system/ee/ExpressionEngine/Library/CP/GridInput.php
+++ b/system/ee/ExpressionEngine/Library/CP/GridInput.php
@@ -162,7 +162,7 @@ class GridInput extends Table
     public function namespaceInputs($search, $replace)
     {
         return preg_replace(
-            '/(<[input|select|textarea][^>]*)name=["\']([^"\'\[\]]+)([^"\']*)["\']/',
+            '/(<(?:input|select|textarea)[^>]*)name=["\']([^"\'\[\]]+)([^"\']*)["\']/',
             $replace,
             $search
         );


### PR DESCRIPTION
EECORE-2121
fixes [#185](https://github.com/ExpressionEngine/ExpressionEngine/issues/185)