### PR TITLE
Resolves #2667 to allow show_user_error() to handle 2D array of errors

### DIFF
--- a/system/ee/legacy/core/Output.php
+++ b/system/ee/legacy/core/Output.php
@@ -658,7 +658,13 @@ class EE_Output
             $content .= "<li>" . $errors . "</li>\n";
         } else {
             foreach ($errors as $val) {
-                $content .= "<li>" . $val . "</li>\n";
+                if (! is_array($val)) {
+                    $content .= "<li>" . $val . "</li>\n";
+                } else {
+                    foreach ($val as $child_val) {
+                        $content .= "<li>" . $child_val . "</li>\n";
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
## Overview
Allow for show_user_errors to handle 2nd dimension array of errors, such as those that can be produced by `{exp:member:reset_password_form}`.

This is a very quick fix that solves the issue I encountered with `{exp:member:reset_password_form}` but I'm always nervous when suggesting changes to a core library! Happy for EE team to propose a more suitable solution if this fix has unintended breaking consequences.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#2667](https://github.com/ExpressionEngine/ExpressionEngine/issues/2667).

Revised output when change is implemented:
![image](https://user-images.githubusercontent.com/17785714/209230502-5a15e406-3f46-45eb-8906-0bb9f1103cc2.png)

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No