### PR TITLE
Resolved #2497 where categories parameter did not work on relationship `siblings` and `parents` tags

### DIFF
--- a/system/ee/legacy/libraries/channel_entries_parser/components/Relationship.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Relationship.php
@@ -70,7 +70,17 @@ class EE_Channel_relationship_parser implements EE_Channel_parser_component
 
             $disabledFeatures = $pre->disabledFeatures();
             if (strpos($tagdata, 'categories') === false) {
-                $disabledFeatures[] = 'relationship_categories';
+                $disableCategories = true;
+                $tagStrings = array_merge($pre->pairs, $pre->singles);
+                foreach ($tagStrings as $string => $data) {
+                    if (strpos($string, 'category') !== false) {
+                        $disableCategories = false;
+                        break;
+                    }
+                }
+                if ($disableCategories) {
+                    $disabledFeatures[] = 'relationship_categories';
+                }
             }
 
             return ee()->relationships_parser->create(

--- a/system/ee/legacy/libraries/channel_entries_parser/components/Relationship.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Relationship.php
@@ -72,10 +72,12 @@ class EE_Channel_relationship_parser implements EE_Channel_parser_component
             if (strpos($tagdata, 'categories') === false) {
                 $disableCategories = true;
                 $tagStrings = array_merge($pre->pairs, $pre->singles);
-                foreach ($tagStrings as $string => $data) {
-                    if (strpos($string, 'category') !== false) {
-                        $disableCategories = false;
-                        break;
+                if (!empty($tagStrings)) {
+                    foreach ($tagStrings as $string => $data) {
+                        if (strpos($string, 'category') !== false) {
+                            $disableCategories = false;
+                            break;
+                        }
                     }
                 }
                 if ($disableCategories) {


### PR DESCRIPTION
Resolved #2497 where categories parameter did not work on relationship `siblings` and `parents` tags