### PR TITLE
Namespaced the Structure core nav parser to avoid conflicts with the …

### DIFF
--- a/system/ee/ExpressionEngine/Addons/structure/libraries/Structure_nav_parser.php
+++ b/system/ee/ExpressionEngine/Addons/structure/libraries/Structure_nav_parser.php
@@ -1,5 +1,11 @@
 <?php
 
+namespace ExpressionEngine\Addons\Structure\Libraries;
+
+use DOMElement;
+use DOMDocument;
+use Structure;
+
 /**
  * Library File for Structure Nav by Rob Sanchez
  *

--- a/system/ee/ExpressionEngine/Addons/structure/mod.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/mod.structure.php
@@ -20,6 +20,8 @@ if (version_compare(APP_VER, '6.0.0', '>=') && defined('PATH_PRO_ADDONS') && is_
     require_once PATH_MOD . 'channel/mod.channel.php';
 }
 
+use ExpressionEngine\Addons\Structure\Libraries\Structure_core_nav_parser;
+
 class Structure extends Channel
 {
     public $nset;
@@ -1166,7 +1168,6 @@ class Structure extends Channel
 
     public function order_entries()
     {
-
         // Grab the delimiter, or default to a pipe
         $delimiter = ee()->TMPL->fetch_param('delimiter');
         $delimiter = $delimiter ? $delimiter : '|';
@@ -1246,7 +1247,6 @@ class Structure extends Channel
             $changed = $this->has_changed($node, $data);
 
             if ($changed) {
-
                 // Retrieve previous listing channel id
                 $prev_lcid_result = ee()->db->query("SELECT listing_cid FROM exp_structure WHERE entry_id = " . $entry_id);
 


### PR DESCRIPTION
…EEHarbor codebase. This has been noticed a few times when upgrading from EE6.


<!-- What's in this pull request? -->
## Overview

Resolves EECORE-2143

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->



