### PR TITLE
Resolved #2658 where some parameters were not available for member management forms

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_images.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_images.php
@@ -211,13 +211,19 @@ class Member_images extends Member
 
         //if we run EE template parser, do some things differently
         if (! empty($tagdata)) {
-            return ee()->functions->form_declaration(array(
-                'enctype' => 'multi',
-                'hidden_fields' => array(
-                    'RET' => (ee()->TMPL->fetch_param('return') && ee()->TMPL->fetch_param('return') != "") ? ee()->functions->create_url(ee()->TMPL->fetch_param('return')) : ee()->functions->fetch_current_uri(),
-                    'ACT' => ee()->functions->fetch_action_id('Member', 'upload_avatar')
-                )
-            )) . $template . '</form>';
+            if (ee()->TMPL->fetch_param('form_name', '') != "") {
+	            $data['name'] = ee()->TMPL->fetch_param('form_name');
+	        }
+
+	        $data['id'] = ee()->TMPL->form_id;
+	        $data['class'] = ee()->TMPL->form_class;
+			$data['enctype'] = 'multi';
+
+            $data['hidden_fields'] = array(
+                'RET' => (ee()->TMPL->fetch_param('return', '') != "") ? ee()->functions->create_url(ee()->TMPL->fetch_param('return')) : ee()->functions->fetch_current_uri(),
+                'ACT' => ee()->functions->fetch_action_id('Member', 'upload_avatar'));
+
+            return ee()->functions->form_declaration($data) . $template . '</form>';
         }
 
         // Finalize the template

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_memberlist.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_memberlist.php
@@ -859,13 +859,19 @@ class Member_memberlist extends Member
         }
 
         if ($is_search_form && !empty($tagdata)) {
-            $template = ee()->functions->form_declaration(array(
-                'hidden_fields' => array(
-                    'ACT' => ee()->functions->fetch_action_id('Member', 'do_member_search'),
-                    'RET' => ee()->TMPL->fetch_param('return') != '' ? ee()->TMPL->fetch_param('return') : str_replace($search_path, '', $result_page),
-                    'no_result_page' => ee()->TMPL->fetch_param('no_result_page')
-                )
-            )) . $template . '</form>';
+            if (ee()->TMPL->fetch_param('form_name', '') != "") {
+	            $data['name'] = ee()->TMPL->fetch_param('form_name');
+	        }
+
+	        $data['id'] = ee()->TMPL->form_id;
+	        $data['class'] = ee()->TMPL->form_class;
+
+            $data['hidden_fields'] = array(
+                'ACT' => ee()->functions->fetch_action_id('Member', 'do_member_search'),
+                'RET' => ee()->TMPL->fetch_param('return') != '' ? ee()->TMPL->fetch_param('return') : str_replace($search_path, '', $result_page),
+                'no_result_page' => ee()->TMPL->fetch_param('no_result_page'));
+
+            $template = ee()->functions->form_declaration($data) . $template . '</form>';
         } else {
             $template = str_replace(LD . "form_declaration" . RD, $form_open, $template);
             $form_open_member_search = ee()->functions->form_declaration(array(

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
@@ -839,13 +839,18 @@ class Member_settings extends Member
             ee()->channel_form_lib->datepicker = get_bool_from_string(ee()->TMPL->fetch_param('datepicker', 'y'));
             ee()->channel_form_lib->compile_js();
 
-            $return = ee()->functions->form_declaration(array(
-                'id' => 'cform',
-                'hidden_fields' => array(
-                    'RET' => (ee()->TMPL->fetch_param('return') && ee()->TMPL->fetch_param('return') != "") ? ee()->functions->create_url(ee()->TMPL->fetch_param('return')) : ee()->functions->fetch_current_uri(),
-                    'ACT' => ee()->functions->fetch_action_id('Member', 'update_profile')
-                )
-            )) . $template . '</form>';
+            if (ee()->TMPL->fetch_param('form_name', '') != "") {
+                $data['name'] = ee()->TMPL->fetch_param('form_name');
+            }
+
+            $data['id'] = 'cform'
+            $data['class'] = ee()->TMPL->form_class;
+
+            $data['hidden_fields'] = array(
+                'RET' => (ee()->TMPL->fetch_param('return') && ee()->TMPL->fetch_param('return') != "") ? ee()->functions->create_url(ee()->TMPL->fetch_param('return')) : ee()->functions->fetch_current_uri(),
+                'ACT' => ee()->functions->fetch_action_id('Member', 'update_profile'));
+
+            $return = ee()->functions->form_declaration($data) . $template . '</form>';
             //make head appear by default
             if (preg_match('/' . LD . 'form_assets' . RD . '/', $return)) {
                 $return = ee()->TMPL->swap_var_single('form_assets', ee()->channel_form_lib->head, $return);

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
@@ -843,7 +843,7 @@ class Member_settings extends Member
                 $data['name'] = ee()->TMPL->fetch_param('form_name');
             }
 
-            $data['id'] = 'cform'
+            $data['id'] = 'cform';
             $data['class'] = ee()->TMPL->form_class;
 
             $data['hidden_fields'] = array(

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
@@ -848,7 +848,8 @@ class Member_settings extends Member
 
             $data['hidden_fields'] = array(
                 'RET' => (ee()->TMPL->fetch_param('return') && ee()->TMPL->fetch_param('return') != "") ? ee()->functions->create_url(ee()->TMPL->fetch_param('return')) : ee()->functions->fetch_current_uri(),
-                'ACT' => ee()->functions->fetch_action_id('Member', 'update_profile'));
+                'ACT' => ee()->functions->fetch_action_id('Member', 'update_profile')
+            );
 
             $return = ee()->functions->form_declaration($data) . $template . '</form>';
             //make head appear by default


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview

Makes Member Management front-end forms more consistent, per feature request. `{exp:member:edit_profile}` is hardcoding the form `id="cform"` and this has been left as-is; otherwise all form tags referenced can now accept `form_class`, `form_name` and `form_id`. Suggest no reason that this isn't made available in v6 too.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#2658](https://github.com/ExpressionEngine/ExpressionEngine/issues/2658).

## Nature of This Change

<!-- Check all that apply: -->

- [ ] 🐛 Fixes a bug
- [x] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
