### PR TITLE
Limit scope of filesystem eager loading

### DIFF
--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
@@ -289,10 +289,14 @@ trait FileManagerTrait
 
         $member = ee()->session->getMember();
 
+        $destinationsToEagerLoad = [];
+
         foreach ($files as $file) {
             if (! $file->memberHasAccess($member)) {
                 continue;
             }
+
+            $destinationsToEagerLoad[$file->upload_location_id] = $file->UploadDestination;
 
             $attrs = [
                 'class' => $file->isDirectory() ? 'drop-target' : '',
@@ -348,6 +352,12 @@ trait FileManagerTrait
                 'attrs' => $attrs,
                 'columns' => $column_renderer->getRenderedTableRowForEntry($file, $view_type, $filepickerMode)
             );
+        }
+
+        // We only need to eager load contents for destinations that are displaying
+        // files in this current page of the listing
+        foreach($destinationsToEagerLoad as $destination) {
+            $destination->eagerLoadContents();
         }
 
         if ($missing_files) {

--- a/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
+++ b/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
@@ -297,10 +297,6 @@ class FileSystemEntity extends ContentModel
         $filesystem = ee('File')->getPath($path, $adapter);
         $filesystem->setUrl($this->getAbsoluteUrl());
 
-        // This will effectively eager load the directory and speed up checks
-        // for file existence, especially in remote filesystems.  This might
-        // make more sense to move into file listing controllers eventually
-        $filesystem->getDirectoryContents($path, true);
         $this->filesystem = $filesystem;
 
         return $this->filesystem;

--- a/system/ee/ExpressionEngine/Model/File/UploadDestination.php
+++ b/system/ee/ExpressionEngine/Model/File/UploadDestination.php
@@ -358,12 +358,24 @@ class UploadDestination extends StructureModel
 
         $filesystem = ee('File')->getPath($path, $adapter);
         $filesystem->setUrl($this->getProperty('url'));
+        $this->filesystem = $filesystem;
 
+        return $this->filesystem;
+    }
+
+    /**
+     * Eager load the contents of the underlying filesystem by listing the files
+     * and storing results in the cached adapter
+     *
+     * @return Filesystem
+     */
+    public function eagerLoadContents()
+    {
         // This will effectively eager load the directory and speed up checks
         // for file existence, especially in remote filesystems.  This might
         // make more sense to move into file listing controllers eventually
-        $filesystem->getDirectoryContents($path, true);
-        $this->filesystem = $filesystem;
+        $path = $this->parseConfigVars((string) $this->getProperty('server_path'));
+        $this->filesystem->getDirectoryContents($path, true);
 
         return $this->filesystem;
     }


### PR DESCRIPTION
## Overview

Limit the use of filesystem eager loading to control panel listing pages only.  This fixes an issue where loading a few files on the front-end could trigger an eager load of an entire directory.  When the directory is large this would increase load time and memory consumption and is completely unnecessary.

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

