### PR TITLE
Allow making upload directories available for all MSM sites; #78

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -793,7 +793,7 @@ JSC;
 
         $directory_choices += ee('Model')->get('UploadDestination')
             ->fields('id', 'name')
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->filter('module_id', 0)
             ->order('name', 'asc')
             ->all(true)
@@ -887,7 +887,7 @@ JSC;
         if (empty($directories)) {
             $directories = ee('Model')->get('UploadDestination')
                 ->fields('id', 'name')
-                ->filter('site_id', ee()->config->item('site_id'))
+                ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
                 ->filter('module_id', 0)
                 ->all(true)
                 ->getDictionary('id', 'name');

--- a/system/ee/ExpressionEngine/Addons/filepicker/mcp.filepicker.php
+++ b/system/ee/ExpressionEngine/Addons/filepicker/mcp.filepicker.php
@@ -12,6 +12,7 @@ use ExpressionEngine\Model\File\UploadDestination;
 use ExpressionEngine\Addons\FilePicker\FilePicker as Picker;
 use ExpressionEngine\Service\File\ViewType;
 use ExpressionEngine\Library\CP\FileManager\Traits\FileManagerTrait;
+use ExpressionEngine\Service\Validation\Result as ValidationResult;
 
 /**
  * File Picker Module control panel
@@ -38,7 +39,7 @@ class Filepicker_mcp
     protected function getUserUploadDirectories()
     {
         $dirs = ee('Model')->get('UploadDestination')
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->filter('module_id', 0)
             ->order('name', 'asc')
             ->all();
@@ -53,7 +54,7 @@ class Filepicker_mcp
     protected function getSystemUploadDirectories()
     {
         $dirs = ee('Model')->get('UploadDestination')
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->filter('module_id', '!=', 0)
             ->all();
 
@@ -151,7 +152,7 @@ class Filepicker_mcp
         // Generate the contents of the new folder modal
         $newFolderModal = ee('View')->make('files/modals/folder')->render([
             'name' => 'modal-new-folder',
-            'form_url'=> ee('CP/URL')->make('files/createSubdirectory')->compile(),
+            'form_url' => ee('CP/URL')->make('files/createSubdirectory')->compile(),
             'choices' => $this->getUploadLocationsAndDirectoriesDropdownChoices(),
             'selected' => (int) ee('Request')->get('directory_id'),
         ]);

--- a/system/ee/ExpressionEngine/Addons/filepicker/mcp.filepicker.php
+++ b/system/ee/ExpressionEngine/Addons/filepicker/mcp.filepicker.php
@@ -54,7 +54,7 @@ class Filepicker_mcp
     protected function getSystemUploadDirectories()
     {
         $dirs = ee('Model')->get('UploadDestination')
-            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
+            ->filter('site_id', ee()->config->item('site_id'))
             ->filter('module_id', '!=', 0)
             ->all();
 
@@ -230,7 +230,7 @@ class Filepicker_mcp
     private function fileInfo($id)
     {
         $file = ee('Model')->get('File', $id)
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->first();
 
         if (! $file || ! $file->exists()) {

--- a/system/ee/ExpressionEngine/Addons/filepicker/upd.filepicker.php
+++ b/system/ee/ExpressionEngine/Addons/filepicker/upd.filepicker.php
@@ -79,7 +79,7 @@ class Filepicker_upd
         $existing = ee('Model')->get('UploadDestination')
             ->fields('name')
             ->filter('name', 'IN', array_keys($member_directories))
-            ->filter('site_id', $site_id)
+            ->filter('site_id', 'IN', [0, $site_id])
             ->all()
             ->pluck('name');
 

--- a/system/ee/ExpressionEngine/Addons/grid/ft.file_grid.php
+++ b/system/ee/ExpressionEngine/Addons/grid/ft.file_grid.php
@@ -54,7 +54,7 @@ class file_grid_ft extends Grid_ft
     {
         $directory_choices = ['all' => lang('all')] + ee('Model')->get('UploadDestination')
             ->fields('id', 'name')
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->filter('module_id', 0)
             ->order('name', 'asc')
             ->all(true)

--- a/system/ee/ExpressionEngine/Addons/moblog/mcp.moblog.php
+++ b/system/ee/ExpressionEngine/Addons/moblog/mcp.moblog.php
@@ -525,7 +525,7 @@ EOT;
                             'type' => 'select',
                             'choices' => ee('Model')->get('UploadDestination')
                                 ->fields('site_id', 'module_id', 'id', 'name')
-                                ->filter('site_id', ee()->config->item('site_id'))
+                                ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
                                 ->filter('module_id', 0)
                                 ->all()
                                 ->getDictionary('id', 'name'),
@@ -575,8 +575,8 @@ EOT;
      * Creates some javascript functions that are used to switch
      * various pull-down menus
      *
-     * @access	public
-     * @return	void
+     * @access public
+     * @return void
      */
     public function _filtering_menus($form_name)
     {

--- a/system/ee/ExpressionEngine/Controller/Files/AbstractFiles.php
+++ b/system/ee/ExpressionEngine/Controller/Files/AbstractFiles.php
@@ -93,7 +93,7 @@ abstract class AbstractFiles extends CP_Controller
         }
 
         $upload_destinations = ee('Model')->get('UploadDestination')
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->filter('module_id', 0)
             ->order('name', 'asc');
 

--- a/system/ee/ExpressionEngine/Controller/Files/Files.php
+++ b/system/ee/ExpressionEngine/Controller/Files/Files.php
@@ -64,7 +64,7 @@ class Files extends AbstractFilesController
     public function directory(int $id)
     {
         $dir = ee('Model')->get('UploadDestination', $id)
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->first();
 
         if (! $dir) {
@@ -284,7 +284,7 @@ class Files extends AbstractFilesController
             ->with('UploadDestination')
             ->fields('file_id')
             ->filter('UploadDestination.module_id', 0)
-            ->filter('site_id', ee()->config->item('site_id'));
+            ->filter('File.site_id', ee()->config->item('site_id'));
 
         $this->exportFiles($files->all()->pluck('file_id'));
 
@@ -727,7 +727,7 @@ class Files extends AbstractFilesController
 
         $id = ee()->input->post('dir_id');
         $dir = ee('Model')->get('UploadDestination', $id)
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->first();
 
         if (! $dir) {

--- a/system/ee/ExpressionEngine/Controller/Files/Files.php
+++ b/system/ee/ExpressionEngine/Controller/Files/Files.php
@@ -284,7 +284,7 @@ class Files extends AbstractFilesController
             ->with('UploadDestination')
             ->fields('file_id')
             ->filter('UploadDestination.module_id', 0)
-            ->filter('File.site_id', ee()->config->item('site_id'));
+            ->filter('File.site_id', 'IN', [0, ee()->config->item('site_id')]);
 
         $this->exportFiles($files->all()->pluck('file_id'));
 
@@ -818,7 +818,7 @@ class Files extends AbstractFilesController
 
         // Loop through the files and add them to the zip
         $files = ee('Model')->get('File', $file_ids)
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->all()
             ->filter(function ($file) use ($member) {
                 return $file->memberHasAccess($member);
@@ -867,7 +867,7 @@ class Files extends AbstractFilesController
         $member = ee()->session->getMember();
 
         $files = ee('Model')->get('FileSystemEntity', $file_ids)
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->all()
             ->filter(function ($file) use ($member) {
                 return $file->memberHasAccess($member);

--- a/system/ee/ExpressionEngine/Controller/Files/Uploads.php
+++ b/system/ee/ExpressionEngine/Controller/Files/Uploads.php
@@ -256,17 +256,13 @@ class Uploads extends AbstractFilesController
 
         if (bool_config_item('multiple_sites_enabled')) {
             $vars['sections'][0][] = array(
-                'title' => 'enable_partial_on_all_sites',
-                'desc' => 'enable_partial_on_all_sites_desc',
+                'title' => 'share_directory_on_all_sites',
+                'desc' => 'share_directory_on_all_sites_desc',
                 'fields' => array(
-                    'site_id' => array(
-                        'type' => 'inline_radio',
-                        'choices' => array(
-                            '0' => 'all_sites',
-                            ee()->config->item('site_id') => ee()->config->item('site_label') . ' ' . lang('only')
-                        ),
-                        'encode' => false,
-                        'value' => '0',
+                    'share_directory' => array(
+                        'type' => 'yes_no',
+                        'value' => $upload_destination->site_id === 0,
+                        'disabled' => ! $upload_destination->isNew()
                     )
                 )
             );
@@ -640,6 +636,11 @@ class Uploads extends AbstractFilesController
     private function validateUploadPreferences($upload_destination)
     {
         $upload_destination->set($_POST);
+
+        if ($upload_destination->isNew() && ee('Request')->post('share_directory') == 'y') {
+            $upload_destination->site_id = 0;
+        }
+
         // Pull adapter specific configuration
         if (isset($_POST['_for_adapter']) && isset($_POST['_for_adapter'][$_POST['adapter']])) {
             $adapterSettings = $_POST['_for_adapter'][$_POST['adapter']];
@@ -746,7 +747,7 @@ class Uploads extends AbstractFilesController
 
         foreach ($new_sizes as $row_id => $columns) {
             $model = ee('Model')->make('FileDimension', $columns);
-            $model->site_id = ee()->config->item('site_id');
+            $model->site_id = $upload_destination->site_id;
             $upload_destination->FileDimensions[] = $model;
 
             $validate[$row_id] = $model;

--- a/system/ee/ExpressionEngine/Controller/Members/Roles/Roles.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Roles/Roles.php
@@ -465,7 +465,7 @@ class Roles extends AbstractRolesController
         $assignedUploadDestinations = $role->AssignedUploadDestinations->getDictionary('id', 'site_id');
         if (!empty($assignedUploadDestinations)) {
             foreach ($assignedUploadDestinations as $dest_id => $dest_site_id) {
-                if ($dest_site_id != $site_id) {
+                if ($dest_site_id != 0 && $dest_site_id != $site_id) {
                     $uploadDestinationIds[] = $dest_id;
                 }
             }
@@ -952,7 +952,7 @@ class Roles extends AbstractRolesController
             ->getDictionary('module_id', 'module_name');
 
         $allowed_upload_destinations = ee('Model')->get('UploadDestination')
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->filter('module_id', 0)
             ->all()
             ->getDictionary('id', 'name');

--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
@@ -15,7 +15,6 @@ use ExpressionEngine\Library\CP\FileManager\ColumnFactory;
 
 trait FileManagerTrait
 {
-    
     protected function listingsPage($uploadLocation = null, $view_type = 'list', $filepickerMode = false)
     {
         $vars = array();
@@ -56,10 +55,10 @@ trait FileManagerTrait
 
         $files = ee('Model')->get($model)
             // ->fields($model . '.*', 'UploadDestination.server_path', 'UploadDestination.url');
-            ->with('UploadDestination');
+            ->with('UploadDestination')
+            ->filter('site_id', ee()->config->item('site_id'));
         if (empty($upload_location_id)) {
-            $files->filter('UploadDestination.module_id', 0)
-                ->filter('site_id', ee()->config->item('site_id'));
+            $files->filter('UploadDestination.module_id', 0);
         } else {
             $files->filter('upload_location_id', $upload_location_id);
         }
@@ -85,7 +84,7 @@ trait FileManagerTrait
                 $vars['breadcrumbs'] = array_merge([$base_url->compile() => $uploadLocation->name], array_reverse($breadcrumbs));
                 $base_url->setQueryStringVariable('directory_id', (int) ee('Request')->get('directory_id'));
             }
-        } else if (bool_config_item('file_manager_compatibility_mode')) {
+        } elseif (bool_config_item('file_manager_compatibility_mode')) {
             $files->filter('directory_id', 0);
         }
 
@@ -205,7 +204,7 @@ trait FileManagerTrait
                         }
                     }
                 }
-                if (!empty($column->getEntryManagerColumnFields())) {
+                /*if (!empty($column->getEntryManagerColumnFields())) {
                     foreach ($column->getEntryManagerColumnFields() as $field) {
                         if (!empty($field)) {
                             // $files->fields($field);
@@ -213,7 +212,7 @@ trait FileManagerTrait
                     }
                 } else {
                     // $files->fields($column->getTableColumnIdentifier());
-                }
+                }*/
             }
         }
 
@@ -259,7 +258,7 @@ trait FileManagerTrait
         }
 
         $sort_field = ($sort_col == 'date_added') ? 'upload_date' : $columns[$sort_col]->getEntryManagerColumnSortField();
-        $preselectedFileId =ee()->session->flashdata('file_id');
+        $preselectedFileId = ee()->session->flashdata('file_id');
 
         if ($preselectedFileId) {
             $files = $files->order('FIELD( file_id, ' . $preselectedFileId . ' )', 'DESC', false);
@@ -312,7 +311,7 @@ trait FileManagerTrait
             ];
 
             if ($file->isDirectory()) {
-                $attrs['file_upload_id'] = $file->upload_location_id.'.'.$file->file_id;
+                $attrs['file_upload_id'] = $file->upload_location_id . '.' . $file->file_id;
             }
 
             if (! $file->exists()) {
@@ -372,7 +371,6 @@ trait FileManagerTrait
 
         $table->setData($data);
 
-
         $vars['table'] = $table->viewData($base_url);
         $vars['form_url'] = $vars['table']['base_url'];
 
@@ -386,7 +384,7 @@ trait FileManagerTrait
             'lang.remove_confirm' => lang('file') . ': <b>### ' . lang('files') . '</b>',
             'viewManager.saveDefaultUrl' => ee('CP/URL')->make('files/views/save-default', ['upload_id' => $upload_location_id, 'viewtype' => $view_type])->compile()
         ]);
-        
+
         ee()->cp->add_js_script(array(
             'file' => array(
                 'cp/confirm_remove',
@@ -405,7 +403,7 @@ trait FileManagerTrait
     private function createUploadLocationFilter($uploadLocation = null)
     {
         $upload_destinations = ee('Model')->get('UploadDestination')
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->filter('module_id', 0)
             ->order('name', 'asc');
 
@@ -544,7 +542,7 @@ trait FileManagerTrait
         if (ee('Permission')->can('upload_new_files')) {
             $upload_destinations = ee('Model')->get('UploadDestination')
                 ->fields('id', 'name', 'adapter')
-                ->filter('site_id', ee()->config->item('site_id'))
+                ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
                 ->filter('module_id', 0)
                 ->order('name', 'asc')
                 ->all();

--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
@@ -56,7 +56,7 @@ trait FileManagerTrait
         $files = ee('Model')->get($model)
             // ->fields($model . '.*', 'UploadDestination.server_path', 'UploadDestination.url');
             ->with('UploadDestination')
-            ->filter('site_id', ee()->config->item('site_id'));
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')]);
         if (empty($upload_location_id)) {
             $files->filter('UploadDestination.module_id', 0);
         } else {

--- a/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
@@ -28,7 +28,7 @@ class Filesystem
             $syspath = str_replace('\\', '/', SYSPATH);
             $openBaseDir = ini_get('open_basedir');
             // Check if open_basedir restrictions are in effect
-            /*if (!empty($openBaseDir)) {
+            if (!empty($openBaseDir)) {
                 // Find the open_basedir root that our $syspath lives under
                 foreach (explode(':', ini_get('open_basedir')) as $path) {
                     $normalizedPath = str_replace('\\', '/', $path);
@@ -39,13 +39,13 @@ class Filesystem
             } else {
                 // If open_basedir is not enabled set our root to the top directory in the syspath
                 $syspathRoot = realpath($syspath . str_repeat('../', substr_count($syspath, '/') - 1));
-            }*/
+            }
             $adapter = new Adapter\Local([
-                'path' => $syspath//$this->normalizeAbsolutePath($syspathRoot ?: $syspath)
+                'path' => $this->normalizeAbsolutePath($syspathRoot ?: $syspath)
             ]);
         } else {
             // Fix prefixes
-            //$adapter->setPathPrefix($this->normalizeAbsolutePath($adapter->getPathPrefix()));
+            $adapter->setPathPrefix($this->normalizeAbsolutePath($adapter->getPathPrefix()));
         }
         // Create the cache store
         $cacheStore = new Flysystem\Cached\Storage\Memory();
@@ -58,7 +58,7 @@ class Filesystem
         $config = array_merge($defaults, $config);
 
         $this->flysystem = new Flysystem\Filesystem($adapter, $config);
-        /*$this->flysystem->addPlugin(new Flysystem\Plugin\GetWithMetadata());*/
+        $this->flysystem->addPlugin(new Flysystem\Plugin\GetWithMetadata());
     }
 
     /**

--- a/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
@@ -24,11 +24,11 @@ class Filesystem
     {
         if (is_null($adapter)) {
             $syspathRoot = null;
-            // Normalize the System Path and then find the root 
+            // Normalize the System Path and then find the root
             $syspath = str_replace('\\', '/', SYSPATH);
             $openBaseDir = ini_get('open_basedir');
             // Check if open_basedir restrictions are in effect
-            if(!empty($openBaseDir)) {
+            /*if (!empty($openBaseDir)) {
                 // Find the open_basedir root that our $syspath lives under
                 foreach (explode(':', ini_get('open_basedir')) as $path) {
                     $normalizedPath = str_replace('\\', '/', $path);
@@ -36,16 +36,16 @@ class Filesystem
                         $syspathRoot = $normalizedPath;
                     }
                 }
-            }else{
+            } else {
                 // If open_basedir is not enabled set our root to the top directory in the syspath
                 $syspathRoot = realpath($syspath . str_repeat('../', substr_count($syspath, '/') - 1));
-            }
+            }*/
             $adapter = new Adapter\Local([
-                'path' => $this->normalizeAbsolutePath($syspathRoot ?: $syspath)
+                'path' => $syspath//$this->normalizeAbsolutePath($syspathRoot ?: $syspath)
             ]);
-        }else{
+        } else {
             // Fix prefixes
-            $adapter->setPathPrefix($this->normalizeAbsolutePath($adapter->getPathPrefix()));
+            //$adapter->setPathPrefix($this->normalizeAbsolutePath($adapter->getPathPrefix()));
         }
         // Create the cache store
         $cacheStore = new Flysystem\Cached\Storage\Memory();
@@ -58,7 +58,7 @@ class Filesystem
         $config = array_merge($defaults, $config);
 
         $this->flysystem = new Flysystem\Filesystem($adapter, $config);
-        $this->flysystem->addPlugin(new Flysystem\Plugin\GetWithMetadata());
+        /*$this->flysystem->addPlugin(new Flysystem\Plugin\GetWithMetadata());*/
     }
 
     /**
@@ -756,7 +756,7 @@ class Filesystem
      */
     public function isWritable($path = '/')
     {
-        if(! $this->isLocal()) {
+        if (! $this->isLocal()) {
             return true;
         }
 
@@ -1035,7 +1035,7 @@ class Filesystem
      */
     protected function normalizeAbsolutePath($path)
     {
-        if(empty($path)) {
+        if (empty($path)) {
             return '';
         }
 

--- a/system/ee/ExpressionEngine/Model/File/UploadDestination.php
+++ b/system/ee/ExpressionEngine/Model/File/UploadDestination.php
@@ -207,7 +207,7 @@ class UploadDestination extends StructureModel
     {
         $overrides = array();
 
-        if ($this->getProperty('site_id') != ee()->config->item('site_id')) {
+        if ($this->getProperty('site_id') != 0 && $this->getProperty('site_id') != ee()->config->item('site_id')) {
             $overrides = ee()->config->get_cached_site_prefs($this->getProperty('site_id'));
         }
 
@@ -553,7 +553,7 @@ class UploadDestination extends StructureModel
         if (! is_null($this->_exists)) {
             return $this->_exists;
         }
-    
+
         try {
             return $this->_exists = $this->getFilesystem()->exists('');
         } catch (\Exception $e) {
@@ -620,7 +620,7 @@ class UploadDestination extends StructureModel
         $basename = ($renamer === false) ? $basename : substr($basename, 0, -strlen($renamer));
 
         foreach ($manipulations as $manipulation) {
-            if($filesystem->exists("{$dirname}/_{$manipulation}/")) {
+            if ($filesystem->exists("{$dirname}/_{$manipulation}/")) {
                 $files = $filesystem->getDirectoryContents("{$dirname}/_{$manipulation}/");
                 $files = array_filter($files, function ($file) use ($basename) {
                     return (strpos($file, "{$basename}_") === 0);

--- a/system/ee/ExpressionEngine/Service/File/Upload.php
+++ b/system/ee/ExpressionEngine/Service/File/Upload.php
@@ -260,7 +260,7 @@ class Upload
     public function uploadTo($upload_location_id, $directory_id = 0)
     {
         $uploadLocation = ee('Model')->get('UploadDestination', $upload_location_id)
-            ->filter('site_id', ee()->config->item('site_id'))
+            ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
             ->first();
 
         if (! $uploadLocation) {
@@ -473,10 +473,12 @@ class Upload
 
                 $file->getFilesystem()->forceCopy($src, $file->getAbsolutePath());
             } else {
-                if (($file->description && ($file->description != $original->description))
+                if (
+                    ($file->description && ($file->description != $original->description))
                     || ($file->credit && ($file->credit != $original->credit))
                     || ($file->location && ($file->location != $original->location))
-                    || ($file->Categories->count() > 0 && ($file->Categories->count() != $file->Categories->count()))) {
+                    || ($file->Categories->count() > 0 && ($file->Categories->count() != $file->Categories->count()))
+                ) {
                     $result['warning'] = lang('replace_no_metadata');
                 }
 

--- a/system/ee/ExpressionEngine/View/files/index.php
+++ b/system/ee/ExpressionEngine/View/files/index.php
@@ -43,7 +43,7 @@ if (! AJAX_REQUEST) {
             <?php $i = 0; ?>
             <div class="f_manager-table-breadcrumbs">
                 <ul class="breadcrumb">
-                    <?php foreach($breadcrumbs as $url => $name) : ?>
+                    <?php foreach ($breadcrumbs as $url => $name) : ?>
                         <?php $i++; ?>
                         <?php if ($i < count($breadcrumbs)) : ?>
                         <li><a href="<?=$url?>" data-filter-url="<?=$url?>"><i class="fal fa-<?=($i == 1 ? 'hdd' : 'folder')?>"></i><?=$name?></a></li>

--- a/system/ee/language/english/filemanager_lang.php
+++ b/system/ee/language/english/filemanager_lang.php
@@ -469,6 +469,10 @@ $lang = array(
 
     'type_directory' => 'Folder',
 
+    'share_directory_on_all_sites' => 'Share Upload Directory on all sites?',
+
+    'share_directory_on_all_sites_desc' => 'Make files in this directory accessible through all MSM sites.<br><b>Note:</b> this can only be set on creation and cannot be changed.',
+
     'upload_btn_edit' => 'edit',
 
     'upload_btn_sync' => 'sync',

--- a/system/ee/legacy/libraries/File_field.php
+++ b/system/ee/legacy/libraries/File_field.php
@@ -957,7 +957,7 @@ class File_field
 
         $upload_destinations = [];
         foreach ($upload_prefs as $upload_pref) {
-            if ($upload_pref->site_id == ee()->config->item('site_id') &&
+            if (($upload_pref->site_id == 0 || $upload_pref->site_id == ee()->config->item('site_id')) &&
                 $upload_pref->module_id == 0) {
                 $upload_destinations[$upload_pref->id] = [
                     'label' => $upload_pref->name,

--- a/system/ee/legacy/libraries/File_field.php
+++ b/system/ee/legacy/libraries/File_field.php
@@ -808,7 +808,7 @@ class File_field
             return '';
         }
 
-        if (strpos((string) $data, 'file:') !== false ) {
+        if (strpos((string) $data, 'file:') !== false) {
             if (preg_match_all('/{file\:(\d+)\:url}/', (string) $data, $matches, PREG_SET_ORDER)) {
                 $file_ids = [];
                 foreach ($matches as $match) {

--- a/system/ee/legacy/libraries/Filemanager.php
+++ b/system/ee/legacy/libraries/Filemanager.php
@@ -144,7 +144,7 @@ class Filemanager
         $dir = ee('Model')->get('UploadDestination', $dir_id);
 
         if (! $ignore_site_id) {
-            $dir->filter('site_id', ee()->config->item('site_id'));
+            $dir->filter('site_id', 'IN', [0, ee()->config->item('site_id')]);
         }
 
         if ($dir->count() < 1) {
@@ -302,6 +302,7 @@ class Filemanager
         $prefs['upload_location_id'] = $directory['id'];
 
         $prefs = array_merge($prefs, $dir_prefs);
+        $prefs['site_id'] = ee()->config->item('site_id');
 
         if (! isset($prefs['dimensions'])) {
             $prefs['dimensions'] = array();
@@ -1605,7 +1606,7 @@ class Filemanager
         $directories = ee('Model')->get('UploadDestination');
 
         if (!$ignore_site_id) {
-            $directories->filter('site_id', ee()->config->item('site_id'));
+            $directories->filter('site_id', 'IN', [0, ee()->config->item('site_id')]);
         }
 
         $dirs = $directories->all()->indexBy('id');

--- a/system/ee/legacy/libraries/Filemanager.php
+++ b/system/ee/legacy/libraries/Filemanager.php
@@ -302,7 +302,6 @@ class Filemanager
         $prefs['upload_location_id'] = $directory['id'];
 
         $prefs = array_merge($prefs, $dir_prefs);
-        $prefs['site_id'] = ee()->config->item('site_id');
 
         if (! isset($prefs['dimensions'])) {
             $prefs['dimensions'] = array();

--- a/tests/cypress/cypress/integration/files/shared_upload_dir.ee6.js
+++ b/tests/cypress/cypress/integration/files/shared_upload_dir.ee6.js
@@ -1,0 +1,231 @@
+/// <reference types="Cypress" />
+
+import SiteForm from '../../elements/pages/site/SiteForm';
+import SiteManager from '../../elements/pages/site/SiteManager';
+import UploadEdit from '../../elements/pages/files/UploadEdit';
+import FileManager from '../../elements/pages/files/FileManager';
+import UploadSync from '../../elements/pages/files/UploadSync';
+import EditFile from '../../elements/pages/files/EditFile';
+const { _, $ } = Cypress
+
+
+const editFile = new EditFile;
+
+const managerPage = new FileManager;
+const uploadEdit = new UploadEdit;
+const siteManager = new SiteManager;
+
+
+context('Shared Upload Directories', () => {
+    before(function () {
+        cy.task('db:seed')
+        cy.eeConfig({ item: 'save_tmpl_files', value: 'y' })
+        cy.eeConfig({ item: 'multiple_sites_enabled', value: 'y' })
+        cy.eeConfig({ item: 'enable_dock', value: 'n' })
+
+        //copy templates
+        cy.task('filesystem:copy', { from: 'support/templates/*', to: '../../system/user/templates/' }).then(() => {
+            cy.authVisit('admin.php?/cp/design')
+        })
+
+        
+        siteManager.load();
+        cy.dismissLicenseAlert()
+
+        cy.get('.main-nav a').contains('Add Site').first().click()
+
+        const form = new SiteForm
+        form.add_site({
+            name: 'Second Site',
+            short_name: 'second_site'
+        })
+
+        siteManager.get('global_menu').click()
+        siteManager.get('dropdown').find('a[href*="cp/msm/switch_to/2"]').click()
+        cy.authVisit('admin.php?/cp/design')
+
+        cy.hasNoErrors()
+
+        siteManager.get('global_menu').click()
+        siteManager.get('dropdown').find('a[href*="cp/msm/switch_to/1"]').click()
+    })
+
+    after(function() {
+      cy.eeConfig({ item: 'enable_dock', value: 'y' })
+    })
+
+    context('using shared upload directory', () => {
+
+        before(function() {
+            
+        })
+
+        it('should save shared upload directory on site 2', () => {
+            siteManager.load();
+            siteManager.get('global_menu').click()
+            siteManager.get('dropdown').find('a[href*="cp/msm/switch_to/2"]').click()
+
+            uploadEdit.load()
+            uploadEdit.get('url').should('not.be.visible')
+            cy.get('[data-input-value=adapter] .select__button').click()
+            cy.get('[data-input-value=adapter] .select__dropdown .select__dropdown-item').contains('Local').click()
+            uploadEdit.get('name').clear().type('Shared Directory')
+            uploadEdit.get('url').clear().type(Cypress.config().baseUrl + '/uploads/')
+            uploadEdit.get('server_path').clear().type('{base_path}/uploads/', {parseSpecialCharSequences: false})
+
+            uploadEdit.get('grid_add_no_results').click()
+            uploadEdit.name_for_row(1).clear().type('cropped')
+            uploadEdit.resize_type_for_row(1).select('Crop (part of image)')
+            uploadEdit.width_for_row(1).clear().type('100')
+
+            cy.get('#fieldset-share_directory .toggle-btn').click()
+
+            uploadEdit.submit()
+            cy.hasNoErrors()
+
+            siteManager.load();
+            siteManager.get('global_menu').click()
+            siteManager.get('dropdown').find('a[href*="cp/msm/switch_to/1"]').click()
+
+            managerPage.load()
+            cy.get('.secondary-sidebar__files').contains('Shared Directory')
+        })
+
+        it('upload files on site 1 and check they are visible on site 2', () => {
+            cy.auth();
+            managerPage.load()
+            cy.get('.secondary-sidebar__files .sidebar__link a').contains('Shared Directory').click()
+            cy.wait(1000)
+
+            cy.get('.file-upload-widget').then(function(widget) {
+                $(widget).removeClass('hidden')
+            })
+            cy.intercept('/admin.php?/cp/addons/settings/filepicker/ajax-upload').as('upload')
+            cy.intercept('/admin.php?/cp/files/directory/*').as('table')
+            managerPage.get('file_input').find('.file-field__dropzone').attachFile('../../support/file/programming.gif', { subjectType: 'drag-n-drop' })
+            cy.wait('@upload')
+            cy.wait('@table')
+            cy.hasNoErrors()
+        
+            editFile.get('selected_file').should('exist')
+            editFile.get('selected_file').contains("programming.gif")
+
+            siteManager.load();
+            siteManager.get('global_menu').click()
+            siteManager.get('dropdown').find('a').contains('Second Site').click()
+
+            managerPage.load()
+            cy.get('.app-listing__row').contains("programming.gif")
+            cy.get('.secondary-sidebar__files .sidebar__link a').contains('Shared Directory').click()
+            cy.get('.app-listing__row').contains("programming.gif")
+        })
+
+        it('add files and display them on frontend', () => {
+          cy.intercept("**/filepicker/**").as('ajax')
+          cy.authVisit('/admin.php?/cp/publish/edit')
+          cy.get('a').contains('Getting to Know ExpressionEngine').click()
+          cy.wait(2000) //wait for picker on textarea to initiliaze
+          cy.get('.textarea-field-filepicker').first().click()
+          cy.wait('@ajax')
+          cy.get('.modal-file').should('be.visible')
+          let lake_id = null;
+          cy.get('.modal-file .app-listing__row a').contains('programming.gif').parents('tr').invoke('attr', 'data-id').then((id) => {
+            lake_id = id;
+          })
+          cy.get('.modal-file .app-listing__row a').contains('programming.gif').click()
+          cy.get('.modal-file').should('not.be.visible')
+          cy.wait(1000)//give JS some extra time
+          cy.get('textarea.markItUpEditor').invoke('val').then((val) => {
+            expect(val).to.contain('<img src="{file:' + lake_id + ':url}"')
+          })
+    
+          cy.get('.file-field-filepicker[title=Edit]').click()
+          cy.wait('@ajax')
+          cy.get('.modal-file').should('be.visible')
+          cy.wait(1000)//give JS some extra time
+          let ocean_id = null
+          cy.get('.modal-file .app-listing__row a').contains('programming.gif').parents('tr').invoke('attr', 'data-id').then((id) => {
+            ocean_id = id;
+          })
+          cy.wait(1000)//give JS some extra tim
+          cy.get('.modal-file .app-listing__row a').contains('programming.gif').click()
+          cy.get('.modal-file').should('not.be.visible')
+          cy.wait(1000)//give JS some extra time
+          cy.get('.js-file-input').invoke('val').then((val) => {
+            expect(val).to.eq('{file:' + ocean_id + ':url}')
+          })
+          cy.get('.fields-upload-chosen-name').should('contain', 'programming.gif')
+    
+          cy.get('body').type('{ctrl}', {release: false}).type('s')
+          cy.get('textarea.markItUpEditor').invoke('val').then((val) => {
+            expect(val).to.contain('<img src="{file:' + lake_id + ':url}"')
+          })
+          cy.get('.fields-upload-chosen-name').should('contain', 'programming.gif')
+    
+          cy.on('uncaught:exception', (err, runnable) => {
+            // return false to prevent the error from
+            // failing this test
+            return false
+          })
+    
+          cy.visit('/index.php/entries/files')
+          cy.hasNoErrors()
+          cy.get('figure.left img').should('be.visible').and(($img) => {
+                // "naturalWidth" and "naturalHeight" are set when the image loads
+                expect($img[0].naturalWidth).to.be.eq(100)
+          })
+          cy.get('figure.left img').invoke('attr', 'src').then((src) => {
+            expect(src).to.contain('programming.gif')
+          })
+          cy.get('figure.right img').should('be.visible').and(($img) => {
+                // "naturalWidth" and "naturalHeight" are set when the image loads
+                expect($img[0].naturalWidth).to.be.greaterThan(0)
+          })
+          cy.get('figure.right img').invoke('attr', 'src').then((src) => {
+            expect(src).to.contain('programming.gif')
+          })
+          cy.get('section.w-12 p img').should('be.visible').and(($img) => {
+            // "naturalWidth" and "naturalHeight" are set when the image loads
+            expect($img[0].naturalWidth).to.be.greaterThan(0)
+          })
+          cy.get('section.w-12 p img').invoke('attr', 'src').then((src) => {
+            expect(src).to.contain('programming.gif')
+          })
+    
+          //turn on compatibility mode and make sure everything still works
+          cy.log('turn on compatibility mode and make sure everything still works')
+          cy.eeConfig({ item: 'file_manager_compatibility_mode', value: 'y' })
+          cy.wait(1000)
+          
+          cy.visit('/index.php/entries/files')
+          cy.hasNoErrors()
+          cy.get('figure.left img').should('be.visible').and(($img) => {
+                // "naturalWidth" and "naturalHeight" are set when the image loads
+                expect($img[0].naturalWidth).to.be.eq(100)
+          })
+          cy.get('figure.left img').invoke('attr', 'src').then((src) => {
+            expect(src).to.contain('programming.gif')
+          })
+          cy.get('figure.right img').should('be.visible').and(($img) => {
+                // "naturalWidth" and "naturalHeight" are set when the image loads
+                expect($img[0].naturalWidth).to.be.greaterThan(0)
+          })
+          cy.get('figure.right img').invoke('attr', 'src').then((src) => {
+            expect(src).to.contain('programming.gif')
+          })
+          cy.get('section.w-12 p img').should('be.visible').and(($img) => {
+            // "naturalWidth" and "naturalHeight" are set when the image loads
+            expect($img[0].naturalWidth).to.be.greaterThan(0)
+          })
+          cy.get('section.w-12 p img').invoke('attr', 'src').then((src) => {
+            expect(src).to.contain('programming.gif')
+          })
+
+    
+          cy.eeConfig({ item: 'file_manager_compatibility_mode', value: 'n' })
+        })
+    
+      })
+
+
+})

--- a/tests/cypress/support/templates/default_site/entries.group/files.html
+++ b/tests/cypress/support/templates/default_site/entries.group/files.html
@@ -1,0 +1,18 @@
+{layout="cypress/layout"}
+{exp:channel:entries entry_id="1"}
+<h1>{title}</h1>
+
+<section class=" w-12">
+    {news_body}
+</section>
+
+<figure class="left">
+    <img src="{news_image:cropped}">
+</figure>
+
+<figure class="right">
+    <img src="{news_image}{url}{/news_image}">
+</figure>
+
+
+{/exp:channel:entries}


### PR DESCRIPTION
Allow making upload directories available for all MSM sites; #78

This PR is adding new setting to Upload Directories:
![image](https://user-images.githubusercontent.com/752126/210994842-cefc8d4b-55f0-4b54-9a37-8fd364c9c642.png)
when turned on, the `site_id` for upload directory itself, file dimensions and actual files is set to `0` and thus all of those become available for all MSM sites.

This setting cannot be changed for existing upload directories, because doing that would involve updating site_id for existing files, which has some (though very low) potential to break sites
