### PR TITLE
Improved PHP 8.1 support

### DIFF
--- a/system/ee/ExpressionEngine/Library/Advisor/TemplateAdvisor.php
+++ b/system/ee/ExpressionEngine/Library/Advisor/TemplateAdvisor.php
@@ -69,11 +69,13 @@ class TemplateAdvisor
                     'link' => ee('CP/URL', 'cp/design/snippets/edit/' . $template->getId())->compile()
                 ];
             }
+			
+			$template_data = (empty($template_data)) ? '' : $template_data;
 
             $template_data = ee()->template->remove_ee_comments($template_data);
 
             $tags_found = preg_match_all($regexp, $template_data, $keys, PREG_PATTERN_ORDER);
-
+			
             $tmpl_info['details'][] = $keys;
 
             foreach ($keys[0] as $key) {

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -2964,7 +2964,7 @@ class EE_Template
      */
     public function remove_ee_comments($str)
     {
-        if (strpos($str, '{!--') === false) {
+        if (strpos((string) $str, '{!--') === false) {
             return $str;
         }
 


### PR DESCRIPTION
While I wasn't able to replicate, had a user getting

> Severity: E_DEPRECATED Deprecated preg_match_all(): Passing null to parameter [#2](https://expressionengine.zendesk.com/agent/tickets/2) ($subject) of type string is deprecated ee/ExpressionEngine/Library/Advisor/TemplateAdvisor.php, line 75

> Severity: E_DEPRECATED Deprecated strpos(): Passing null to parameter [#1](https://expressionengine.zendesk.com/agent/tickets/1) ($haystack) of type string is deprecated ee/legacy/libraries/Template.php, line 2967

Running 6.4.2 php 8.1.  I'm slightly suspicious it could be unique, but it seemed worthwhile adding the check/cast.