### PR TITLE
Display update date in success message after saving an entry; #1157

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -453,7 +453,7 @@ abstract class AbstractPublish extends CP_Controller
             ? ee('CP/Alert')->makeStandard()
             : ee('CP/Alert')->makeInline('entry-form');
 
-        $lang_string = sprintf(lang($action . '_entry_success_desc'), htmlentities($edit_entry_url, ENT_QUOTES, 'UTF-8'), htmlentities($entry->title, ENT_QUOTES, 'UTF-8'));
+        $lang_string = sprintf(lang($action . '_entry_success_desc'), htmlentities($edit_entry_url, ENT_QUOTES, 'UTF-8'), htmlentities($entry->title, ENT_QUOTES, 'UTF-8'), ee()->localize->human_time($entry->edit_date));
 
         $alert->asSuccess()
             ->withTitle(lang($action . '_entry_success'))

--- a/system/ee/language/english/content_lang.php
+++ b/system/ee/language/english/content_lang.php
@@ -116,7 +116,7 @@ $lang = array(
 
     'edit_entry_success' => 'Entry Updated',
 
-    'edit_entry_success_desc' => 'The entry <a href=\'%1$s\'><b>%2$s</b></a> has been updated.',
+    'edit_entry_success_desc' => 'The entry <a href=\'%1$s\'><b>%2$s</b></a> has been updated at %3$s.',
 
     'edit_entry_with_title' => 'Edit Entry: %s',
 


### PR DESCRIPTION
Display update date in success message after saving an entry; closes #1157