### PR TITLE
Resolved #2375 where Profiler section in CP had some English words hardcoded

### DIFF
--- a/system/ee/ExpressionEngine/Service/Profiler/Section/Performance.php
+++ b/system/ee/ExpressionEngine/Service/Profiler/Section/Performance.php
@@ -53,7 +53,7 @@ class Performance extends ProfilerSection
 
         $data = array();
         if (function_exists('memory_get_usage') && ($usage = memory_get_usage()) != '') {
-            $data[lang('profiler_memory')] = $this->fmt_factory->make('Number', $usage)->bytes() . ' of ' . ini_get('memory_limit');
+            $data[lang('profiler_memory')] = $this->fmt_factory->make('Number', $usage)->bytes() . lang('of') . ' ' . ini_get('memory_limit');
         } else {
             $data[lang('profiler_memory')] = lang('profiler_no_memory_usage');
         }

--- a/system/ee/ExpressionEngine/Service/Profiler/Section/Performance.php
+++ b/system/ee/ExpressionEngine/Service/Profiler/Section/Performance.php
@@ -53,7 +53,7 @@ class Performance extends ProfilerSection
 
         $data = array();
         if (function_exists('memory_get_usage') && ($usage = memory_get_usage()) != '') {
-            $data[lang('profiler_memory')] = $this->fmt_factory->make('Number', $usage)->bytes() . lang('of') . ' ' . ini_get('memory_limit');
+            $data[lang('profiler_memory')] = $this->fmt_factory->make('Number', $usage)->bytes() . ' ' . lang('of') . ' ' . ini_get('memory_limit');
         } else {
             $data[lang('profiler_memory')] = lang('profiler_no_memory_usage');
         }


### PR DESCRIPTION
## Overview

In system/ee/ExpressionEngine/Service/Profiler/Section/Performance.php, line 56, the word "of" is hardcoded. You'll only notice when using a language pack, where it should be translated to, say, "de" in French or "von" in German, but is not.

fixes #2375

## Nature of This Change

Simply use `lang('of')` which uses the correct string from the language files.

- [X] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security

## Is this backwards compatible?

- [X] Yes
- [ ] No