### PR TITLE
Resolved #2621 where `{exp:channel:entries orderby="view_count_one"}` when used on category page could throw error on MySQL 5.7

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -1821,6 +1821,7 @@ class Channel
 
                             if (count($order_array) - 1 == $key) {
                                 $end .= ", t.entry_date " . $sort_array[$key];
+                                $distinct_select .= ', t.entry_date ';
                             }
 
                             $sort_array[$key] = false;


### PR DESCRIPTION
Resolved #2621 where `{exp:channel:entries orderby="view_count_one"}` when used on category page could throw error on MySQL 5.7