### PR TITLE
Resolved #2431 image HTML button not editable in profile

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Profile/Buttons.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Profile/Buttons.php
@@ -300,6 +300,7 @@ class Buttons extends Settings
         $close = isset($values['tag_close']) ? $values['tag_close'] : '';
         $shortcut = isset($values['accesskey']) ? $values['accesskey'] : '';
         $class = isset($values['classname']) ? $values['classname'] : '';
+        $readonly = isset($values['classname']) && $values['classname'] == 'html-upload' ? true : false;
 
         $vars['sections'] = array(
             array(
@@ -313,21 +314,21 @@ class Buttons extends Settings
                     'title' => 'tag_open',
                     'desc' => 'tag_open_desc',
                     'fields' => array(
-                        'tag_open' => array('type' => 'text', 'value' => $open, 'required' => true)
+                        'tag_open' => array('type' => 'text', 'value' => $open, 'required' => true, 'attrs' => ($readonly ? 'readonly="readonly"' : ''))
                     )
                 ),
                 array(
                     'title' => 'tag_close',
                     'desc' => 'tag_close_desc',
                     'fields' => array(
-                        'tag_close' => array('type' => 'text', 'value' => $close)
+                        'tag_close' => array('type' => 'text', 'value' => $close, 'attrs' => ($readonly ? 'readonly="readonly"' : ''))
                     )
                 ),
                 array(
                     'title' => 'accesskey',
                     'desc' => 'accesskey_desc',
                     'fields' => array(
-                        'accesskey' => array('type' => 'text', 'value' => $shortcut),
+                        'accesskey' => array('type' => 'text', 'value' => $shortcut, 'attrs' => ($readonly ? 'readonly="readonly"' : '')),
                         'classname' => array('type' => 'hidden', 'value' => $class)
                     )
                 )


### PR DESCRIPTION
During release testing we discovered that the patch for #2431 was not applied to the Member Profile HTML buttons.  
This PR addresses that scenario and makes sure the image HTML button is in read-only mode when editing the profile buttons.