### PR TITLE
Added default empty string to placeholder variable

### DIFF
--- a/system/ee/ExpressionEngine/Service/Filter/Filter.php
+++ b/system/ee/ExpressionEngine/Service/Filter/Filter.php
@@ -58,7 +58,7 @@ abstract class Filter
     /**
      * @var string The value to use for the custom input's placeholder="" attribute
      */
-    protected $placeholder;
+    protected $placeholder = '';
 
     /**
      * @var bool Whether or not this filter has a custom <input> element


### PR DESCRIPTION
php 8.1, eeh rating module was throwing:

```Deprecated
htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated

ee/ExpressionEngine/View/_shared/filters/filter.php, line 17```

Basically, the collection filter didn't have a default specified, so it was null and htmlentities didn't love it.

Seemed better to put a default here than require it of add-ons.

<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Replace this paragraph with a description of your changes and reasoning. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [ ] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
