### PR TITLE
Improved Pro Search collections page UI

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro_search/mcp.pro_search.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/mcp.pro_search.php
@@ -649,8 +649,8 @@ class Pro_search_mcp
                             'title'      => lang('both'),
                             'data-build' => 'both'
                         );
-                    }// make more clear that languages required for these tools. People thought they were missing
-                    else {
+                    } else {
+                        // make more clear that languages required for these tools. People thought they were missing
                         $items['glossary'] = array(
                             'href'       => '#',
                             'title'      => lang('set_langauge_to_use_tool'),

--- a/system/ee/ExpressionEngine/Addons/pro_search/mcp.pro_search.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/mcp.pro_search.php
@@ -649,7 +649,21 @@ class Pro_search_mcp
                             'title'      => lang('both'),
                             'data-build' => 'both'
                         );
+                    }// make more clear that languages required for these tools. People thought they were missing
+                    else {
+                        $items['glossary'] = array(
+                            'href'       => '#',
+                            'title'      => lang('set_langauge_to_use_tool'),
+                            'disabled' => 'true'
+                        );
+
+                        $items['sync'] = array(
+                            'href'       => '#',
+                            'title'      => lang('set_langauge_to_use_tool'),
+                            'disabled' => 'true'
+                        );
                     }
+
 
                     // Add custom row
                     $row[] = array(

--- a/system/ee/language/english/pro_search_lang.php
+++ b/system/ee/language/english/pro_search_lang.php
@@ -164,6 +164,8 @@ $lang = array(
     "lexicon_removed_word" =>
     "Removed “%s”.",
 
+    "set_langauge_to_use_tool" =>
+    "* language setting missing: Pick a language to enable",
     //----------------------------------------
     // Edit collection page - fields
     //----------------------------------------


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

People were confused as to why the new pro search was missing the lexicon tool for collections.  This tool is only run if a language for a collection has been picked.  This just disables and gives that message so it is clearer that we did not remove the tool

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#NN](https://github.com/ExpressionEngine/ExpressionEngine/issues/NN).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/NNN

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
