### PR TITLE
Resolved #2490 where visual indication was missing when Directory Sync was started

### DIFF
--- a/themes/ee/asset/javascript/src/cp/fields/synchronize.js
+++ b/themes/ee/asset/javascript/src/cp/fields/synchronize.js
@@ -24,7 +24,9 @@ EE.fieldManager.sync_listen = function() {
 		event.preventDefault();
 
 		// Disable sync button
-		$('.button', this).prop('disabled', true);
+		$('.button', $('.form-standard form')).each(function() {
+			$(this).val($(this).data('work-text')).addClass('work').prop('disabled', true);
+		});
 
 		// Remove any existing alerts
 		$('.app-notice--inline').remove();

--- a/themes/ee/asset/javascript/src/cp/files/synchronize.js
+++ b/themes/ee/asset/javascript/src/cp/files/synchronize.js
@@ -34,7 +34,10 @@ EE.file_manager.sync_listen = function() {
 		EE.file_manager.update_progress(0);
 
 		// Disable sync button
-		$('.button', this).prop('disabled', true);
+		$(this).parents('form').find('.button').prop('disabled', true);
+		$(this).parents('form').find('.button').each(function() {
+			$(this).text($(this).data('work-text'));
+		});
 
 		// Remove any existing alerts
 		$('.app-notice--inline').remove();


### PR DESCRIPTION
Resolved #2490 
After clicking the Directory Sync button, the cursor shifts to a wait state and the Directory Sync button is disabled
