### PR TITLE
Feature/inline member registration errors

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
@@ -671,8 +671,6 @@ class Member_register extends Member
             ->get('forum_boards');
     }
 
-
-
     /**
      * Member Self-Activation
      */

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
@@ -157,13 +157,6 @@ class Member_register extends Member
             $reg_form = ee()->TMPL->parse_variables($reg_form, array($field_values));
         }
 
-        // parse the errors
-        $error_tags = ee()->session->flashdata('error_tags');
-
-        if (!empty($error_tags)) {
-            $reg_form = ee()->TMPL->parse_variables($reg_form, array($error_tags));
-        }
-
         $un_min_len = str_replace(
             "%x",
             ee()->config->item('un_min_len'),
@@ -201,6 +194,13 @@ class Member_register extends Member
         if(ee()->TMPL->fetch_param('error_handling') == 'inline') {
             // determine_error_return function looks for yes.
             $inline_errors = 'yes';
+
+            // parse the errors
+            $error_tags = ee()->session->flashdata('error_tags');
+
+            if (!empty($error_tags)) {
+                $reg_form = ee()->TMPL->parse_variables($reg_form, array($error_tags));
+            }
         }
 
         // Generate Form declaration

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
@@ -214,8 +214,6 @@ class Member_register extends Member
             ]),
         );
 
-        
-
         if(!empty(ee()->TMPL->form_class)) {
             $data['class'] = ee()->TMPL->form_class;
         }


### PR DESCRIPTION
Updating member registration tags to support inline errors.

Inline error handeling lines up with channel forms.

Requires you to add
error_handling="inline"

to your {exp:member:registration_form opening tag.
To output errors, each registration_form field name is prefixed with error.
if error:username}{error:username}{/if}

docs: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/525