### PR TITLE
Allow swatches in Colorpicker fieldtype to have names

### DIFF
--- a/cp-styles/app/styles/legacy/_key-value-item.scss
+++ b/cp-styles/app/styles/legacy/_key-value-item.scss
@@ -36,7 +36,7 @@
 		}
 
 		.field-control{
-			flex: 1 1 auto;
+			flex: 1 1 0;
 			padding: 0 5px;
 		}
 
@@ -49,7 +49,7 @@
 	display: flex;
 
 		.field-instruct{
-			flex: 1 1 auto;
+			flex: 1 1 0;
 			margin-bottom: 5px;
 
 				label{
@@ -65,7 +65,7 @@
 				}
 
 				&:last-child{
-					padding-left: 0;
+					padding-left: 5px;
 				}
 		}
 }

--- a/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
+++ b/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
@@ -95,7 +95,7 @@ class Colorpicker_ft extends EE_Fieldtype
     {
         ee()->cp->add_js_script('file', array('library/simplecolor', 'components/colorpicker'));
 
-        return $this->create_colorpicker([
+        return $this->createColorPicker([
             'allowedColors' => $this->get_setting('allowed_colors'),
             'inputId' => $this->field_id,
             'inputName' => $this->field_name,
@@ -110,7 +110,7 @@ class Colorpicker_ft extends EE_Fieldtype
      * Creates a color picker input with the specified values
      * The values are passed to the react color picker component
     */
-    private function create_colorpicker($info, $disabled = false)
+    private function createColorPicker($info, $disabled = false)
     {
         $data = base64_encode(json_encode($info));
 
@@ -126,10 +126,10 @@ class Colorpicker_ft extends EE_Fieldtype
     /**
      * Replace the field tag on the frontend.
      *
-     * @param string  Stored data for the field
-     * @param array   The tag's parameters
-     * @param mixed   If the tag is a pair, the tagdata. Otherwise FALSE.
-     * @return string Parsed tagdata
+     * @param string $data Stored data for the field
+     * @param array  $params The tag's parameters
+     * @param mixed  $tagdata If the tag is a pair, the tagdata. Otherwise FALSE.
+     * @return string
      */
     public function replace_tag($data, $params = array(), $tagdata = false)
     {
@@ -138,11 +138,36 @@ class Colorpicker_ft extends EE_Fieldtype
     }
 
     /**
+     * @param string $data Stored data for the field
+     * @param array  $params The tag's parameters
+     * @param mixed  $tagdata If the tag is a pair, the tagdata. Otherwise FALSE.
+     * @return string
+     */
+    public function replace_name($data, $params = [], $tagdata = false)
+    {
+        $swatches = $this->get_setting('value_swatches');
+        $collection = [];
+
+        foreach ($swatches as $swatch) {
+            if (strpos($swatch, '|') !== false) {
+                $parts = explode('|', $swatch);
+                $collection[$parts[0]] = $parts[1];
+            }
+        }
+
+        if (array_key_exists($data, $collection)) {
+            return $collection[$data];
+        }
+
+        return $data;
+    }
+
+    /**
      * :contrast_color modifier
      *
      * Returns a black or white color in contrast to the fields color
      */
-    public function replace_contrast_color($data, $params = array(), $tagdata = false)
+    public function replace_contrast_color($data, $params = [], $tagdata = false)
     {
         try {
             $color = new Color($data);
@@ -170,12 +195,12 @@ class Colorpicker_ft extends EE_Fieldtype
         // The settings contain color picker fields,
         // so when the user chooses the color picker fieldtype, render them
         ee()->javascript->output('$(document).ready(function () {
-			$("input[name=field_type]").change(function () {
-				setTimeout(function () {
-					ColorPicker.renderFields()
-				}, 100);
-			})
-		})');
+            $("input[name=field_type]").change(function () {
+                setTimeout(function () {
+                    ColorPicker.renderFields()
+                }, 100);
+            })
+        })');
 
         $data = array_merge($this->default_settings, $data);
 
@@ -205,12 +230,12 @@ class Colorpicker_ft extends EE_Fieldtype
                 'fields' => [
                     'colorpicker_default_color' => [
                         'type' => 'html',
-                        'content' => $this->create_colorpicker([
+                        'content' => $this->createColorPicker([
                             'allowedColors' => 'any',
                             'initialColor' => $data['colorpicker_default_color'],
                             'inputName' => 'colorpicker_default_color'
                         ])
-                    ]
+                    ],
                 ]
             ],
             [
@@ -280,7 +305,8 @@ class Colorpicker_ft extends EE_Fieldtype
             $data['value_swatches'] = $data['value_swatches']['rows'];
 
             foreach ($data['value_swatches'] as $row) {
-                $value_colors[] = $row['color'];
+                $colorName = isset($row['name']) && $row['name'] !== '' ? '|' . $row['name'] : '';
+                $value_colors[] = $row['color'] . $colorName;
             }
         }
 
@@ -303,7 +329,19 @@ class Colorpicker_ft extends EE_Fieldtype
 
             return $manual_colors;
         } else {
-            return $this->get_setting('value_swatches');
+            $swatches = $this->get_setting('value_swatches');
+            $collection = [];
+
+            foreach ($swatches as $swatch) {
+                if (strpos($swatch, '|') !== false) {
+                    $parts = explode('|', $swatch);
+                    $collection[] = $parts[0];
+                } else {
+                    $collection[] = $swatch;
+                }
+            }
+
+            return $collection;
         }
     }
 
@@ -312,13 +350,19 @@ class Colorpicker_ft extends EE_Fieldtype
         $grid = ee('CP/MiniGridInput', array('field_name' => 'value_swatches'));
 
         $grid->loadAssets();
-        $grid->setColumns(['colors' => ['label' => '']]);
+        $grid->setColumns([
+            'colors' => [
+                'label' => '',
+            ],
+            'name' => [
+                'label' => '',
+            ],
+        ]);
         $grid->setNoResultsText(lang('no_colorpicker_swatches'), lang('add_new'));
 
         $grid->setBlankRow([
-            // array('html' => '<input name="color" />'),
-            // array('html' => form_input('color', ''))
-            array('html' => $this->create_colorpicker(['inputName' => 'color'], true))
+            ['html' => $this->createColorPicker(['inputName' => 'color'], true)],
+            ['html' => form_input('name', '', 'placeholder="Name"')]
         ]);
 
         $grid->setData([]);
@@ -329,15 +373,23 @@ class Colorpicker_ft extends EE_Fieldtype
             $i = 1;
 
             foreach ($data['value_swatches'] as $color) {
+                if (strpos($color, '|') !== false) {
+                    $parts = explode('|', $color);
+                    $color = $parts[0];
+                    $name = $parts[1];
+                }
+
                 $pairs[] = array(
                     'attrs' => array('row_id' => $i),
                     'columns' => array(
-                        // array('html' => form_input('color', $color))
                         [
-                            'html' => $this->create_colorpicker([
+                            'html' => $this->createColorPicker([
                                 'initialColor' => $color,
                                 'inputName' => 'color'
                             ])
+                        ],
+                        [
+                            'html' => form_input('name', $name ?? '')
                         ]
                     )
                 );

--- a/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
+++ b/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
@@ -352,17 +352,17 @@ class Colorpicker_ft extends EE_Fieldtype
         $grid->loadAssets();
         $grid->setColumns([
             'colors' => [
-                'label' => '',
+                'label' => 'Color',
             ],
             'name' => [
-                'label' => '',
+                'label' => 'Name',
             ],
         ]);
         $grid->setNoResultsText(lang('no_colorpicker_swatches'), lang('add_new'));
 
         $grid->setBlankRow([
             ['html' => $this->createColorPicker(['inputName' => 'color'], true)],
-            ['html' => form_input('name', '', 'placeholder="Name"')]
+            ['html' => form_input('name', '')]
         ]);
 
         $grid->setData([]);
@@ -373,6 +373,8 @@ class Colorpicker_ft extends EE_Fieldtype
             $i = 1;
 
             foreach ($data['value_swatches'] as $color) {
+                $name = '';
+
                 if (strpos($color, '|') !== false) {
                     $parts = explode('|', $color);
                     $color = $parts[0];

--- a/themes/ee/cp/css/common.min.css
+++ b/themes/ee/cp/css/common.min.css
@@ -37433,7 +37433,7 @@ body[data-theme="dark"] {
   background-color: transparent;
 }
 .fields-keyvalue-item .field-control {
-  flex: 1 1 auto;
+  flex: 1 1 0;
   padding: 0 5px;
 }
 .fields-keyvalue-item .field-control:first-of-type {
@@ -37444,7 +37444,7 @@ body[data-theme="dark"] {
   display: flex;
 }
 .fields-keyvalue-header .field-instruct {
-  flex: 1 1 auto;
+  flex: 1 1 0;
   margin-bottom: 5px;
 }
 .fields-keyvalue-header .field-instruct label {
@@ -37457,7 +37457,7 @@ body[data-theme="dark"] {
   padding-right: 0;
 }
 .fields-keyvalue-header .field-instruct:last-child {
-  padding-left: 0;
+  padding-left: 5px;
 }
 
 /*


### PR DESCRIPTION
## Overview

Color picker is great, but the hex color value doesn't jive well with site css. Usually colors or themes are given a name and assigned through a class instead of relying on `<div style="color: {colorpicker_field}">` this change provides an optional Name field so we use `div class="my-thing__{colorpicker_field:name}">` instead.

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [x] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security 

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
If this gets approved in this form or some form I'll update the docs

