### PR TITLE
Resolved #2553 where `{exp:channel:entries}` output could miss some results on MSM installations with duplicate channel names

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -1196,7 +1196,7 @@ class Channel
         /**------*/
 
         if ($channel = ee()->TMPL->fetch_param('channel')) {
-            $channels = ee('Model')->get('Channel')->fields('channel_id', 'channel_name')->all(true)->getDictionary('channel_id', 'channel_name');
+            $channels = ee('Model')->get('Channel')->fields('channel_id', 'channel_name')->all(true);
             $channelInOperator = 'IN';
             if (strpos($channel, 'not ') === 0) {
                 $channelInOperator = 'NOT IN';
@@ -1210,9 +1210,9 @@ class Channel
             }
             $channel_ids = array();
             foreach ($options as $option) {
-                foreach ($channels as $channel_id => $channel_name) {
-                    if (strtolower($option) == strtolower($channel_name)) {
-                        $channel_ids[] = $channel_id;
+                foreach ($channels as $channelModel) {
+                    if (strtolower($option) == strtolower($channelModel->channel_name)) {
+                        $channel_ids[] = $channelModel->channel_id;
                     }
                 }
             }


### PR DESCRIPTION
For EE7

Resolved #2553 where `{exp:channel:entries}` output could miss some results on MSM installations with duplicate channel names