### PR TITLE
Resolved #2080 where Comments column was shown in Entry Manager when Comment module is disabled

### DIFF
--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
@@ -79,9 +79,16 @@ class ColumnFactory
      */
     private static function getStandardColumns()
     {
-        return array_map(function ($identifier, $column) {
-            return static::getColumn($identifier);
-        }, array_keys(static::$standard_columns), static::$standard_columns);
+        return array_filter(
+            array_map(function ($identifier, $column) {
+                if ($identifier != 'comments' || bool_config_item('enable_comments')) {
+                    return static::getColumn($identifier);
+                }
+            }, array_keys(static::$standard_columns), static::$standard_columns),
+            function ($column) {
+                return (! empty($column));
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
Resolved #2080 where Comments column was shown in Entry Manager when Comment module is disabled