### PR TITLE
cache relationships query so it would be reused on multiple loops

### DIFF
--- a/system/ee/legacy/libraries/relationship_parser/Tree_builder.php
+++ b/system/ee/legacy/libraries/relationship_parser/Tree_builder.php
@@ -174,13 +174,13 @@ class EE_relationship_tree_builder
                 foreach ($authorFields as $field) {
                     $entriesQuery->fields('Author.' . $field);
                 }
-                $entries_result = $entriesQuery->all()
+                $entries_result = $entriesQuery->all(true)
                     ->getModChannelResultsArray($disabled);
                 unset($entriesQuery);
             } else {
                 $entries_result = ee('Model')->get('ChannelEntry', $unique_entry_ids)
                     ->with($entriesQueryWith)
-                    ->all()
+                    ->all(true)
                     ->getModChannelResultsArray($disabledFeatures);
             }
 


### PR DESCRIPTION
The issue reported here: https://eecms.slack.com/archives/C04CUNNR9/p1669300219540029

Basically, if you have channel entries tag with a relationships field that relates to same entry, it goes to database to fetch that entry each time.
This fix is caching the query so it would not happen