### PR TITLE
Resolved issue when saving some member profile settings could show PHP error when using PHP 8

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Profile/Profile.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Profile/Profile.php
@@ -321,7 +321,7 @@ class Profile extends CP_Controller
                         // Handle arrays of checkboxes as a special case;
                         if ($field['type'] == 'checkbox') {
                             foreach ($field['choices']  as $property => $label) {
-                                $this->member->$property = in_array($property, $post) ? 'y' : 'n';
+                                $this->member->$property = in_array($property, (array) $post) ? 'y' : 'n';
                             }
                         } else {
                             if ($post !== false) {


### PR DESCRIPTION
If you have no checkboxes selected:

in_array(): Argument #2 ($haystack) must be of type array, string given

ee/ExpressionEngine/Controller/Members/Profile/Profile.php:325
