### PR TITLE
Resolved issue where Pro Search filters were using Low Search naming

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_filters.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_filters.php
@@ -102,15 +102,20 @@ class Pro_search_filters
                 }
 
                 // Compose file name
-                $file = $dir . "/lsf.{$item}.php";
+                // Compose class name
+                if (version_compare(ee()->config->item('app_version'), '7.0.0', '>=')) {
+                    $file = $dir . "/psf.{$item}.php";
+                    $class = 'Pro_search_filter_' . $item;
+                }
+                else {
+                    $file = $dir . "/lsf.{$item}.php";
+                    $class = 'Low_search_filter_' . $item;
+                }
 
                 // Skip if not a file
                 if (! file_exists($file)) {
                     continue;
                 }
-
-                // Compose class name
-                $class = 'Pro_search_filter_' . $item;
 
                 if (! class_exists($class)) {
                     require_once($file);

--- a/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_filters.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_filters.php
@@ -103,14 +103,8 @@ class Pro_search_filters
 
                 // Compose file name
                 // Compose class name
-                if (version_compare(ee()->config->item('app_version'), '7.0.0', '>=')) {
-                    $file = $dir . "/psf.{$item}.php";
-                    $class = 'Pro_search_filter_' . $item;
-                }
-                else {
-                    $file = $dir . "/lsf.{$item}.php";
-                    $class = 'Low_search_filter_' . $item;
-                }
+                $file = $dir . "/psf.{$item}.php";
+                $class = 'Pro_search_filter_' . $item;
 
                 // Skip if not a file
                 if (! file_exists($file)) {

--- a/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_filters.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_filters.php
@@ -7,7 +7,6 @@
  * @copyright Copyright (c) 2003-2022, Packet Tide, LLC (https://www.packettide.com)
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
-
 if (! defined('BASEPATH')) {
     exit('No direct script access allowed');
 }
@@ -101,21 +100,32 @@ class Pro_search_filters
                     continue;
                 }
 
-                // Compose file name
-                // Compose class name
-                $file = $dir . "/psf.{$item}.php";
-                $class = 'Pro_search_filter_' . $item;
+                $possibleFiles = [
+                    $dir . "/lsf.{$item}.php",
+                    $dir . "/psf.{$item}.php",
+                ];
 
-                // Skip if not a file
-                if (! file_exists($file)) {
-                    continue;
-                }
+                $possibleClasses = [
+                    'Low_search_filter_' . $item,
+                    'Pro_search_filter_' . $item,
+                ];
 
-                if (! class_exists($class)) {
+                // Check low search files and pro search files for available filters
+                foreach ($possibleFiles as $file) {
+                    // Skip if not a file
+                    if (! file_exists($file)) {
+                        continue;
+                    }
+
+                    // Load the class
                     require_once($file);
-                }
 
-                $this->_filters[$item] = new $class();
+                    foreach ($possibleClasses as $class) {
+                        if (class_exists($class)) {
+                            $this->_filters[$item] = new $class();
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
When we moved from low search to pro search. We have pro search trying to pull in filters from other addons that are still extending off of low search. My idea was that we separate out based on EE version to avoid errors in pro search whenever someone has another addon that has a filter.

The one thing that is a pain point doing it this way is that all the addons that have a filter would have to just copy that file give it the name psf.addon_name.php and then change the class line. (Super quick but seems redundant) and also all the addon managers would have to do that. But I don't see another way to get around this while keeping add-ons compatible for ee 7 and ee6 and below.

Original PR: #2597 

