### PR TITLE
Fixed a bug where channel entry search parameter could only be used once

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -641,6 +641,7 @@ class Channel
                 continue;
             }
 
+            $title_field = FALSE;
             $sites = ($site_ids ? $site_ids : array(ee()->config->item('site_id')));
             foreach ($sites as $site_name => $site_id) {
                 // We're goign to repeat the search on each site
@@ -649,6 +650,7 @@ class Channel
                 if (in_array($field_name, ['title', 'url_title'])) {
                     $table = 't';
                     $search_column_name = $table . '.' . $field_name;
+                    $title_field = TRUE;
                 } else if (! isset($this->cfields[$site_id][$field_name])) {
                     continue;
                 }
@@ -659,7 +661,7 @@ class Channel
                     $fields_sql .= ' OR ';
                 }
 
-                if (!isset($search_column_name)) {
+                if (! $title_field) {
                     $field_id = $this->cfields[$site_id][$field_name];
                     $table = (isset($legacy_fields[$field_id])) ? "wd" : "exp_channel_data_field_{$field_id}";
                     $search_column_name = $table . '.field_id_' . $this->cfields[$site_id][$field_name];

--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -641,7 +641,6 @@ class Channel
                 continue;
             }
 
-            $title_field = FALSE;
             $sites = ($site_ids ? $site_ids : array(ee()->config->item('site_id')));
             foreach ($sites as $site_name => $site_id) {
                 // We're goign to repeat the search on each site
@@ -650,7 +649,6 @@ class Channel
                 if (in_array($field_name, ['title', 'url_title'])) {
                     $table = 't';
                     $search_column_name = $table . '.' . $field_name;
-                    $title_field = TRUE;
                 } else if (! isset($this->cfields[$site_id][$field_name])) {
                     continue;
                 }
@@ -661,13 +659,14 @@ class Channel
                     $fields_sql .= ' OR ';
                 }
 
-                if (! $title_field) {
+                if (!isset($search_column_name)) {
                     $field_id = $this->cfields[$site_id][$field_name];
                     $table = (isset($legacy_fields[$field_id])) ? "wd" : "exp_channel_data_field_{$field_id}";
                     $search_column_name = $table . '.field_id_' . $this->cfields[$site_id][$field_name];
                 }
 
                 $fields_sql .= ee()->channel_model->field_search_sql($terms, $search_column_name, $site_id);
+                unset($search_column_name);
             } // foreach($sites as $site_id)
             if (! empty($fields_sql)) {
                 $sql .= ' AND (' . $fields_sql . ')';


### PR DESCRIPTION
You should be able to do:

{exp:channel:entries channel="searching" search:seo_title="seriouslies|sblarg" search:seo_title="second|booter" search:contact_email="Third" search:contact_phone="first"}

But in the query, it was only querying one of the custom field tables instead of all 3.

<img width="723" alt="Screen Shot 2022-09-23 at 4 43 20 PM" src="https://user-images.githubusercontent.com/1181219/192053509-09fe2ef8-87fe-4b3f-bf4a-7bf8f8f4b17f.png">

See how it keeps hitting exp_channel_data_field_10 instead of the tables for the other 2 searches?  
