### PR TITLE
Resolved #2622 where deleting several legacy channel fields could cause MySQL error

### DIFF
--- a/system/ee/ExpressionEngine/Service/Model/Query/Delete.php
+++ b/system/ee/ExpressionEngine/Service/Model/Query/Delete.php
@@ -349,6 +349,14 @@ class Delete extends Query
             }
 
             $name = $relation->getName();
+
+            // for delete queries, we don't need full set of columns
+            // ... and some might be already gone because of previous queries
+            $relation_meta = $this->store->getMetaDataReader($relation->getTargetModel());
+            $relation_pk = $relation_meta->getPrimaryKey();
+            if (count($withs)) {
+                $query->fields('CurrentlyDeleting.' . $relation_pk);
+            }
             $models = $query->with($withs)->all();
 
             foreach ($models as $model) {


### PR DESCRIPTION
Resolved #2622 where deleting several legacy channel fields could cause MySQL error

EECORE-2165

The original problem was related to the fact that the fields are using shared `exp_channel_data` table and not their own tables. The delete query is also making select query to get the relationships, and full list of fields is included (which is pre-fetched), but because one field is already deleted, the column would not exist.

I believe full set of fields is not needed and primary key would suffice, however I'm not sure if that's not causing significant slowdown with queries. This needs to be tested well, and not just with channel fields, but deleting different kinds of things in different ways.

