### PR TITLE
Update the license mentions of Pro components

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -306,6 +306,14 @@ The following subcomponents are licensed under the MIT License:
     PHP CSS Parser
         Copyright (c) 2011 Raphael Schweikert, https://www.sabberworm.com/
 
+    Constant-Time Encoding:
+        Copyright (c) 2016 - 2022 Paragon Initiative Enterprises
+
+    TOTP / HOTP library in PHP:
+        Copyright (c) 2014-2016 Florent Morselli
+
+    Safe PHP:
+        Copyright (c) 2018 TheCodingMachine
 
     The Selection and Range components use code heavily inspired by:
 
@@ -339,20 +347,22 @@ The following subcomponents are licensed with the BSD-2-Clause license:
         Copyright (c) 2011-2017, Aura for PHP
         All rights reserved.
 
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are met:
-
-        Redistributions of source code must retain the above copyright notice, this
-        list of conditions and the following disclaimer.
-
-        Redistributions in binary form must reproduce the above copyright notice,
-        this list of conditions and the following disclaimer in the documentation
-        and/or other materials provided with the distribution.
-
     For the PHP SimplePie's IPv6 component:
-
         Copyright (c) 2003-2005 The PHP Group
 
+    For QR Code generator
+        Copyright (c) 2017, Ben Scholzen 'DASPRiD'
+        All rights reserved.
+
+    For Assert
+        Copyright (c) 2011-2013, Benjamin Eberlei
+        All rights reserved.
+
+    For PHP 7.1 enums
+        Copyright (c) 2017, Ben Scholzen 'DASPRiD'
+        All rights reserved.
+
+    BSD-2-Clause license:
         Redistribution and use in source and binary forms, with or without modification, are
         permitted provided that the following conditions are met:
 


### PR DESCRIPTION
EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/2114 by @TomJaeger 