### PR TITLE
Allow module tabs to be displayed as columns in Entry Manager; #645

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pages/tab.pages.php
+++ b/system/ee/ExpressionEngine/Addons/pages/tab.pages.php
@@ -392,6 +392,24 @@ class Pages_tab
         $site->site_pages = $site_pages;
         $site->save();
     }
+
+    public function renderTableCell($data, $field_id, $entry)
+    {
+        $site_pages = ee()->config->item('site_pages');
+        $site_id = ee()->config->item('site_id');
+        $uri = array_key_exists($entry->entry_id, $site_pages[$site_id]['uris']) ? $site_pages[$site_id]['uris'][$entry->entry_id] : '';
+        if (!empty($uri)) {
+            return '<a href="' . str_replace('//', '/', ee()->functions->fetch_site_index(0, 0) . $uri) . '" target="_blank"><i class="fal fa-link"></i></a>';
+        }
+        return '';
+    }
+
+    public function getTableColumnConfig()
+    {
+        return [
+            'encode' => false
+        ];
+    }
 }
 
 // EOF

--- a/system/ee/ExpressionEngine/Addons/structure/tab.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/tab.structure.php
@@ -47,6 +47,23 @@ class Structure_tab
         return $settings;
     }
 
+    public function renderTableCell($data, $field_id, $entry)
+    {
+        $site_pages = $this->sql->get_site_pages(true);
+        $uri = array_key_exists($entry->entry_id, $site_pages['uris']) ? $site_pages['uris'][$entry->entry_id] : '';
+        if (!empty($uri)) {
+            return '<a href="' . Structure_Helper::remove_double_slashes(ee()->functions->fetch_site_index(0, 0) . $uri) . '" target="_blank"><i class="fal fa-link"></i></a>';
+        }
+        return '';
+    }
+
+    public function getTableColumnConfig()
+    {
+        return [
+            'encode' => false
+        ];
+    }
+
     public function display($channel_id, $entry_id = '')
     {
         return $this->publish_tabs($channel_id, $entry_id);

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
@@ -51,6 +51,8 @@ class ColumnFactory
             self::$instances[$identifier] = new $class($identifier);
         } elseif (strpos($identifier, 'field_id_') === 0 && $field = self::getCompatibleField($identifier)) {
             self::$instances[$identifier] = new Columns\CustomField($identifier, $field);
+        } elseif (strpos($identifier, 'tab_') === 0) {
+            self::$instances[$identifier] = new Columns\ModuleTab($identifier);
         } else {
             return null;
         }
@@ -68,7 +70,8 @@ class ColumnFactory
     {
         return array_merge(
             static::getStandardColumns(),
-            static::getCustomFieldColumns($channel)
+            static::getCustomFieldColumns($channel),
+            static::getTabColumns()
         );
     }
 
@@ -122,6 +125,21 @@ class ColumnFactory
     }
 
     /**
+     * Returns Column objects for modules with tabs
+     *
+     * @return array[Column]
+     */
+    protected static function getTabColumns()
+    {
+        return array_map(function ($tab) {
+            if (strpos($tab, 'tab_') !== 0) {
+                $tab = 'tab_' . $tab;
+            }
+            return self::getColumn($tab);
+        }, self::getCompatibleTabs());
+    }
+
+    /**
      * Returns a ChannelField object given a field_id_x identifier
      *
      * @return ChannelField
@@ -148,11 +166,11 @@ class ColumnFactory
      */
     private static function getCompatibleFieldtypes()
     {
-        static $fieldtypes;
-        if (empty($fieldtypes)) {
+        static $fieldtypes = false;
+        if ($fieldtypes === false) {
             $cache_key = '/EntryManager/CompatibleFieldtypes';
             $fieldtypes = ee()->cache->get($cache_key);
-            if (empty($fieldtypes)) {
+            if ($fieldtypes === false) {
                 $fieldtypes = ee('Model')->get('Fieldtype')->all()->pluck('name');
                 ee()->legacy_api->instantiate('channel_fields');
                 $fieldtypes = array_filter($fieldtypes, function ($fieldtype) {
@@ -165,6 +183,40 @@ class ColumnFactory
         }
 
         return $fieldtypes;
+    }
+
+    /**
+     * Return list of tab files that implement ColumnInterface
+     *
+     * @return array[string]
+     */
+    private static function getCompatibleTabs()
+    {
+        static $tabs = false;
+        if ($tabs === false) {
+            $cache_key = '/EntryManager/CompatibleTabs';
+            $tabs = ee()->cache->get($cache_key);
+            if ($tabs === false) {
+                $tabs = [];
+                if (empty(ee()->cp->installed_modules)) {
+                    ee()->cp->get_installed_modules();
+                }
+                foreach (ee()->cp->installed_modules as $module_name) {
+                    $module = ee('Addon')->get($module_name);
+                    if ($module->hasTab()) {
+                        include_once($module->getPath() . '/tab.' . $module_name . '.php');
+                        $class_name = ucfirst($module_name) . '_tab';
+                        $OBJ = new $class_name();
+                        if (method_exists($OBJ, 'renderTableCell') === true) {
+                            $tabs[] = 'tab_' . $module_name;
+                        }
+                    }
+                }
+                ee()->cache->save($cache_key, $tabs);
+            }
+        }
+
+        return $tabs;
     }
 
     /**

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/ModuleTab.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/ModuleTab.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2022, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Library\CP\EntryManager\Columns;
+
+use ExpressionEngine\Library\CP\EntryManager\Columns\Column;
+use ExpressionEngine\Model\Channel\ChannelField;
+use ExpressionEngine\Model\Content\FieldFacade;
+
+/**
+ * Module Tab Column
+ */
+class ModuleTab extends Column
+{
+    private $tab;
+    private $module;
+
+    public function __construct($identifier)
+    {
+        parent::__construct($identifier);
+
+        if (empty($this->tab)) {
+            $module_name = substr($identifier, 4); // strip 'tab_'
+            $this->module = ee('Addon')->get($module_name);
+            include_once($this->module->getPath() . '/tab.' . $module_name . '.php');
+            $class_name = ucfirst($module_name) . '_tab';
+            $this->tab = new $class_name();
+        }
+    }
+
+    public function getTableColumnLabel()
+    {
+        return $this->module->getName();
+    }
+
+    public function getTableColumnConfig()
+    {
+        if (method_exists($this->tab, 'getTableColumnConfig')) {
+            return $this->tab->getTableColumnConfig();
+        }
+
+        return parent::getTableColumnConfig();
+        return [
+            'encode' => false
+        ];
+    }
+
+    public function renderTableCell($data, $field_id, $entry)
+    {
+        return $this->tab->renderTableCell($data, $field_id, $entry);
+    }
+}

--- a/system/ee/ExpressionEngine/Service/Addon/Addon.php
+++ b/system/ee/ExpressionEngine/Service/Addon/Addon.php
@@ -34,7 +34,7 @@ class Addon
         $this->shortname = $provider->getPrefix();
 
         $files = $this->getFilesMatching('*' . $this->getPrefix() . '.php');
-        $possibleComponents = ['upd', 'mcp', 'mod', 'pi', 'ext', 'rtefb', 'upgrade', 'spam', 'jump'];
+        $possibleComponents = ['upd', 'mcp', 'mod', 'pi', 'ext', 'tab', 'rtefb', 'upgrade', 'spam', 'jump'];
         foreach ($possibleComponents as $type) {
             if (in_array($this->getPath() . "/{$type}." . $this->getPrefix() . '.php', $files)) {
                 $this->_components[] = $type;
@@ -515,6 +515,17 @@ class Addon
     public function hasSpam()
     {
         return $this->hasFile('spam');
+    }
+
+
+    /**
+     * Has a tab.* file?
+     *
+     * @return bool TRUE of it does, FALSE if not
+     */
+    public function hasTab()
+    {
+        return $this->hasFile('tab');
     }
 
     /**


### PR DESCRIPTION
Allow module tabs to be displayed as columns in Entry Manager; closes #645

The `tab.module_name.php` files need to implement `renderTableCell` method - see Structure or Pages for an example