### PR TITLE
Allow template engines to be assigned to templates

### DIFF
--- a/build-tools/build.json
+++ b/build-tools/build.json
@@ -1,5 +1,5 @@
 {
-    "tag": "7.2.2",
+    "tag": "7.2.3",
 
     "repositories": {
         "app": "git@github.com:ExpressionEngine/ExpressionEngine",

--- a/system/ee/ExpressionEngine/Model/Template/Template.php
+++ b/system/ee/ExpressionEngine/Model/Template/Template.php
@@ -98,6 +98,7 @@ class Template extends FileSyncedModel
     protected $group_id;
     protected $template_name;
     protected $template_type;
+    protected $template_engine;
     protected $template_data;
     protected $template_notes;
     protected $edit_date;

--- a/system/ee/ExpressionEngine/Model/Template/Template.php
+++ b/system/ee/ExpressionEngine/Model/Template/Template.php
@@ -197,11 +197,12 @@ class Template extends FileSyncedModel
     public function getFileExtension($template_type = null)
     {
         $type = $template_type ?: $this->template_type;
+        $engine = $this->template_engine ?: null;
 
         ee()->load->library('api');
         ee()->legacy_api->instantiate('template_structure');
 
-        return ee()->api_template_structure->file_extensions($type);
+        return ee()->api_template_structure->file_extensions($type, $engine);
     }
 
     /**

--- a/system/ee/ExpressionEngine/Tests/bootstrap.php
+++ b/system/ee/ExpressionEngine/Tests/bootstrap.php
@@ -11,7 +11,7 @@ define('SYSPATH', $project_base);
 define('BASEPATH', SYSPATH . 'ee/legacy/');
 define('PATH_CACHE', SYSPATH . 'user/cache/');
 define('APPPATH', BASEPATH);
-define('APP_VER', '7.2.2');
+define('APP_VER', '7.2.3');
 define('PATH_THEMES', realpath(SYSPATH . '/../themes') . '/');
 define('DOC_URL', 'http://our.doc.url/');
 

--- a/system/ee/installer/controllers/wizard.php
+++ b/system/ee/installer/controllers/wizard.php
@@ -13,7 +13,7 @@
  */
 class Wizard extends CI_Controller
 {
-    public $version = '7.2.2'; // The version being installed
+    public $version = '7.2.3'; // The version being installed
     public $installed_version = '';  // The version the user is currently running (assuming they are running EE)
     public $schema = null; // This will contain the schema object with our queries
     public $languages = array(); // Available languages the installer supports (set dynamically based on what is in the "languages" folder)

--- a/system/ee/installer/schema/mysql_schema.php
+++ b/system/ee/installer/schema/mysql_schema.php
@@ -923,6 +923,7 @@ class EE_Schema
 			group_id int(6) unsigned NOT NULL,
 			template_name varchar(50) NOT NULL,
 			template_type varchar(16) NOT NULL default 'webpage',
+            template_engine varchar(24) DEFAULT NULL,
 			template_data mediumtext NULL,
 			template_notes text NULL,
 			edit_date int(10) NOT NULL DEFAULT 0,

--- a/system/ee/installer/updates/ud_6_04_02.php
+++ b/system/ee/installer/updates/ud_6_04_02.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2022, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Updater\Version_6_4_2;
+
+/**
+ * Update
+ */
+class Updater
+{
+    public $version_suffix = '';
+
+    /**
+     * Do Update
+     *
+     * @return TRUE
+     */
+    public function do_update()
+    {
+        return true;
+    }
+}
+
+// EOF

--- a/system/ee/installer/updates/ud_7_02_03.php
+++ b/system/ee/installer/updates/ud_7_02_03.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2022, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Updater\Version_7_2_3;
+
+/**
+ * Update
+ */
+class Updater
+{
+    public $version_suffix = '';
+
+    /**
+     * Do Update
+     *
+     * @return TRUE
+     */
+    public function do_update()
+    {
+        $steps = new \ProgressIterator(
+            [
+                'addTemplateEngineToTemplates',
+            ]
+        );
+
+        foreach ($steps as $k => $v) {
+            $this->$v();
+        }
+
+        return true;
+    }
+
+
+    private function addTemplateEngineToTemplates()
+    {
+        if (!ee()->db->field_exists('template_engine', 'templates')) {
+            ee()->smartforge->add_column(
+                'templates',
+                [
+                    'template_engine' => [
+                        'type' => 'varchar',
+                        'constraint' => 24,
+                        'default' => null,
+                        'null' => true
+                    ]
+                ],
+                'template_type'
+            );
+        }
+    }
+}
+
+// EOF

--- a/system/ee/installer/updates/ud_7_02_03.php
+++ b/system/ee/installer/updates/ud_7_02_03.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2022, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Updater\Version_7_2_3;
+
+/**
+ * Update
+ */
+class Updater
+{
+    public $version_suffix = '';
+
+    /**
+     * Do Update
+     *
+     * @return TRUE
+     */
+    public function do_update()
+    {
+        return true;
+    }
+}
+
+// EOF

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -74,8 +74,8 @@ class EE_Core
 
         // application constants
         define('APP_NAME', 'ExpressionEngine');
-        define('APP_BUILD', '20221128');
-        define('APP_VER', '7.2.2');
+        define('APP_BUILD', '20221201');
+        define('APP_VER', '7.2.3');
         define('APP_VER_ID', '');
         define('SLASH', '&#47;');
         define('LD', '{');

--- a/system/ee/legacy/libraries/api/Api_template_structure.php
+++ b/system/ee/legacy/libraries/api/Api_template_structure.php
@@ -234,7 +234,7 @@ class Api_template_structure extends Api
         $engine = ($engine && array_key_exists($engine, $this->template_engines)) ? ".$engine" : null;
 
         if (isset($this->file_extensions[$template_type])) {
-            return implode('', array_filter([$engine, $this->file_extensions[$template_type]]));
+            return implode('', array_filter([$this->file_extensions[$template_type], $engine]));
         } else { 
             // Check custom template types for a file extension
             // -------------------------------------------
@@ -247,7 +247,7 @@ class Api_template_structure extends Api
 
             if ($template_types != null) {
                 if (isset($template_types[$template_type]['template_file_extension'])) {
-                    return implode('', array_filter([$engine, $template_types[$template_type]['template_file_extension']]));
+                    return implode('', array_filter([$template_types[$template_type]['template_file_extension'], $engine]));
                 }
             }
         }
@@ -296,9 +296,9 @@ class Api_template_structure extends Api
 
         foreach ($this->file_extensions as $type => $extension) {
             foreach ($engines as $engine) {
-                $ext = '.' . implode('.', array_filter([
-                    $engine,
-                    ltrim($extension, '.')
+                $ext = implode('.', array_filter([
+                    $extension,
+                    $engine
                 ]));
                 $extensions[$type][] = ['extension' => $ext, 'engine' => $engine ?: null];
             }

--- a/system/ee/legacy/models/template_model.php
+++ b/system/ee/legacy/models/template_model.php
@@ -1039,6 +1039,11 @@ class Template_Entity
     /**
      *
      */
+    protected $template_engine;
+
+    /**
+     *
+     */
     protected $template_data;
 
     /**

--- a/system/ee/legacy/models/template_model.php
+++ b/system/ee/legacy/models/template_model.php
@@ -93,7 +93,7 @@ class Template_model extends CI_Model
         $this->legacy_api->instantiate('template_structure');
         $filepath = PATH_TMPL . $this->config->item('site_short_name') . DIRECTORY_SEPARATOR
             . $template->get_group()->group_name . '.group' . DIRECTORY_SEPARATOR . $template->template_name
-            . $this->api_template_structure->file_extensions($template->template_type);
+            . $this->api_template_structure->file_extensions($template->template_type, $template->template_engine);
 
         // We don't need the other site's configuration values anymore, so
         // reset them.  If we do this here we only have to do it once,
@@ -296,7 +296,7 @@ class Template_model extends CI_Model
             chmod($basepath, DIR_WRITE_MODE);
         }
 
-        $filename = $template->template_name . $this->api_template_structure->file_extensions($template->template_type);
+        $filename = $template->template_name . $this->api_template_structure->file_extensions($template->template_type, $template->template_engine);
 
         if (! $fp = fopen($basepath . DIRECTORY_SEPARATOR . $filename, FOPEN_WRITE_CREATE_DESTRUCTIVE)) {
             return false;

--- a/tests/cypress/support/config/config.php
+++ b/tests/cypress/support/config/config.php
@@ -7,7 +7,7 @@
 $config['save_tmpl_files'] = 'n';
 $config['legacy_member_templates'] = 'y';
 
-$config['app_version'] = '7.2.2';
+$config['app_version'] = '7.2.3';
 $config['encryption_key'] = '4b9e521eb02751d8466a3e9b764524aff14b91ad';
 $config['session_crypt_key'] = '1f307a8afe66e692c2689508a5d9f783606379a8';
 $config['base_path'] = $_SERVER['DOCUMENT_ROOT'];


### PR DESCRIPTION
## Overview

Add the ability for templates to have extensions derived from different templating engines.

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
