### PR TITLE
fix recaptcha

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member.php
@@ -1350,7 +1350,7 @@ class Member
         $captcha->word = $string;
         $captcha->save();
 
-        if ($result['success'] !== true || $result['score'] < ee()->config->item('recaptcha_score_threshhold')) {
+        if ($result['success'] !== true || $result['score'] < ee()->config->item('recaptcha_score_threshold')) {
             $string = "failed";
         }
 


### PR DESCRIPTION
## Overview

I was pulling my hair why recaptcha v3 was not working on Expression Engine 7.1.6

Two issues:
1) i had to manually add the recaptcha_check action to the apporiate table as the member setup apparantly was not correctly run (page was upgraded from 2.something, so has seen some stuff)
```sql
INSERT INTO `exp_actions` (`class`, `method`, `csrf_exempt`) VALUES ('Member', 'recaptcha_check', '1');
```
2) the typo which is being fixed by this pull request.
3) the requirement of having `{captcha}` somewhere in some template is not 100% clear from documentation, 

## Nature of This Change

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
