### PR TITLE
Resolved #2663 where forgot password form could generate erroneous reset URLs

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -768,11 +768,11 @@ class Member_auth extends Member
                 $reset_url = ee()->functions->fetch_site_index(0, 0) . '/' . $reset_url;
             }
         } else {
-            $reset_url = reduce_double_slashes(ee()->functions->fetch_site_index(0, 0) . '/' . ee()->config->item('profile_trigger') . '/reset_password');
+            $reset_url = ee()->functions->fetch_site_index(0, 0) . '/' . ee()->config->item('profile_trigger') . '/reset_password';
         }
 
         // Add the reset code and possible forum_id to the reset pass url.
-        $reset_url .= '?id=' . $resetcode . $forum_id;
+        $reset_url = reduce_double_slashes($reset_url . '?id=' . $resetcode . $forum_id);
 
         if (! empty($protected['email_template'])) {
             $email_template = ee()->TMPL->fetch_template_and_parse_from_path($protected['email_template']);


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Moves the reduce_double_slashes($reset_url) function down a line so it picks up from both branches of the if-statement

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#2663](https://github.com/ExpressionEngine/ExpressionEngine/issues/2663).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No
