### PR TITLE
Added ability to skip success message after submitting email contact form; #1034

### DIFF
--- a/system/ee/ExpressionEngine/Addons/email/mod.email.php
+++ b/system/ee/ExpressionEngine/Addons/email/mod.email.php
@@ -822,6 +822,8 @@ class Email
                 $data['rate'] = ee()->input->get_post('redirect');
             } elseif (ee()->input->get_post('redirect') == 'none') {
                 $data['redirect'] = '';
+            } elseif (ee()->input->get_post('redirect') == 'return') {
+                ee()->functions->redirect($return_link);
             }
         }
 


### PR DESCRIPTION
Added ability to skip success message after submitting email contact form; closes #1034### 

docs: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/527