### PR TITLE
Resolved issue where Pro Search filters were using Low Search naming

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_filters.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_filters.php
@@ -102,15 +102,20 @@ class Pro_search_filters
                 }
 
                 // Compose file name
-                $file = $dir . "/lsf.{$item}.php";
+                // Compose class name
+                if (version_compare(ee()->config->item('app_version'), '7.0.0', '>=')) {
+                    $file = $dir . "/psf.{$item}.php";
+                    $class = 'Pro_search_filter_' . $item;
+                }
+                else {
+                    $file = $dir . "/lsf.{$item}.php";
+                    $class = 'Low_search_filter_' . $item;
+                }
 
                 // Skip if not a file
                 if (! file_exists($file)) {
                     continue;
                 }
-
-                // Compose class name
-                $class = 'Pro_search_filter_' . $item;
 
                 if (! class_exists($class)) {
                     require_once($file);

--- a/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_filters.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_filters.php
@@ -103,14 +103,8 @@ class Pro_search_filters
 
                 // Compose file name
                 // Compose class name
-                if (version_compare(ee()->config->item('app_version'), '7.0.0', '>=')) {
-                    $file = $dir . "/psf.{$item}.php";
-                    $class = 'Pro_search_filter_' . $item;
-                }
-                else {
-                    $file = $dir . "/lsf.{$item}.php";
-                    $class = 'Low_search_filter_' . $item;
-                }
+                $file = $dir . "/psf.{$item}.php";
+                $class = 'Pro_search_filter_' . $item;
 
                 // Skip if not a file
                 if (! file_exists($file)) {


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

When we moved from low search to pro search.  We have pro search trying to pull in filters from other addons that are still extending off of low search.  My idea was that we separate out based on EE version to avoid errors in pro search whenever someone has another addon that has a filter.

The one thing that is a painpoint doing it this way is that all the addons that have a filter would have to just copy that file give it the name psf.addon_name.php and then change the class line.  (Super quick but seems redundent) and also all the addon managers would have to do that.  But I dont see other way to get around this while keeping addons compatible for ee 7 and ee6 and below.

If someone has better idea please share :)

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
