### PR TITLE
Fixed display of checkboxes on the Channel page Status tab

### DIFF
--- a/cp-styles/app/styles/components/_checkboxes-and-radios.scss
+++ b/cp-styles/app/styles/components/_checkboxes-and-radios.scss
@@ -180,6 +180,10 @@ $radio-size: 15px;
 		&:hover {
 			// background: color(bg-10);
 		}
+
+		&.checkbox-label__text-editable {
+			display: block;
+		}
 	}
 
 	input {

--- a/themes/ee/cp/css/common.min.css
+++ b/themes/ee/cp/css/common.min.css
@@ -16708,6 +16708,9 @@ input[type=checkbox].checkbox--small:active:not(:disabled) {
   border-radius: 5px;
   pointer-events: auto;
 }
+.checkbox-label .checkbox-label__text.checkbox-label__text-editable {
+  display: block;
+}
 .checkbox-label input {
   z-index: 1;
   position: absolute;


### PR DESCRIPTION
During release testing, I found that checkboxes on the Channel -> Status are not displayed correctly
This PR fixed css issue