### PR TITLE
Resolved #2360, #2303 where certain server configuration were giving PHP error that caused file management to not function properly

### DIFF
--- a/system/ee/ExpressionEngine/Library/Filesystem/Adapter/Local.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/Adapter/Local.php
@@ -35,11 +35,12 @@ class Local extends Flysystem\Adapter\Local implements AdapterInterface, Validat
         $permissions = [];
 
         $root = \is_link($root) ? \realpath($root) : $root;
+        $isRoot = substr_count(str_replace('\\', '/', $root), '/') === 1;
         $this->permissionMap = \array_replace_recursive(static::$permissions, $permissions);
 
         // Overriding parent constructor to remove this behavior of creating the root if it does not exist
         // $this->ensureDirectory($root);
-        if (!\is_dir($root) || !\is_readable($root)) {
+        if (!\is_dir($root) || (!$isRoot && !\is_readable($root))) {
             //throw an exception if root is not valid, but only if it's not validation request
             if ($this->settings['allow_missing'] ?? false) {
                 $this->rootExists = false;


### PR DESCRIPTION
## Overview

If the Local filesystem adapter is using a root path that is at the base of the system's filesystem we will relax the 'is readable' requirement on the path.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#2360](https://github.com/ExpressionEngine/ExpressionEngine/issues/2360).
Resolves [#2303](https://github.com/ExpressionEngine/ExpressionEngine/issues/2303).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No