### PR TITLE
Resolved #2430 where editing template by member without settings & access permission was resetting allowed roles

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Design/Template.php
+++ b/system/ee/ExpressionEngine/Controller/Design/Template.php
@@ -593,7 +593,7 @@ class Template extends AbstractDesignController
                 ->withTitle(lang('update_template_error'))
                 ->addToBody(lang('update_template_error_desc'))
                 ->now();
-        } else {
+        } else if (ee('Request')->post('allowed_roles') !== null) {
             $access = ee()->input->post('allowed_roles') ?: array();
 
             $roles = ee('Model')->get('Role', $access)


### PR DESCRIPTION
Resolved #2430 where editing template by member without settings & access permission was resetting allowed roles

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/2434

EECORE-2145
