### PR TITLE
Resolved #2437 where building Pro Search Collection via URL did not work properly

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro_search/addon.json
+++ b/system/ee/ExpressionEngine/Addons/pro_search/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Pro Search",
     "shortname": "pro_search",
-    "version": "8.0.1",
+    "version": "8.0.2",
     "description": "Powerful site search and Find &amp; Replace utility",
     "trial": true,
     "namespace": "Pro\\Search",

--- a/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_settings.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_settings.php
@@ -45,6 +45,7 @@ class Pro_search_settings
         'search_log_size'     => '500',
         'ignore_words'        => 'a an and the or of s',
         'disabled_filters'    => array(),
+        'build_index_act_key' => '',
         'stop_words'          =>
             // http://dev.mysql.com/doc/refman/5.5/en/fulltext-stopwords.html
             "a's able about above according accordingly across actually after afterwards again against ain't
@@ -90,7 +91,7 @@ class Pro_search_settings
         'can_manage_lexicon'   => array(),
         'can_replace'          => array(),
         'can_view_search_log'  => array(),
-        'can_view_replace_log' => array()
+        'can_view_replace_log' => array(),
     );
 
     private $_search_modes = array('any', 'all', 'exact', 'auto');

--- a/system/ee/ExpressionEngine/Addons/pro_search/mcp.pro_search.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/mcp.pro_search.php
@@ -7,7 +7,6 @@
  * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
-
 if (! defined('BASEPATH')) {
     exit('No direct script access allowed');
 }
@@ -232,6 +231,22 @@ class Pro_search_mcp
                 'default_result_page' => array(
                     'type'  => 'text',
                     'value' => ee()->pro_search_settings->get('default_result_page')
+                )
+            )
+        );
+
+        // --------------------------------------
+        // Build Index ACT key
+        // --------------------------------------
+        $actUrl = ee()->functions->fetch_site_index(0, 0) . QUERY_MARKER . 'ACT=' . ee()->cp->fetch_action_id($this->class_name, 'build_index') . AMP . 'key=' . ee()->pro_search_settings->get('build_index_act_key') . AMP . 'collection_id=1';
+
+        $sections[0][] = array(
+            'title' => 'build_index_act_key',
+            'desc' => sprintf(lang('build_index_act_key_help'), $actUrl),
+            'fields' => array(
+                'build_index_act_key' => array(
+                    'type'  => 'text',
+                    'value' => ee()->pro_search_settings->get('build_index_act_key')
                 )
             )
         );
@@ -663,7 +678,6 @@ class Pro_search_mcp
                             'disabled' => 'true'
                         );
                     }
-
 
                     // Add custom row
                     $row[] = array(

--- a/system/ee/ExpressionEngine/Addons/pro_search/mod.pro_search.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/mod.pro_search.php
@@ -1488,7 +1488,7 @@ class Pro_search
 
         // Make sure the IDs
         if (! is_array($ids)) {
-            $ids = preg_split('/\D+/', $ids, null, PREG_SPLIT_NO_EMPTY);
+            $ids = preg_split('/\D+/', $ids, 0, PREG_SPLIT_NO_EMPTY);
         }
 
         // Filter the ids, bail out if we end up empty

--- a/system/ee/ExpressionEngine/Addons/pro_search/mod.pro_search.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/mod.pro_search.php
@@ -7,7 +7,6 @@
  * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
-
 if (! defined('BASEPATH')) {
     exit('No direct script access allowed');
 }
@@ -1384,12 +1383,12 @@ class Pro_search
      */
     public function build_index()
     {
-        // License key must be given
-        $license_key = '';
+        // ACT key must be given
+        $build_index_act_key = $this->settings->get('build_index_act_key');
         $given_key = ee()->input->get_post('key');
 
         // Bail out if keys don't match
-        if (! ($given_key && $license_key == $given_key && REQ == 'ACTION')) {
+        if (! ($given_key && $build_index_act_key == $given_key && REQ == 'ACTION')) {
             show_error(ee()->lang->line('not_authorized'));
         }
 

--- a/system/ee/ExpressionEngine/Addons/pro_search/upd.pro_search.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/upd.pro_search.php
@@ -337,6 +337,10 @@ class Pro_search_upd
             $this->_v801();
         }
 
+        if (version_compare($current, '8.0.2', '<')) {
+            $this->_v802();
+        }
+
         $this->logMessageAboutLowVersion();
 
         // --------------------------------------
@@ -713,6 +717,31 @@ class Pro_search_upd
 
         // Add the field to the table
         ee()->db->query($sql);
+    }
+
+    /**
+     * Update routines for version 8.0.2
+     *
+     * @access     private
+     * @return     void
+     */
+    private function _v802()
+    {
+        // If build_index_act_key is empty, we assign a new random key
+        if (empty(ee()->pro_search_settings->get('build_index_act_key'))) {
+            // If there is an existing license key, we will use that
+            if (!empty(ee()->pro_search_settings->get('license_key'))) {
+                $key = ee()->pro_search_settings->get('license_key');
+            } else {
+                // Make a pseudo-random key for the Build Index ACT key
+                $key = strtoupper(bin2hex(random_bytes(20)));
+            }
+
+            ee()->pro_search_settings->set(['build_index_act_key' => $key]);
+
+            ee()->db->where('class', $this->class_name . '_ext');
+            ee()->db->update('extensions', array('settings' => serialize(ee()->pro_search_settings->get())));
+        }
     }
 
     private function logMessageAboutLowVersion()

--- a/system/ee/ExpressionEngine/Addons/pro_search/upd.pro_search.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/upd.pro_search.php
@@ -119,6 +119,9 @@ class Pro_search_upd
             $this->_add_hook($hook);
         }
 
+        // Generate an initial key for the ACT url
+        $this->createNewActKey();
+
         // --------------------------------------
 
         return true;
@@ -729,19 +732,31 @@ class Pro_search_upd
     {
         // If build_index_act_key is empty, we assign a new random key
         if (empty(ee()->pro_search_settings->get('build_index_act_key'))) {
+            // Start with a null key
+            $key = null;
+
             // If there is an existing license key, we will use that
             if (!empty(ee()->pro_search_settings->get('license_key'))) {
                 $key = ee()->pro_search_settings->get('license_key');
-            } else {
-                // Make a pseudo-random key for the Build Index ACT key
-                $key = strtoupper(bin2hex(random_bytes(20)));
             }
 
-            ee()->pro_search_settings->set(['build_index_act_key' => $key]);
-
-            ee()->db->where('class', $this->class_name . '_ext');
-            ee()->db->update('extensions', array('settings' => serialize(ee()->pro_search_settings->get())));
+            // Create a new ACT key
+            $this->createNewActKey($key);
         }
+    }
+
+    private function createNewActKey($key = null)
+    {
+        // If we didnt pass in a key, generate one
+        if (is_null($key)) {
+            // Make a pseudo-random key for the Build Index ACT key
+            $key = strtoupper(bin2hex(random_bytes(20)));
+        }
+
+        ee()->pro_search_settings->set(['build_index_act_key' => $key]);
+
+        ee()->db->where('class', $this->class_name . '_ext');
+        ee()->db->update('extensions', array('settings' => serialize(ee()->pro_search_settings->get())));
     }
 
     private function logMessageAboutLowVersion()

--- a/system/ee/language/english/pro_search_lang.php
+++ b/system/ee/language/english/pro_search_lang.php
@@ -442,6 +442,13 @@ $lang = array(
     "default_result_page_help" =>
     "If a <code>result_page</code> is not explicitly given, the search will fall back to this result page.",
 
+    "build_index_act_key" =>
+    "Build Index ACT Key",
+
+    "build_index_act_key_help" =>
+    "Key for building the index via an ACT url. This can be anything, but we recommend an alphanumeric string 16+ characters long. Please note, building the index via an ACT url will not work if this key is not set. Example ACT URL for building a collection with id 1: <br>
+    <code>%s</code>",
+
     "min_word_length" =>
     "Minimum word length",
 


### PR DESCRIPTION
Fixes #2743

Adds setting to pro search:
<img width="966" alt="Screenshot 2023-01-13 at 4 02 35 PM" src="https://user-images.githubusercontent.com/11818941/212434651-104c3ef7-4a2b-4ada-95c1-4af23c816f6b.png">

It will automatically generate a key on install and on upgrade. If there is still a license key saved in the settings from Low Search, it will use that so existing ACT URLs continue to work.
