### PR TITLE
Resolved #2553 where `{exp:channel:entries}` output could miss some results on MSM installations with duplicate channel names

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -1192,7 +1192,7 @@ class Channel
         /**------*/
 
         if ($channel = ee()->TMPL->fetch_param('channel')) {
-            $channels = ee('Model')->get('Channel')->fields('channel_id', 'channel_name')->all(true)->getDictionary('channel_name', 'channel_id');
+            $channels = ee('Model')->get('Channel')->fields('channel_id', 'channel_name')->all(true);
             $channelInOperator = 'IN';
             if (strpos($channel, 'not ') === 0) {
                 $channelInOperator = 'NOT IN';
@@ -1206,9 +1206,9 @@ class Channel
             }
             $channel_ids = array();
             foreach ($options as $option) {
-                foreach ($channels as $channel_name => $channel_id) {
-                    if (strtolower($option) == strtolower($channel_name)) {
-                        $channel_ids[] = $channels[$channel_name];
+                foreach ($channels as $channelModel) {
+                    if (strtolower($option) == strtolower($channelModel->channel_name)) {
+                        $channel_ids[] = $channelModel->channel_id;
                     }
                 }
             }


### PR DESCRIPTION
For EE6

Resolved https://github.com/ExpressionEngine/ExpressionEngine/issues/2553 where {exp:channel:entries} output could miss some results on MSM installations with duplicate channel names