### PR TITLE
Resolved #2410 where some fieldtypes could not be used as columns in Entry Manager

### DIFF
--- a/system/ee/ExpressionEngine/Addons/multi_select/ft.multi_select.php
+++ b/system/ee/ExpressionEngine/Addons/multi_select/ft.multi_select.php
@@ -23,6 +23,8 @@ class Multi_select_ft extends OptionFieldtype
 
     public $has_array_data = true;
 
+    public $entry_manager_compatible = true;
+
     /**
      * A list of operators that this fieldtype supports
      *
@@ -248,6 +250,11 @@ class Multi_select_ft extends OptionFieldtype
     public function update($version)
     {
         return true;
+    }
+
+    public function renderTableCell($data, $field_id, $entry)
+    {
+        return $this->replace_tag($data);
     }
 }
 

--- a/system/ee/ExpressionEngine/Addons/select/ft.select.php
+++ b/system/ee/ExpressionEngine/Addons/select/ft.select.php
@@ -23,6 +23,8 @@ class Select_ft extends OptionFieldtype
 
     public $has_array_data = true;
 
+    public $entry_manager_compatible = true;
+
     public $size = 'small';
 
     /**


### PR DESCRIPTION
Resolved #2410 where some fieldtypes could not be used as columns in Entry Manager

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/2425