### PR TITLE
Feature/6.x/update tests v7 copy

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member.php
@@ -1350,7 +1350,7 @@ class Member
         $captcha->word = $string;
         $captcha->save();
 
-        if ($result['success'] !== true || $result['score'] < ee()->config->item('recaptcha_score_threshhold')) {
+        if ($result['success'] !== true || $result['score'] < ee()->config->item('recaptcha_score_threshold')) {
             $string = "failed";
         }
         return ee()->output->send_ajax_response(['success' => $result['success'], 'code' => $string]);

--- a/system/ee/installer/updates/ud_3_00_00.php
+++ b/system/ee/installer/updates/ud_3_00_00.php
@@ -1076,8 +1076,7 @@ class Updater
         $member_directories = array();
 
         if (bool_config_item('enable_avatars')) {
-            $avatar_uploads = ee('Model')
-                ->get('UploadDestination')->filter('name', 'Avatars')->first();
+            $avatar_uploads = ee('db')->from('upload_prefs')->where('name', 'Avatars')->count_all_results();
 
             if (empty($avatar_uploads)) {
                 $member_directories['Avatars'] = array(
@@ -1092,8 +1091,7 @@ class Updater
         }
 
         if (bool_config_item('enable_photos')) {
-            $member_photo_uploads = ee('Model')
-                ->get('UploadDestination')->filter('name', 'Member Photos')->first();
+            $member_photo_uploads = ee('db')->from('upload_prefs')->where('name', 'Member Photos')->count_all_results();
 
             if (empty($member_photo_uploads)) {
                 $member_directories['Member Photos'] = array(
@@ -1108,8 +1106,7 @@ class Updater
         }
 
         if (bool_config_item('allow_signatures')) {
-            $signature_uploads = ee('Model')
-                ->get('UploadDestination')->filter('name', 'Signature Attachments')->first();
+            $signature_uploads = ee('db')->from('upload_prefs')->where('name', 'Signature Attachments')->count_all_results();
 
             if (empty($signature_uploads)) {
                 $member_directories['Signature Attachments'] = array(
@@ -1125,8 +1122,7 @@ class Updater
 
         if (bool_config_item('prv_msg_enabled')
             && bool_config_item('prv_msg_allow_attachments')) {
-            $pm_uploads = ee('Model')
-                ->get('UploadDestination')->filter('name', 'PM Attachments')->first();
+            $pm_uploads = ee('db')->from('upload_prefs')->where('name', 'PM Attachments')->count_all_results();
 
             if (empty($pm_uploads)) {
                 $member_directories['PM Attachments'] = array(
@@ -1143,17 +1139,10 @@ class Updater
         }
 
         foreach ($member_directories as $name => $dir) {
-            $directory = ee('Model')->make('UploadDestination');
-            $directory->site_id = $site_id;
-            $directory->name = $name;
-            //$dir->removeNoAccess(); //function not defined since 2.x, so not using it
-            $directory->setModule($module);
-
-            foreach ($dir as $property => $value) {
-                $directory->$property = $value;
-            }
-
-            $directory->save();
+            $dir['site_id'] = $site_id;
+            $dir['name'] = $name;
+            $data['module_id'] = $module->getId(); // this is a terribly named column - should be called `hidden`
+            ee()->db->insert('upload_prefs', $dir);
         }
 
         return true;

--- a/system/ee/installer/updates/ud_3_01_00.php
+++ b/system/ee/installer/updates/ud_3_01_00.php
@@ -294,26 +294,23 @@ class Updater
                 'max_size' => $member_prefs['prv_msg_attach_maxsize']
             );
 
-            $existing = ee('Model')->get('UploadDestination')
-                ->fields('name')
-                ->filter('name', 'IN', array_keys($member_directories))
-                ->filter('site_id', $site['site_id'])
-                ->all()
-                ->pluck('name');
+            $existing = ee('db')->from('upload_prefs')
+                ->select('name')
+                ->where_in('name', array_keys($member_directories))
+                ->where('site_id', $site['site_id'])
+                ->get();
 
-            foreach ($existing as $name) {
-                unset($member_directories[$name]);
+            foreach ($existing->result() as $row) {
+                unset($member_directories[$row->name]);
             }
 
             foreach ($member_directories as $name => $data) {
-                $dir = ee('Model')->make('UploadDestination', $data);
-                $dir->site_id = $site['site_id'];
-                $dir->name = $name;
-                //$dir->removeNoAccess(); //function not defined since 2.x, so not using it
-                $dir->module_id = 1; // this is a terribly named column - should be called `hidden`
-                $dir->save();
+                $data['site_id'] = $site['site_id'];
+                $data['name'] = $name;
+                $data['module_id'] = 1; // this is a terribly named column - should be called `hidden`
+                ee()->db->insert('upload_prefs', $data);
 
-                ee()->db->where('upload_id', $dir->getId());
+                ee()->db->where('upload_id', ee()->db->insert_id());
                 ee()->db->delete('upload_no_access');
             }
         }

--- a/system/ee/installer/updates/ud_3_04_02.php
+++ b/system/ee/installer/updates/ud_3_04_02.php
@@ -71,13 +71,13 @@ class Updater
      */
     private function fix_file_dimension_site_ids()
     {
-        $upload_destinations = ee('Model')->get('UploadDestination')->all();
+        $upload_destinations = ee('db')->from('upload_prefs')->get();
 
         foreach ($upload_destinations as $upload) {
-            foreach ($upload->FileDimensions as $size) {
+            $FileDimensions = ee('db')->where('upload_location_id', $upload->id)->from('file_dimensions')->get();
+            foreach ($FileDimensions->result() as $size) {
                 if ($size->site_id != $upload->site_id) {
-                    $size->site_id = $upload->site_id;
-                    $size->save();
+                    ee('db')->where('id', $size->id)->update('file_dimensions', ['site_id' => $upload->site_id]);
                 }
             }
         }

--- a/system/ee/installer/updates/ud_4_02_02.php
+++ b/system/ee/installer/updates/ud_4_02_02.php
@@ -42,9 +42,9 @@ class Updater
         $warning = false;
         $directories = array();
         // Get all of the file upload directories and see if any are using themes/ee
-        $upload_destinations = ee('Model')->get('UploadDestination')->all();
+        $upload_destinations =  ee('db')->from('upload_prefs')->get();
 
-        foreach ($upload_destinations as $upload) {
+        foreach ($upload_destinations->result() as $upload) {
             if (strpos($upload->server_path, 'themes/ee/site/default/asset/img/') !== false) {
                 $warning = true;
                 $directories[$upload->server_path] = $upload->name;

--- a/system/ee/installer/updates/ud_6_00_00_b_1.php
+++ b/system/ee/installer/updates/ud_6_00_00_b_1.php
@@ -206,7 +206,9 @@ class Updater
         ee('Model')->get('Config')->filter('key', 'IN', ['enable_avatars', 'allow_avatar_uploads'])->delete();
 
         // Remove avatar member preference
-        ee()->dbforge->drop_column('members', 'display_avatars');
+        if (ee()->db->field_exists('display_avatars', 'members')) {
+            ee()->dbforge->drop_column('members', 'display_avatars');
+        }
     }
 
     private function removeJqueryAddon()

--- a/tests/cypress/cypress/integration/addons/query.ee6.js
+++ b/tests/cypress/cypress/integration/addons/query.ee6.js
@@ -34,7 +34,7 @@ context('Query', () => {
         cy.get('.query-results--parsed-files__field_id_3').first().invoke('text').should('eq', "/images/about/ee_banner_120_240.gif")
     })
     it('parse base variables', function(){
-      var baseUrl =  Cypress.env('CYPRESS_BASE_URL').endsWith('/') ?  Cypress.env('CYPRESS_BASE_URL').slice(0, -1) :  Cypress.env('CYPRESS_BASE_URL')
+      var baseUrl = Cypress.config().baseUrl.endsWith('/') ? Cypress.config().baseUrl.slice(0, -1) : Cypress.config().baseUrl
       cy.get('.query-results--parsed-bases__3 .query-results--parsed-bases__url').first().invoke('text').should('contain', baseUrl + "/images/avatars/")
       cy.get('.query-results--parsed-bases__3').first().should('have.class', 'odd')
     })

--- a/tests/cypress/cypress/integration/addons/query.ee6.js
+++ b/tests/cypress/cypress/integration/addons/query.ee6.js
@@ -8,7 +8,7 @@ const addon_manager = new AddonManager;
 const siteManager = new SiteManager;
 const form = new SiteForm;
 
-context('Request', () => {
+context('Query', () => {
 
   before(function(){
     cy.task('db:seed')
@@ -34,8 +34,9 @@ context('Request', () => {
         cy.get('.query-results--parsed-files__field_id_3').first().invoke('text').should('eq', "/images/about/ee_banner_120_240.gif")
     })
     it('parse base variables', function(){
-		cy.get('.query-results--parsed-bases__3 .query-results--parsed-bases__url').first().invoke('text').should('contain', "http://localhost:8888/images/avatars/")
-		cy.get('.query-results--parsed-bases__3').first().should('have.class', 'odd')
+      var baseUrl =  Cypress.env('CYPRESS_BASE_URL').endsWith('/') ?  Cypress.env('CYPRESS_BASE_URL').slice(0, -1) :  Cypress.env('CYPRESS_BASE_URL')
+      cy.get('.query-results--parsed-bases__3 .query-results--parsed-bases__url').first().invoke('text').should('contain', baseUrl + "/images/avatars/")
+      cy.get('.query-results--parsed-bases__3').first().should('have.class', 'odd')
     })
   })
 })

--- a/tests/cypress/cypress/integration/z_installer/updater.ee6.js
+++ b/tests/cypress/cypress/integration/z_installer/updater.ee6.js
@@ -94,53 +94,55 @@ context('Updater', () => {
     })
   })
 
-it('turns system off if system was off before updating', () => {
-    cy.task('installer:revert_config').then(() => {
-        cy.task('installer:replace_config', {
-            file: 'support/config/config-5.3.0.php', options: {
-                database: {
-                    hostname: Cypress.env("DB_HOST"),
-                    database: Cypress.env("DB_DATABASE"),
-                    username: Cypress.env("DB_USER"),
-                    password: Cypress.env("DB_PASSWORD")
-                },
-                app_version: '5.3.0',
-                is_system_on: 'n',
-            }
-        }).then(() => {
-            cy.task('db:load', '../../support/sql/database_5.3.0.sql').then(() => {
-                test_cli_update()
-                cy.eeConfig({ item: 'is_system_on' }).then((config) => {
-                    expect(config.trim()).to.be.equal('n')
-                })
-            })
-        })
-    })
-})
+  it('turns system off if system was off before updating', () => {
+      cy.task('installer:revert_config').then(() => {
+          cy.task('installer:replace_config', {
+              file: 'support/config/config-5.3.0.php', options: {
+                  database: {
+                      hostname: Cypress.env("DB_HOST"),
+                      database: Cypress.env("DB_DATABASE"),
+                      username: Cypress.env("DB_USER"),
+                      password: Cypress.env("DB_PASSWORD")
+                  },
+                  app_version: '5.3.0',
+                  is_system_on: 'n',
+              }
+          }).then(() => {
+              cy.task('db:load', '../../support/sql/database_5.3.0.sql').then(() => {
+                  test_cli_update()
+                  cy.task('installer:disable')
+                  cy.eeConfig({ item: 'is_system_on' }).then((config) => {
+                      expect(config.trim()).to.be.equal('n')
+                  })
+              })
+          })
+      })
+  })
 
-    it('turns system on if system was on before updating', () => {
-        cy.task('installer:revert_config').then(() => {
-            cy.task('installer:replace_config', {
-                file: 'support/config/config-5.3.0.php', options: {
-                    database: {
-                        hostname: Cypress.env("DB_HOST"),
-                        database: Cypress.env("DB_DATABASE"),
-                        username: Cypress.env("DB_USER"),
-                        password: Cypress.env("DB_PASSWORD")
-                    },
-                    app_version: '5.3.0',
-                    is_system_on: 'y',
-                }
-            }).then(() => {
-                cy.task('db:load', '../../support/sql/database_5.3.0.sql').then(() => {
-                    test_cli_update()
-                    cy.eeConfig({ item: 'is_system_on' }).then((config) => {
-                        expect(config.trim()).to.be.equal('y')
-                    })
-                })
-            })
-        })
-    })
+  it('turns system on if system was on before updating', () => {
+      cy.task('installer:revert_config').then(() => {
+          cy.task('installer:replace_config', {
+              file: 'support/config/config-5.3.0.php', options: {
+                  database: {
+                      hostname: Cypress.env("DB_HOST"),
+                      database: Cypress.env("DB_DATABASE"),
+                      username: Cypress.env("DB_USER"),
+                      password: Cypress.env("DB_PASSWORD")
+                  },
+                  app_version: '5.3.0',
+                  is_system_on: 'y',
+              }
+          }).then(() => {
+              cy.task('db:load', '../../support/sql/database_5.3.0.sql').then(() => {
+                  test_cli_update()
+                  cy.task('installer:disable')
+                  cy.eeConfig({ item: 'is_system_on' }).then((config) => {
+                      expect(config.trim()).to.be.equal('y')
+                  })
+              })
+          })
+      })
+  })
 
   context('when updating from 2.x to 6.x', () => {
     beforeEach(function(){
@@ -218,34 +220,7 @@ it('turns system off if system was off before updating', () => {
       })
     })
 
-    it.only('has all required modules installed after the update', () => {
-      test_update()
-      test_templates()
-
-      let installed_modules = []
-      cy.task('db:query', 'SELECT module_name FROM exp_modules').then((result) => {
-        result[0].forEach(function(row){
-          installed_modules.push(row.module_name.toLowerCase());
-        });
-
-        expect(installed_modules).to.include('consent')
-        expect(installed_modules).to.include('channel')
-        expect(installed_modules).to.include('comment')
-        expect(installed_modules).to.include('member')
-        expect(installed_modules).to.include('stats')
-        expect(installed_modules).to.include('rte')
-        expect(installed_modules).to.include('file')
-        expect(installed_modules).to.include('filepicker')
-        expect(installed_modules).to.include('search')
-        expect(installed_modules).to.include('pro')
-      })
-
-      cy.task('db:query', 'SELECT * FROM exp_dashboard_widgets').then((result) => {
-        expect(result[0].length).to.be.gt(1)
-      })
-    })
-
-    it('has all required modules installed after CLI update', () => {
+    it('has all required modules installed after the update', () => {
       test_cli_update()
       test_templates()
 
@@ -255,7 +230,6 @@ it('turns system off if system was off before updating', () => {
           installed_modules.push(row.module_name.toLowerCase());
         });
 
-        expect(installed_modules).to.include('consent')
         expect(installed_modules).to.include('channel')
         expect(installed_modules).to.include('comment')
         expect(installed_modules).to.include('member')
@@ -264,11 +238,6 @@ it('turns system off if system was off before updating', () => {
         expect(installed_modules).to.include('file')
         expect(installed_modules).to.include('filepicker')
         expect(installed_modules).to.include('search')
-        expect(installed_modules).to.include('pro')
-      })
-
-      cy.task('db:query', 'SELECT * FROM exp_dashboard_widgets').then((result) => {
-        expect(result[0].length).to.be.gt(1)
       })
     })
   })
@@ -384,8 +353,6 @@ it('turns system off if system was off before updating', () => {
       cy.task('filesystem:delete', mailing_list_zip).then(() => {
         cy.exec('php ../../system/ee/eecli.php update -v -y --skip-cleanup')
       })
-
-      test_version()
   }
 
   function test_update(mailinglist = false, expect_login = false) {


### PR DESCRIPTION
Fixed an EE6 error where update could fail with a MySQL error if avatars weren't installed, plus porting over the rest of the changes (sans a v7 update) from

https://github.com/ExpressionEngine/ExpressionEngine/commit/87724d79476928dd27070109b213f7d218a1da7b#diff-2ead70f153800499a912f8c71c3940d8546537476defbffb3ba05ccb6f95bd81