### PR TITLE
update GitHub actions and add PSR-12 check

### DIFF
--- a/.github/workflows/feature-test.cypress.minimal.yml
+++ b/.github/workflows/feature-test.cypress.minimal.yml
@@ -20,10 +20,10 @@ jobs:
         steps:
 
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Checkout Pro
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: EllisLab/ExpressionEngine-Pro
                 token: ${{ secrets.ORG_ACCESS_TOKEN }}
@@ -83,22 +83,21 @@ jobs:
                 ls -lar tests/cypress/support/templates/pro.group/
 
             - name: Run Cypress Tests
-              uses: cypress-io/github-action@v2
+              uses: cypress-io/github-action@v5
               with:
                 browser: chrome
-                headless: true
                 working-directory: tests/cypress
                 config-file: feature.cypress.json
 
             - name: Archive screenshots
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: failure()
               with:
                 name: cypress-tests
                 path: tests/cypress/cypress/screenshots/
 
             - name: Archive server errors
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: failure()
               with:
                 name: error.log

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -33,6 +33,10 @@ jobs:
                 tools: phpcs, cs2pr
                 ini-values: error_log=/home/runner/php_errors.log, memory_limit=512M
 
+          - name: Install dependencies
+            working-directory: build-tools
+            run: composer install
+
           - name: Check PHP code style
             id: check
             continue-on-error: true

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -30,9 +30,13 @@ jobs:
                 php-version: '8.1'
                 extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick
                 coverage: none
-                tools: php-cs-fixer, cs2pr
+                tools: phpcs, cs2pr
                 ini-values: error_log=/home/runner/php_errors.log, memory_limit=512M
 
           - name: Check PHP code style
-            id: phpcs
+            id: check
+            run: phpcs --standard=phpcs.ruleset.xml --report=checkstyle ${{ steps.changed_files.outputs.all_changed_files }}
+
+          - name: Update the PR
+            id: display
             run: phpcs --standard=phpcs.ruleset.xml --report=checkstyle ${{ steps.changed_files.outputs.all_changed_files }} | cs2pr

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -40,9 +40,4 @@ jobs:
           - name: Check PHP code style
             id: check
             continue-on-error: true
-            run: phpcs --standard=phpcs.ruleset.xml --report=checkstyle ${{ steps.changed_files.outputs.all_changed_files }}
-
-          - name: Update the PR
-            id: display
-            continue-on-error: true
-            run: phpcs --standard=phpcs.ruleset.xml --report=checkstyle ${{ steps.changed_files.outputs.all_changed_files }} | cs2pr
+            run: phpcs -p -vvv --standard=phpcs.ruleset.xml --report=checkstyle ${{ steps.changed_files.outputs.all_changed_files }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -35,8 +35,10 @@ jobs:
 
           - name: Check PHP code style
             id: check
+            continue-on-error: true
             run: phpcs --standard=phpcs.ruleset.xml --report=checkstyle ${{ steps.changed_files.outputs.all_changed_files }}
 
           - name: Update the PR
             id: display
+            continue-on-error: true
             run: phpcs --standard=phpcs.ruleset.xml --report=checkstyle ${{ steps.changed_files.outputs.all_changed_files }} | cs2pr

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -27,7 +27,7 @@ jobs:
           - name: Setup PHP
             uses: shivammathur/setup-php@v2
             with:
-                php-version: '7.4'
+                php-version: '8.1'
                 extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick
                 coverage: none
                 tools: phpcs, cs2pr
@@ -40,4 +40,4 @@ jobs:
           - name: Check PHP code style
             id: check
             continue-on-error: true
-            run: phpcs -p -vvv --standard=phpcs.ruleset.xml --report=checkstyle ${{ steps.changed_files.outputs.all_changed_files }}
+            run: phpcs --standard=phpcs.ruleset.xml --report=checkstyle ${{ steps.changed_files.outputs.all_changed_files }} | cs2pr

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -35,5 +35,4 @@ jobs:
 
           - name: Check PHP code style
             id: phpcs
-            run: |
-              php-cs-fixer fix -vvv --dry-run --config=.php-cs-fixer.dist.php --format=checkstyle ${{ steps.changed_files.outputs.all_changed_files }} | cs2pr
+            run: phpcs --standard=phpcs.ruleset.xml --report=checkstyle ${{ steps.changed_files.outputs.all_changed_files }} | cs2pr

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -27,7 +27,7 @@ jobs:
           - name: Setup PHP
             uses: shivammathur/setup-php@v2
             with:
-                php-version: '8.1'
+                php-version: '7.4'
                 extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick
                 coverage: none
                 tools: phpcs, cs2pr

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,39 @@
+name: PSR-12
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - '*.dev'
+
+jobs:
+    check:
+
+        name: PSR-12 compatibility check
+
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@v3
+            with:
+              ref: ${{ github.event.pull_request.head.sha }}
+
+          - name: Get changed files
+            id: changed_files
+            uses: tj-actions/changed-files@v35
+            with:
+              separator: " "
+
+          - name: Setup PHP
+            uses: shivammathur/setup-php@v2
+            with:
+                php-version: '8.1'
+                extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick
+                coverage: none
+                tools: php-cs-fixer, cs2pr
+                ini-values: error_log=/home/runner/php_errors.log, memory_limit=512M
+
+          - name: Check PHP code style
+            id: phpcs
+            run: |
+              php-cs-fixer fix -vvv --dry-run --config=.php-cs-fixer.dist.php --format=checkstyle ${{ steps.changed_files.outputs.all_changed_files }} | cs2pr

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -15,18 +15,18 @@ jobs:
       version: ${{ steps.build_json.outputs.BUILD_VERSION }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-            php-version: '7.4'
+            php-version: '8.1'
             extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick
             coverage: none
             ini-values: error_log=/home/runner/php_errors.log, memory_limit=128M
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '10'
 
@@ -46,7 +46,7 @@ jobs:
         working-directory: build-tools
         run: |
           content=`node -pe 'JSON.parse(process.argv[1]).tag' "$(cat build.json)"`
-          echo "::set-output name=BUILD_VERSION::$content"
+          echo "BUILD_VERSION=$content" >> $GITHUB_OUTPUT
 
       - name: Run build process
         working-directory: build-tools
@@ -58,7 +58,7 @@ jobs:
           gulp app --local --nogit --head --skip-lint --jira-collector --skip-pro --version=${{ steps.build_json.outputs.BUILD_VERSION }}
 
       - name: Archive Build files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: EE${{ steps.build_json.outputs.BUILD_VERSION }}
           path: build-tools/builds
@@ -87,21 +87,19 @@ jobs:
         with:
           repository: ExpressionEngine/ExpressionEngine
           regex: '^\d+\.\d+\.\d+$'
-
-      - name: Fetch list of tags
-        run: |
-          git fetch --tags
+          releases-only: true
 
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v1
+        uses: mikepenz/release-changelog-builder-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
         with:
           fromTag: ${{ steps.prev_release_tag.outputs.tag }}
+          toTag: ${{ steps.build_json.outputs.BUILD_VERSION }}
           configuration: build-tools/changelog.config.json
 
-      - uses: ncipollo/release-action@v1.10.0
+      - uses: ncipollo/release-action@v1.12.0
         with:
           artifacts: "build-tools/builds/ExpressionEngine*,build-tools/builds/signature*"
           name: ExpressionEngine ${{ steps.build_json.outputs.BUILD_VERSION }} DP ${{ env.dp_ver }}
@@ -136,7 +134,7 @@ jobs:
       steps:
 
             - name: Checkout repo
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 repository: ExpressionEngine/ExpressionEngine
                 path: __repo
@@ -202,22 +200,21 @@ jobs:
               run: php -S localhost:8888 &
 
             - name: Run Cypress Tests
-              uses: cypress-io/github-action@v2
+              uses: cypress-io/github-action@v5
               with:
                 browser: chrome
-                headless: true
                 working-directory: tests/cypress
                 config-file: updater.cypress.json
 
             - name: Archive screenshots
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: failure()
               with:
                 name: cypress-tests-updater
                 path: tests/cypress/cypress/screenshots/
 
             - name: Archive server errors
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: failure()
               with:
                 name: updater.error.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,18 @@ jobs:
         id: tagName
       
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-            php-version: '7.4'
+            php-version: '8.1'
             extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick
             coverage: none
             ini-values: error_log=/home/runner/php_errors.log, memory_limit=128M
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '10'
       
@@ -50,10 +50,11 @@ jobs:
           gulp app --local --head --skip-lint --skip-pro --version=${{ steps.tagName.outputs.tag }}
   
       - name: Archive Build files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: EE${{ steps.tagName.outputs.tag }}
           path: build-tools/builds
+
       - name: Get previous release tag
         id: prev_release_tag
         continue-on-error: true
@@ -61,24 +62,24 @@ jobs:
         with:
           repository: ExpressionEngine/ExpressionEngine
           regex: '^\d+\.\d+\.\d+$'
-      #- name: Fetch list of tags
-      #  run: |
-      #    git fetch --tags
-      #- name: Build Changelog
-      #  id: build_changelog
-      #  uses: mikepenz/release-changelog-builder-action@v1
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
-      #  with:
-      #    fromTag: ${{ steps.prev_release_tag.outputs.tag }}
-      #    configuration: build-tools/changelog.config.json
-      - uses: ncipollo/release-action@v1.10.0
+
+      - name: Build Changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.ORG_ACCESS_TOKEN }}
+        with:
+          fromTag: ${{ steps.prev_release_tag.outputs.tag }}
+          toTag: ${{ steps.build_json.outputs.BUILD_VERSION }}
+          configuration: build-tools/changelog.config.json
+
+      - uses: ncipollo/release-action@v1.12.0
         with:
           artifacts: "build-tools/builds/ExpressionEngine*,build-tools/builds/signature*"
           name: ExpressionEngine ${{ steps.tagName.outputs.tag }}
           allowUpdates: true
           token: ${{ secrets.ORG_ACCESS_TOKEN }}
-          body: ExpressionEngine ${{ steps.tagName.outputs.tag }}
+          body: ${{ steps.build_changelog.outputs.changelog }}
       - name: Directory Listing on Failure
         if: failure()
         run: |

--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -25,10 +25,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Checkout code
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
 
           - name: Cache repository info
-            uses: actions/cache@v2
+            uses: actions/cache@v3
             with:
               path: .git
               key: cache-ee-git-${{ github.sha }}
@@ -36,13 +36,13 @@ jobs:
           - name: Setup PHP
             uses: shivammathur/setup-php@v2
             with:
-                php-version: '7.4'
+                php-version: '8.1'
                 extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick
                 coverage: none
                 ini-values: error_log=/home/runner/php_errors.log, memory_limit=128M
 
           - name: Setup node
-            uses: actions/setup-node@v2
+            uses: actions/setup-node@v3
             with:
               node-version: '10'
 
@@ -55,7 +55,7 @@ jobs:
             working-directory: build-tools
             run: |
               content=`node -pe 'JSON.parse(process.argv[1]).tag' "$(cat build.json)"`
-              echo "::set-output name=BUILD_VERSION::$content"
+              echo "BUILD_VERSION=$content" >> $GITHUB_OUTPUT
 
           - name: Run build process 
             working-directory: build-tools
@@ -71,7 +71,7 @@ jobs:
               mv ExpressionEngine${{ steps.build_json.outputs.BUILD_VERSION }} ExpressionEngine
 
           - name: Cache built EE version
-            uses: actions/cache@v2
+            uses: actions/cache@v3
             with:
               path: build-tools/builds/ExpressionEngine
               key: cache-ee-build-${{ github.sha }}
@@ -98,7 +98,7 @@ jobs:
         steps:
 
             - name: Use cached EE build
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                 path: build-tools/builds/ExpressionEngine
                 key: cache-ee-build-${{ github.sha }}
@@ -109,7 +109,7 @@ jobs:
                 cp -R build-tools/builds/ExpressionEngine/. ./
             
             - name: Restore cached git history
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                 path: .git
                 key: cache-ee-git-${{ github.sha }}
@@ -176,16 +176,15 @@ jobs:
               env:
                 CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
               run: |
-                echo "::set-output name=SPECS::$(node tests/cypress-split.js 10 ${{ matrix.containers }})"
+                echo "SPECS=$(node tests/cypress-split.js 10 ${{ matrix.containers }})" >> $GITHUB_OUTPUT
               id: specs
 
             - name: Run Cypress Tests (without dashboard)
-              uses: cypress-io/github-action@v2
+              uses: cypress-io/github-action@v5
               if: "${{ env.CYPRESS_RECORD_KEY == '' }}"
               with:
                 spec: ${{ steps.specs.outputs.SPECS }}
                 browser: chrome
-                headless: true
                 working-directory: tests/cypress
                 config-file: cypress.json
               env:
@@ -197,11 +196,10 @@ jobs:
                 chrome-version: beta
 
             - name: Run Cypress Tests
-              uses: cypress-io/github-action@v2
+              uses: cypress-io/github-action@v5
               if: "${{ env.CYPRESS_RECORD_KEY != '' }}"
               with:
                 browser: chrome
-                headless: true
                 working-directory: tests/cypress
                 config-file: cypress.json
                 record: true
@@ -214,21 +212,21 @@ jobs:
                 COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
 
             - name: Archive screenshots
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: failure()
               with:
                 name: cypress-tests-PHP${{ matrix.php }}-${{ matrix.containers }}
                 path: tests/cypress/cypress/screenshots/
 
             - name: Archive server errors
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: failure()
               with:
                 name: error.PHP${{ matrix.php }}-${{ matrix.containers }}.log
                 path: /home/runner/php_errors.log
 
             - name: Archive performance logs
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               with:
                 name: csv-reports.PHP${{ matrix.php }}-${{ matrix.containers }}
                 path: tests/cypress/cypress/downloads/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Checkout code
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
 
           - name: Cache repository info
-            uses: actions/cache@v2
+            uses: actions/cache@v3
             with:
               path: .git
               key: cache-ee-git-${{ github.sha }}
@@ -35,13 +35,13 @@ jobs:
           - name: Setup PHP
             uses: shivammathur/setup-php@v2
             with:
-                php-version: '7.4'
+                php-version: '8.1'
                 extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick
                 coverage: none
                 ini-values: error_log=/home/runner/php_errors.log, memory_limit=128M
 
           - name: Setup node
-            uses: actions/setup-node@v2
+            uses: actions/setup-node@v3
             with:
               node-version: '10'
 
@@ -54,7 +54,7 @@ jobs:
             working-directory: build-tools
             run: |
               content=`node -pe 'JSON.parse(process.argv[1]).tag' "$(cat build.json)"`
-              echo "::set-output name=BUILD_VERSION::$content"
+              echo "BUILD_VERSION=$content" >> $GITHUB_OUTPUT
 
           - name: Run build process
             working-directory: build-tools
@@ -70,7 +70,7 @@ jobs:
               mv ExpressionEngine${{ steps.build_json.outputs.BUILD_VERSION }} ExpressionEngine
 
           - name: Cache built EE version
-            uses: actions/cache@v2
+            uses: actions/cache@v3
             with:
               path: build-tools/builds/ExpressionEngine
               key: cache-ee-build-${{ github.sha }}
@@ -111,13 +111,31 @@ jobs:
                   - php: 8.1
                     os: ubuntu-latest
                     containers: 5
+                  - php: 8.2
+                    os: ubuntu-latest
+                    containers: 0
+                  - php: 8.2
+                    os: ubuntu-latest
+                    containers: 1
+                  - php: 8.2
+                    os: ubuntu-latest
+                    containers: 2
+                  - php: 8.2
+                    os: ubuntu-latest
+                    containers: 3
+                  - php: 8.2
+                    os: ubuntu-latest
+                    containers: 4
+                  - php: 8.2
+                    os: ubuntu-latest
+                    containers: 5
 
         name: Cypress Tests, PHP${{ matrix.php }} - ${{ matrix.os }} ${{ matrix.containers }}
 
         steps:
 
             - name: Use cached EE build
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                 path: build-tools/builds/ExpressionEngine
                 key: cache-ee-build-${{ github.sha }}
@@ -127,7 +145,7 @@ jobs:
                 cp -R build-tools/builds/ExpressionEngine/* ./
 
             - name: Restore cached git history
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                 path: .git
                 key: cache-ee-git-${{ github.sha }}
@@ -197,11 +215,10 @@ jobs:
 
             - name: Run Cypress Tests
               if: matrix.php != '5.6'
-              uses: cypress-io/github-action@v2
+              uses: cypress-io/github-action@v5
               with:
                 # spec: ${{ steps.specs.outputs.SPECS }}
                 browser: chrome
-                headless: true
                 working-directory: tests/cypress
                 config-file: cypress.json
                 record: true
@@ -214,10 +231,9 @@ jobs:
 
             - name: Run Cypress Tests (PHP 5.6)
               if: matrix.php == '5.6'
-              uses: cypress-io/github-action@v2
+              uses: cypress-io/github-action@v5
               with:
                 browser: chrome
-                headless: true
                 working-directory: tests/cypress
                 config-file: cypress.without-pro.json
                 record: true
@@ -229,14 +245,14 @@ jobs:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Archive screenshots
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: failure()
               with:
                 name: cypress-tests-PHP${{ matrix.php }}-${{ matrix.containers }}
                 path: tests/cypress/cypress/screenshots/
 
             - name: Archive server errors
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: failure()
               with:
                 name: error.PHP${{ matrix.php }}-${{ matrix.containers }}.log

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,10 +25,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Checkout code
-            uses: actions/checkout@v2
+            uses: actions/checkout@v3
 
           - name: Cache repository info
-            uses: actions/cache@v2
+            uses: actions/cache@v3
             with:
               path: .git
               key: cache-ee-git-${{ github.sha }}
@@ -36,13 +36,13 @@ jobs:
           - name: Setup PHP
             uses: shivammathur/setup-php@v2
             with:
-                php-version: '7.4'
+                php-version: '8.1'
                 extensions: dom, curl, sqlite, libxml, mbstring, zip, pcntl, pdo, mysql, bcmath, soap, intl, gd, exif, iconv, imagick
                 coverage: none
                 ini-values: error_log=/home/runner/php_errors.log, memory_limit=128M
 
           - name: Setup node
-            uses: actions/setup-node@v2
+            uses: actions/setup-node@v3
             with:
               node-version: '10'
 
@@ -55,7 +55,7 @@ jobs:
             working-directory: build-tools
             run: |
               content=`node -pe 'JSON.parse(process.argv[1]).tag' "$(cat build.json)"`
-              echo "::set-output name=BUILD_VERSION::$content"
+              echo "BUILD_VERSION=$content" >> $GITHUB_OUTPUT
 
           - name: Run build process 
             working-directory: build-tools
@@ -71,7 +71,7 @@ jobs:
               mv ExpressionEngine${{ steps.build_json.outputs.BUILD_VERSION }} ExpressionEngine
 
           - name: Cache built EE version
-            uses: actions/cache@v2
+            uses: actions/cache@v3
             with:
               path: build-tools/builds/ExpressionEngine
               key: cache-ee-build-${{ github.sha }}
@@ -114,10 +114,10 @@ jobs:
                 sudo locale-gen ru
             
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
 
             - name: Use cached EE build
-              uses: actions/cache@v2
+              uses: actions/cache@v3
               with:
                 path: build-tools/builds/ExpressionEngine
                 key: cache-ee-build-${{ github.sha }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,7 +24,7 @@ return (new PhpCsFixer\Config)
         'method_chaining_indentation' => true,
         'no_blank_lines_after_phpdoc' => true,
         'no_extra_blank_lines' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'no_spaces_around_offset' => true,
         'no_whitespace_before_comma_in_array' => true,
         'normalize_index_brace' => true,

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,8 +5,8 @@ $finder = PhpCsFixer\Finder::create()
     ->exclude('vendor')
     ->in(__DIR__);
 
-return (new PhpCsFixer\Config)
-    ->setRules([
+$config = new PhpCsFixer\Config();
+return $config->setRules([
         '@PSR12' => true,
         'array_indentation' => true,
         'binary_operator_spaces' => [
@@ -17,7 +17,7 @@ return (new PhpCsFixer\Config)
         ],
         'blank_line_before_statement' => true,
         'cast_spaces' => true,
-        'concat_space' => [ 'spacing' => 'one' ],
+        'concat_space' => ['spacing' => 'one'],
         'indentation_type' => true,
         'linebreak_after_opening_tag' => true,
         'lowercase_static_reference' => false,

--- a/build-tools/changelog.config.json
+++ b/build-tools/changelog.config.json
@@ -18,6 +18,6 @@
     ],
     "sort": "DESC",
     "template": "${{CHANGELOG}}",
-    "pr_template": "- ${{TITLE}}\n   - PR: #${{NUMBER}}",
+    "pr_template": "- ${{TITLE}}",
     "empty_template": "- no changes"
   }

--- a/build-tools/composer.json
+++ b/build-tools/composer.json
@@ -1,7 +1,6 @@
 {
     "require-dev": {
-        "phpcompatibility/php-compatibility": "*",
-        "phpstan/phpstan": "*"
+        "phpcompatibility/php-compatibility": "*"
     },
     "prefer-stable" : true
 }

--- a/build-tools/composer.lock
+++ b/build-tools/composer.lock
@@ -4,72 +4,126 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcbbd9429325d9d43bba1ff48f332537",
+    "content-hash": "9e5b30b9124996de9576aa6a679a5fa1",
     "packages": [],
     "packages-dev": [
         {
-            "name": "phpstan/phpstan",
-            "version": "1.2.0",
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "cbe085f9fdead5b6d62e4c022ca52dc9427a10ee"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cbe085f9fdead5b6d62e4c022ca52dc9427a10ee",
-                "reference": "cbe085f9fdead5b6d62e4c022ca52dc9427a10ee",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
             },
             "conflict": {
-                "phpstan/phpstan-shim": "*"
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "phpstan",
-                "phpstan.phar"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
-            "description": "PHPStan - PHP Static Analysis Tool",
-            "support": {
-                "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.2.0"
-            },
-            "funding": [
+            "authors": [
                 {
-                    "url": "https://github.com/ondrejmirtes",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/phpstan",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/phpstan",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
-                    "type": "tidelift"
+                    "name": "Greg Sherwood",
+                    "role": "lead"
                 }
             ],
-            "time": "2021-11-18T14:09:01+00:00"
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2022-06-18T07:21:10+00:00"
         }
     ],
     "aliases": [],
@@ -79,5 +133,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -14,6 +14,7 @@
         <exclude name="PSR2.Methods.MethodDeclaration" />
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
         <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock" />
+        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore" />
     </rule>
 
 </ruleset>

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -5,17 +5,12 @@
     <arg name="extensions" value="php"/>
     <arg name="tab-width" value="4"/>
 
-    <config name="installed_paths" value="build-tools/vendor/phpcompatibility/php-compatibility" />
-
-    <!-- Run against the PHPCompatibility ruleset -->
-    <rule ref="PHPCompatibility" />
-
-    <!-- Check for cross-version support for PHP 7.2 and higher. -->
-    <config name="testVersion" value="7.2-"/>
-
     <!-- Code MUST follow all rules outlined in PSR-12. -->
     <rule ref="PSR12">
         <exclude name="Generic.Files.LineLength" />
+        <exclude name="Generic.Files.LineEndings.InvalidEOLChar" />
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps" />
+        <exclude name="PSR1.Classes.ClassDeclaration" />
         <exclude name="PSR2.Methods.MethodDeclaration" />
         <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
         <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock" />

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,17 +1,9 @@
 <?xml version="1.0"?>
 <ruleset name="ExpressionEngine">
     <description>The PSR-12 Custom EE coding standard.</description>
-    <ini name="memory_limit" value="1024M"/>
+    <ini name="memory_limit" value="512M"/>
     <arg name="extensions" value="php"/>
     <arg name="tab-width" value="4"/>
-
-    <config name="installed_paths" value="build-tools/vendor/phpcompatibility/php-compatibility" />
-
-    <!-- Run against the PHPCompatibility ruleset -->
-    <rule ref="PHPCompatibility" />
-
-    <!-- Check for cross-version support for PHP 7.2 and higher. -->
-    <config name="testVersion" value="7.2-"/>
 
     <!-- Code MUST follow all rules outlined in PSR-12. -->
     <rule ref="PSR12">

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -10,8 +10,8 @@
     <!-- Run against the PHPCompatibility ruleset -->
     <rule ref="PHPCompatibility" />
 
-    <!-- Check for cross-version support for PHP 5.6 and higher. -->
-    <config name="testVersion" value="5.6-"/>
+    <!-- Check for cross-version support for PHP 7.2 and higher. -->
+    <config name="testVersion" value="7.2-"/>
 
     <!-- Code MUST follow all rules outlined in PSR-12. -->
     <rule ref="PSR12">

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="ExpressionEngine">
     <description>The PSR-12 Custom EE coding standard.</description>
-    <ini name="memory_limit" value="512M"/>
+    <ini name="memory_limit" value="1024M"/>
     <arg name="extensions" value="php"/>
     <arg name="tab-width" value="4"/>
 

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -5,6 +5,14 @@
     <arg name="extensions" value="php"/>
     <arg name="tab-width" value="4"/>
 
+    <config name="installed_paths" value="build-tools/vendor/phpcompatibility/php-compatibility" />
+
+    <!-- Run against the PHPCompatibility ruleset -->
+    <rule ref="PHPCompatibility" />
+
+    <!-- Check for cross-version support for PHP 7.2 and higher. -->
+    <config name="testVersion" value="7.2-"/>
+
     <!-- Code MUST follow all rules outlined in PSR-12. -->
     <rule ref="PSR12">
         <exclude name="Generic.Files.LineLength" />

--- a/system/ee/ExpressionEngine/Addons/pro/Model/Dashboard/DashboardWidget.php
+++ b/system/ee/ExpressionEngine/Addons/pro/Model/Dashboard/DashboardWidget.php
@@ -156,7 +156,8 @@ class DashboardWidget extends Model
             $file_path = PATH_THIRD . $this->widget_source . '/widgets/' . $this->widget_file . '.' . $this->widget_type;
         }
 
-        switch ($this->widget_type) {
+        switch ($this->widget_type) 
+        {
             case 'php':
                 if (empty($file_path)) {
                     return $html; //no valid path

--- a/system/ee/ExpressionEngine/Addons/pro/Model/Dashboard/DashboardWidget.php
+++ b/system/ee/ExpressionEngine/Addons/pro/Model/Dashboard/DashboardWidget.php
@@ -156,8 +156,7 @@ class DashboardWidget extends Model
             $file_path = PATH_THIRD . $this->widget_source . '/widgets/' . $this->widget_file . '.' . $this->widget_type;
         }
 
-        switch ($this->widget_type) 
-        {
+        switch ($this->widget_type) {
             case 'php':
                 if (empty($file_path)) {
                     return $html; //no valid path


### PR DESCRIPTION
This PR is updating out GitHub scripts to use latest versions of available actions (and avoid deprecation messages)

It is (hopefully) fixing the changelog builder script - we need to make sure we add proper labels to the PR, because unlabelled PRs are not included into changelog

It is also adding PSR-12 check - if the code is failing the standards, it will add annotations to the code on Files tab (the test will not fail though; we could accept non-standartized code if we decide we need to)