### PR TITLE
Resolves #2695 to allow parsing of username tag in forgotten password email instructions template

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -800,7 +800,7 @@ class Member_auth extends Member
         $reset_url .= '?id=' . $resetcode . $forum_id;
 
         if (! empty($protected['email_template'])) {
-            $email_template = ee()->TMPL->fetch_template_and_parse_from_path($protected['email_template']);
+            $email_template = ee()->TMPL->fetch_template_from_path($protected['email_template']);
         } else {
             $email_template = $template['data'];
         }


### PR DESCRIPTION
<!--
ExpressionEngine uses semantic versioning.

- (x.x.X) Bug fixes should target the stability branch
- (x.X.x) Small additive changes should target the next minor branch (release/next-minor if a numbered branch does not yet exist)
- (X.x.x) Breaking or large changes should target the next major branch (release/next-major if a numbered branch does not yet exist)
-->

<!-- What's in this pull request? -->
## Overview

Fixes a parsing error in a user defined forgotten password email template. Proposed solution mirrors the approach for the forgotten username email.

<!-- If this pull request resolves a project issue, provide a link: -->
Resolves [#2695](https://github.com/ExpressionEngine/ExpressionEngine/issues/2695).

## Nature of This Change

<!-- Check all that apply: -->

- [x] 🐛 Fixes a bug
- [ ] 🚀 Implements a new feature
- [ ] 🛁 Refactors existing code
- [ ] 💅 Fixes coding style
- [ ] ✅ Adds tests
- [ ] 👽 Adds new dependency
- [ ] 🔥 Removes unused files / code
- [ ] 🔒 Improves security <!-- if your fix would EXPOSE a current security flaw, do not submit a pull request. Instead report a security bug at https://docs.expressionengine.com/latest/bugs_and_security_reports -->

## Is this backwards compatible?

- [x] Yes
- [ ] No

## Documentation
<!-- Required for new features -->
N/A

<!-- Don't forget to add a single line changelog for your change to the appropriate file!

- changelogs/patch.rst (x.x.X)
- changelogs/minor.rst (x.X.x)
- changelogs/major.rst (X.x.x)

Thank you for contributing to ExpressionEngine! -->
