### PR TITLE
Resolved issue when files on non-local filesystem could not be resized or cropped from CP

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Files/File.php
+++ b/system/ee/ExpressionEngine/Controller/Files/File.php
@@ -90,7 +90,7 @@ class File extends AbstractFilesController
         if ($file->isEditableImage()) {
             ee()->load->library('image_lib');
             // we should really be storing the image properties in the db during file upload
-            $info = $file->actLocally(function($path) {
+            $info = $file->actLocally(function ($path) {
                 return ee()->image_lib->get_image_properties($path, true);
             });
             ee()->image_lib->error_msg = array(); // Reset any erorrs
@@ -209,17 +209,20 @@ class File extends AbstractFilesController
                 ee()->form_validation->set_rules('crop_x', 'lang:x_axis', 'trim|numeric|required');
                 ee()->form_validation->set_rules('crop_y', 'lang:y_axis', 'trim|numeric|required');
                 $action_desc = "cropped";
+
                 break;
             case 'rotate':
                 ee()->form_validation->set_rules('rotate', 'lang:rotate', 'required');
                 $action_desc = "rotated";
                 $active_tab = 1;
+
                 break;
             case 'resize':
                 ee()->form_validation->set_rules('resize_width', 'lang:width', 'trim|is_natural');
                 ee()->form_validation->set_rules('resize_height', 'lang:height', 'trim|is_natural');
                 $action_desc = "resized";
                 $active_tab = 2;
+
                 break;
         }
 
@@ -332,7 +335,7 @@ class File extends AbstractFilesController
             if (ee('Permission')->can('edit_other_entries_channel_id_' . $entry->channel_id)
                 || (ee('Permission')->can('edit_self_entries_channel_id_' . $entry->channel_id) &&
                 $entry->author_id == ee()->session->userdata('member_id'))) {
-                    $title = '<a href="' . ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id) . '">' . $title . '</a>';
+                $title = '<a href="' . ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id) . '">' . $title . '</a>';
             }
             $attrs = [];
             $columns = [
@@ -368,7 +371,7 @@ class File extends AbstractFilesController
             $can_edit = explode('|', rtrim((string) $category->CategoryGroup->can_edit_categories, '|'));
             if (ee('Permission')->isSuperAdmin()
                 || (ee('Permission')->can('edit_categories') && ee('Permission')->hasAnyRole($can_edit))) {
-                    $title = '<a href="' . ee('CP/URL')->make('categories/edit/' . $category->group_id . '/' . $category->cat_id) . '">' . $title . '</a>';
+                $title = '<a href="' . ee('CP/URL')->make('categories/edit/' . $category->group_id . '/' . $category->cat_id) . '">' . $title . '</a>';
             }
             $attrs = [];
             $columns = [
@@ -381,7 +384,7 @@ class File extends AbstractFilesController
             );
         }
         $categoriesTable->setData($data);
-        
+
         $section = [
             [
                 'title' => 'usage_desc',

--- a/system/ee/ExpressionEngine/Controller/Files/File.php
+++ b/system/ee/ExpressionEngine/Controller/Files/File.php
@@ -236,12 +236,12 @@ class File extends AbstractFilesController
             $response = null;
             switch ($action) {
                 case 'crop':
-                    $response = ee()->filemanager->_do_crop($file->getAbsolutePath());
+                    $response = ee()->filemanager->_do_crop($file->getAbsolutePath(), $file->getFilesystem());
 
                     break;
 
                 case 'rotate':
-                    $response = ee()->filemanager->_do_rotate($file->getAbsolutePath());
+                    $response = ee()->filemanager->_do_rotate($file->getAbsolutePath(), $file->getFilesystem());
 
                     break;
 
@@ -258,7 +258,7 @@ class File extends AbstractFilesController
                         }
                     }
 
-                    $response = ee()->filemanager->_do_resize($file->getAbsolutePath());
+                    $response = ee()->filemanager->_do_resize($file->getAbsolutePath(), $file->getFilesystem());
 
                     break;
             }

--- a/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
@@ -447,7 +447,7 @@ class Filesystem
 
         try {
             $this->copy($source, $dest, (!is_null($destinationFilesystem)) ? $that : null);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $that->rename($destBackup, $dest);
 
             throw $e;
@@ -666,7 +666,7 @@ class Filesystem
 
         try {
             $size = $this->flysystem->getSize($path);
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
         }
 
         return $size;

--- a/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
@@ -28,7 +28,7 @@ class Filesystem
             $syspath = str_replace('\\', '/', SYSPATH);
             $openBaseDir = ini_get('open_basedir');
             // Check if open_basedir restrictions are in effect
-            if(!empty($openBaseDir)) {
+            if (!empty($openBaseDir)) {
                 // Find the open_basedir root that our $syspath lives under
                 foreach (explode(':', ini_get('open_basedir')) as $path) {
                     $normalizedPath = str_replace('\\', '/', $path);
@@ -36,14 +36,14 @@ class Filesystem
                         $syspathRoot = $normalizedPath;
                     }
                 }
-            }else{
+            } else {
                 // If open_basedir is not enabled set our root to the top directory in the syspath
                 $syspathRoot = realpath($syspath . str_repeat('../', substr_count($syspath, '/') - 1));
             }
             $adapter = new Adapter\Local([
                 'path' => $this->normalizeAbsolutePath($syspathRoot ?: $syspath)
             ]);
-        }else{
+        } else {
             // Fix prefixes
             $adapter->setPathPrefix($this->normalizeAbsolutePath($adapter->getPathPrefix()));
         }
@@ -100,6 +100,7 @@ class Filesystem
     public function readStream($path)
     {
         $path = $this->normalizeRelativePath($path);
+
         return $this->flysystem->readStream($path);
     }
 
@@ -171,6 +172,7 @@ class Filesystem
     public function writeStream($path, $resource, array $config = [])
     {
         $path = $this->normalizeRelativePath($path);
+
         return $this->flysystem->writeStream($path, $resource, $config);
     }
 
@@ -220,7 +222,7 @@ class Filesystem
     {
         $path = $this->normalizeRelativePath($path);
 
-        if($this->isDir($path)) {
+        if ($this->isDir($path)) {
             return $this->deleteDir($path);
         }
 
@@ -310,6 +312,7 @@ class Filesystem
     public function getWithMetadata($path, $metadata = [])
     {
         $path = $this->normalizeRelativePath($path);
+
         return $this->flysystem->getWithMetadata($this->normalize($path), $metadata);
     }
 
@@ -346,7 +349,7 @@ class Filesystem
         }
 
         // if renaming directory not on local driver...
-        if(!$this->isFile($source) && !$this->isLocal()) {
+        if (!$this->isFile($source) && !$this->isLocal()) {
             return $this->renameFolder($this->normalize($source), $this->normalize($dest));
         }
 
@@ -357,7 +360,6 @@ class Filesystem
 
         return $renamed;
     }
-
 
     /**
      * Rename a folder and all of the files and folders contained within
@@ -372,13 +374,13 @@ class Filesystem
         $this->mkDir($dest, false);
 
         $contents = $this->getDirectoryContents($source);
-        foreach($contents as $path) {
+        foreach ($contents as $path) {
             $toPath = str_replace($source, $dest, $path);
             $result = ($this->isFile($path)) ? $this->flysystem->rename($path, $toPath) : $this->renameFolder($path, $toPath);
             $success = $success && $result;
         }
 
-        if($success) {
+        if ($success) {
             $this->deleteDir($source);
         }
 
@@ -406,7 +408,7 @@ class Filesystem
 
         if ($this->isDir($source)) {
             $result = $this->recursiveCopy($source, $dest, $destinationFilesystem);
-        } else if($destinationFilesystem) {
+        } elseif ($destinationFilesystem) {
             $result = $destinationFilesystem->writeStream($dest, $this->readStream($source));
         } else {
             $result = $this->flysystem->copy($this->normalize($source), $this->normalize($dest));
@@ -429,31 +431,31 @@ class Filesystem
         $source = $this->normalizeRelativePath($source);
         $that = ($destinationFilesystem) ?: $this;
         $dest = $that->normalizeRelativePath($dest);
-        $destBackup = rtrim($dest, '\\/').'.backup';
+        $destBackup = rtrim($dest, '\\/') . '.backup';
 
         if (!$this->exists($source)) {
             throw new FilesystemException("Cannot copy non-existent path: {$source}");
-        }
-
-        if($that->exists($destBackup)) {
-            $that->delete($destBackup);
-        }
-
-        if($that->exists($dest)) {
-            $that->rename($dest, $destBackup);
-        }
-
-        try {
-            $this->copy($source, $dest, (!is_null($destinationFilesystem)) ? $that : null);
-        }catch(\Exception $e) {
-            $that->rename($destBackup, $dest);
-            throw $e;
         }
 
         if ($that->exists($destBackup)) {
             $that->delete($destBackup);
         }
 
+        if ($that->exists($dest)) {
+            $that->rename($dest, $destBackup);
+        }
+
+        try {
+            $this->copy($source, $dest, (!is_null($destinationFilesystem)) ? $that : null);
+        } catch(\Exception $e) {
+            $that->rename($destBackup, $dest);
+
+            throw $e;
+        }
+
+        if ($that->exists($destBackup)) {
+            $that->delete($destBackup);
+        }
     }
 
     /**
@@ -472,13 +474,13 @@ class Filesystem
         $that->flysystem->createDir($dest);
         $result = true;
 
-        foreach($dir as $file) {
+        foreach ($dir as $file) {
             $from = $source . '/' . $file['basename'];
             $to = $dest . '/' . $file['basename'];
 
             if ($this->isDir($from)) {
                 $result = $result && $this->recursiveCopy($from, $to, $destinationFilesystem);
-            } else if(!is_null($destinationFilesystem)) {
+            } elseif (!is_null($destinationFilesystem)) {
                 $result = $result && $destinationFilesystem->writeStream($to, $this->readStream($from));
             } else {
                 $result = $result && $this->flysystem->copy($from, $to);
@@ -499,13 +501,13 @@ class Filesystem
     public function move($source, $dest, $destinationFilesystem = null)
     {
         // Moving a file without a different destination filesystem is just rename
-        if(is_null($destinationFilesystem)) {
+        if (is_null($destinationFilesystem)) {
             return $this->rename($source, $dest);
         }
 
         $copied = $this->copy($source, $dest, $destinationFilesystem);
 
-        if($copied) {
+        if ($copied) {
             return $this->delete($source);
         }
 
@@ -664,7 +666,8 @@ class Filesystem
 
         try {
             $size = $this->flysystem->getSize($path);
-        }catch(\Exception $e){}
+        } catch(\Exception $e) {
+        }
 
         return $size;
     }
@@ -702,6 +705,7 @@ class Filesystem
             return is_dir($this->ensurePrefixedPath($path));
         }
         $path = $this->normalizeRelativePath($path);
+
         return empty($this->extension($path)) && $this->exists($path);
     }
 
@@ -758,7 +762,7 @@ class Filesystem
      */
     public function isWritable($path = '/')
     {
-        if(! $this->isLocal()) {
+        if (! $this->isLocal()) {
             return true;
         }
 
@@ -820,7 +824,7 @@ class Filesystem
      */
     public function getFreeDiskSpace($path = '/')
     {
-        if(!$this->isLocal()) {
+        if (!$this->isLocal()) {
             return null;
         }
 
@@ -855,23 +859,23 @@ class Filesystem
 
         $i = 0;
         $extension = $this->extension($path);
-        $dirname =  ($this->dirname($path) !== '.') ? $this->dirname($path) . '/' : '';
+        $dirname = ($this->dirname($path) !== '.') ? $this->dirname($path) . '/' : '';
         $filename = $this->filename($path);
 
         // Glob only works with local filesytem but is more performant than filtering directory results
         if ($this->isLocal()) {
-            $files = array_map(function($file) {
+            $files = array_map(function ($file) {
                 return $this->filename($file);
             }, glob($this->absolute($dirname . $filename) . '_*' . $extension));
-        }else{
+        } else {
             // Filter out any files that do not start with our filename
-            $files = array_filter($this->getDirectoryContents($dirname), function($file) use($filename) {
+            $files = array_filter($this->getDirectoryContents($dirname), function ($file) use ($filename) {
                 return strpos($file, "{$filename}_") === 0;
             });
         }
 
         // If we do not have any matching files at this point it gets the _1 suffix
-        if(empty($files)) {
+        if (empty($files)) {
             return $dirname . "{$filename}_1.{$extension}";
         }
 
@@ -885,6 +889,7 @@ class Filesystem
                 $number = str_replace('_', '', $number);
                 if (is_numeric($number)) {
                     $i = (int) $number;
+
                     break;
                 }
             }
@@ -960,7 +965,7 @@ class Filesystem
     public function ensureCorrectAccessMode($path)
     {
         // This function is only relevant to Local filesystems
-        if(!$this->isLocal()) {
+        if (!$this->isLocal()) {
             return;
         }
 
@@ -981,7 +986,7 @@ class Filesystem
     {
         $path = $this->normalizeRelativePath($path);
 
-        if(!$this->isFile($path)) {
+        if (!$this->isFile($path)) {
             throw new \Exception("Cannot create a temp file from path: $path");
         }
 
@@ -999,8 +1004,8 @@ class Filesystem
     public function createTempFile()
     {
         $file = tmpfile();
-        if($file === false) {
-            throw new \Exception('Cannot create temp file at "'.sys_get_temp_dir().'"');
+        if ($file === false) {
+            throw new \Exception('Cannot create temp file at "' . sys_get_temp_dir() . '"');
         }
 
         $path = stream_get_meta_data($file)['uri'];
@@ -1037,7 +1042,7 @@ class Filesystem
      */
     protected function normalizeAbsolutePath($path)
     {
-        if(empty($path)) {
+        if (empty($path)) {
             return '';
         }
 
@@ -1086,6 +1091,7 @@ class Filesystem
     protected function removePathPrefix($path)
     {
         $prefix = $this->getPathPrefix();
+
         return (!empty($prefix) && strpos($path, $prefix) === 0) ? substr_replace($path, '', 0, strlen($prefix)) : $path;
     }
 
@@ -1098,6 +1104,7 @@ class Filesystem
     protected function normalizeRelativePath($path)
     {
         $path = $this->normalizeAbsolutePath($path);
+
         return ltrim($this->removePathPrefix($path), '\\/');
     }
 

--- a/system/ee/legacy/libraries/Filemanager.php
+++ b/system/ee/legacy/libraries/Filemanager.php
@@ -30,7 +30,7 @@ class Filemanager
     /**
      * Constructor
      *
-     * @access	public
+     * @access public
      */
     public function __construct()
     {
@@ -55,11 +55,11 @@ class Filemanager
      * @param string $filename The filename to clean the name of
      * @param integer $dir_id The ID of the directory in which we'll check for duplicates
      * @param array $parameters Associative array containing optional parameters
-     * 		'convert_spaces' (Default: TRUE) Setting this to FALSE will not remove spaces
-     * 		'ignore_dupes' (Default: TRUE) Setting this to FALSE will check for duplicates
+     *   'convert_spaces' (Default: TRUE) Setting this to FALSE will not remove spaces
+     *   'ignore_dupes' (Default: TRUE) Setting this to FALSE will check for duplicates
      *
      * @return string Full path and filename of the file, use basepath() to just
-     * 		get the filename
+     *   get the filename
      */
     public function clean_filename($filename, $dir_id, $parameters = array())
     {
@@ -132,7 +132,7 @@ class Filemanager
      * Get the upload directory preferences for an individual directory
      *
      * @param integer $dir_id ID of the directory to get preferences for
-     * @param	bool $ignore_site_id If TRUE, returns upload destinations for all sites
+     * @param bool $ignore_site_id If TRUE, returns upload destinations for all sites
      */
     public function fetch_upload_dir_prefs($dir_id, $ignore_site_id = false)
     {
@@ -195,9 +195,9 @@ class Filemanager
     /**
      * Checks to see if the image is an editable/resizble image
      *
-     * @param	string	$file_path	The full path to the file to check
-     * @param	string	$mime		The file's mimetype
-     * @return	boolean	TRUE if the image is editable, FALSE otherwise
+     * @param string $file_path The full path to the file to check
+     * @param string $mime  The file's mimetype
+     * @return boolean TRUE if the image is editable, FALSE otherwise
      */
     public function is_editable_image($file_path, $mime)
     {
@@ -233,8 +233,8 @@ class Filemanager
     /**
      * Gets Image Height and Width
      *
-     * @param	string	$file_path	The full path to the file to check
-     * @return	mixed	False if function not available, associative array otherwise
+     * @param string $file_path The full path to the file to check
+     * @return mixed False if function not available, associative array otherwise
      */
     public function get_image_dimensions($file_path, $filesystem = null)
     {
@@ -272,8 +272,8 @@ class Filemanager
     /**
      * Save File
      *
-     * @access	public
-     * @param	boolean	$check_permissions	Whether to check permissions or not
+     * @access public
+     * @param boolean $check_permissions Whether to check permissions or not
      */
     public function save_file($file_path, $directory, $prefs = array(), $check_permissions = true)
     {
@@ -425,8 +425,8 @@ class Filemanager
     /**
      * Reorient main image if exif info indicates we should
      *
-     * @access	public
-     * @return	void
+     * @access public
+     * @return void
      */
     public function orientation_check($file_path, $prefs)
     {
@@ -513,8 +513,8 @@ class Filemanager
     /**
      * Resizes main image if it exceeds max heightxwidth- adds metadata to file_data array
      *
-     * @access	public
-     * @return	void
+     * @access public
+     * @return void
      */
     public function max_hw_check($file_path, $prefs)
     {
@@ -613,9 +613,9 @@ class Filemanager
      * Checks the permissions of the current user and directory
      * Returns TRUE if they have access FALSE otherwise
      *
-     * @access	private
-     * @param	int|string	$dir_id		Directory to check permissions on
-     * @return	boolean		TRUE if current user has access, FALSE otherwise
+     * @access private
+     * @param int|string $dir_id  Directory to check permissions on
+     * @return boolean  TRUE if current user has access, FALSE otherwise
      */
     private function _check_permissions($dir_id)
     {
@@ -641,9 +641,9 @@ class Filemanager
     /**
      * Send save_file response
      *
-     * @param	boolean		$status		TRUE if save_file passed, FALSE otherwise
-     * @param	string		$message	Message to send
-     * @return	array		Associative array containing the status and message/file_id
+     * @param boolean  $status  TRUE if save_file passed, FALSE otherwise
+     * @param string  $message Message to send
+     * @return array  Associative array containing the status and message/file_id
      */
     private function _save_file_response($status, $message = '')
     {
@@ -666,9 +666,9 @@ class Filemanager
      *
      * Main Backend Handler
      *
-     * @access	public
-     * @param	mixed	configuration options
-     * @return	void
+     * @access public
+     * @param mixed configuration options
+     * @return void
      */
     public function process_request($config = array())
     {
@@ -725,9 +725,9 @@ class Filemanager
     /**
      * Initialize
      *
-     * @access	private
-     * @param	mixed	configuration options
-     * @return	void
+     * @access private
+     * @param mixed configuration options
+     * @return void
      */
     public function _initialize($config)
     {
@@ -744,9 +744,9 @@ class Filemanager
      *
      * The real filebrowser bootstrapping function. Generates the required html.
      *
-     * @access	private
-     * @param	mixed	configuration options
-     * @return	void
+     * @access private
+     * @param mixed configuration options
+     * @return void
      */
     public function setup()
     {
@@ -777,7 +777,7 @@ class Filemanager
             $vars['filemanager_backend_url'] = ee()->cp->get_safe_refresh();
         }
 
-        unset($_GET['action']);	// current url == get_safe_refresh()
+        unset($_GET['action']); // current url == get_safe_refresh()
 
         $vars['filemanager_directories'] = $this->directories(false);
 
@@ -800,7 +800,7 @@ class Filemanager
         $filebrowser_html = ee()->load->ee_view('_shared/file/browser', $vars, true);
 
         ee()->output->send_ajax_response(array(
-            'manager' => str_replace(array("\n", "\t"), '', $filebrowser_html),	// reduces transfer size
+            'manager' => str_replace(array("\n", "\t"), '', $filebrowser_html), // reduces transfer size
             'directories' => $vars['filemanager_directories']
         ));
     }
@@ -913,15 +913,15 @@ class Filemanager
      *
      * Get information for a single directory
      *
-     * @access	public
-     * @param	int		directory id
-     * @param	bool	ajax request (optional)
-     * @param	bool	return all info (optional)
-     * @return	mixed	directory information
+     * @access public
+     * @param int  directory id
+     * @param bool ajax request (optional)
+     * @param bool return all info (optional)
+     * @return mixed directory information
      */
     public function directory($dir_id, $ajax = false, $return_all = false, $ignore_site_id = false)
     {
-        $return_all = ($ajax) ? false : $return_all;		// safety - ajax calls can never get all info!
+        $return_all = ($ajax) ? false : $return_all;  // safety - ajax calls can never get all info!
 
         $dirs = $this->directories(false, $return_all, $ignore_site_id);
 
@@ -939,10 +939,10 @@ class Filemanager
      *
      * Get all directory information
      *
-     * @access	public
-     * @param	bool	ajax request (optional)
-     * @param	bool	return all info (optional)
-     * @return	mixed	directory information
+     * @access public
+     * @param bool ajax request (optional)
+     * @param bool return all info (optional)
+     * @return mixed directory information
      */
     public function directories($ajax = false, $return_all = false, $ignore_site_id = false)
     {
@@ -957,7 +957,7 @@ class Filemanager
             $dirs = call_user_func($this->config['directories_callback'], array('ignore_site_id' => $ignore_site_id));
         }
 
-        if ($return_all and ! $ajax) {	// safety - ajax calls can never get all info!
+        if ($return_all and ! $ajax) { // safety - ajax calls can never get all info!
             $return = $dirs;
         } else {
             foreach ($dirs as $dir_id => $info) {
@@ -977,8 +977,8 @@ class Filemanager
      *
      * Get all files in a directory
      *
-     * @access	public
-     * @return	mixed	directory information
+     * @access public
+     * @return mixed directory information
      */
     public function directory_contents()
     {
@@ -1048,11 +1048,11 @@ class Filemanager
      *
      * Upload a files
      *
-     * @access	public
-     * @param	int		$dir_id		Upload Directory ID
-     * @param	string	$field		Upload Field Name (optional - defaults to first upload field)
-     * @param 	boolean $image_only	Override to restrict uploads to images
-     * @return	mixed	uploaded file info
+     * @access public
+     * @param int  $dir_id  Upload Directory ID
+     * @param string $field  Upload Field Name (optional - defaults to first upload field)
+     * @param  boolean $image_only Override to restrict uploads to images
+     * @return mixed uploaded file info
      */
     public function upload_file($dir_id = '', $field = false, $image_only = false, $subfolder_id = 0)
     {
@@ -1115,16 +1115,16 @@ class Filemanager
      *
      * Create Thumbnails for a file
      *
-     * @access	public
-     * @param	string	file path
-     * @param	array	file and directory information
-     * @param	bool	Whether or not to create a thumbnail; will do so
-     *		regardless of missing_only setting because directory syncing
-     *		needs to update thumbnails even if no image manipulations are
-     *		updated.
-     * @param	bool	Whether or not to replace missing image
-     *		manipulations only (TRUE) or replace them all (FALSE).
-     * @return	bool	success / failure
+     * @access public
+     * @param string file path
+     * @param array file and directory information
+     * @param bool Whether or not to create a thumbnail; will do so
+     *  regardless of missing_only setting because directory syncing
+     *  needs to update thumbnails even if no image manipulations are
+     *  updated.
+     * @param bool Whether or not to replace missing image
+     *  manipulations only (TRUE) or replace them all (FALSE).
+     * @return bool success / failure
      */
     public function create_thumb($file_path, $prefs, $thumb = true, $missing_only = true)
     {
@@ -1368,10 +1368,10 @@ class Filemanager
      *
      * Create a Watermarked Image
      *
-     * @access	public
-     * @param	string	full path to image
-     * @param	array	file information
-     * @return	bool	success / failure
+     * @access public
+     * @param string full path to image
+     * @param array file information
+     * @return bool success / failure
      */
     public function create_watermark($image_path, $data)
     {
@@ -1398,10 +1398,10 @@ class Filemanager
      *
      * Create a Thumbnail for a file
      *
-     * @access	public
-     * @param	mixed	directory information
-     * @param	mixed	file information
-     * @return	bool	success / failure
+     * @access public
+     * @param mixed directory information
+     * @param mixed file information
+     * @return bool success / failure
      */
     public function ajax_create_thumb()
     {
@@ -1422,11 +1422,11 @@ class Filemanager
      * This assumes the thumbnail has already been created
      *
      * @param array $file Response from save_file, should be an associative array
-     * 	and minimally needs to contain the file_name and the mime_type/file_type
-     * 	Optionally, you can use the file name in the event you don't have the
-     * 	full response from save_file
+     *  and minimally needs to contain the file_name and the mime_type/file_type
+     *  Optionally, you can use the file name in the event you don't have the
+     *  full response from save_file
      * @param integer $directory_id The ID of the upload directory the file is in
-     * @param	bool $ignore_site_id If TRUE, returns upload destinations for all sites
+     * @param bool $ignore_site_id If TRUE, returns upload destinations for all sites
      * @return string URL to the thumbnail
      */
     public function get_thumb($file, $directory_id, $ignore_site_id = false, $filesystem = null)
@@ -1474,10 +1474,10 @@ class Filemanager
      *
      * Creates a list of available thumbnails based on the supplied information
      *
-     * @access	public
-     * @param	mixed	directory information
-     * @param	mixed	list of files
-     * @return	mixed	list of files with added 'has_thumb' boolean key
+     * @access public
+     * @param mixed directory information
+     * @param mixed list of files
+     * @return mixed list of files with added 'has_thumb' boolean key
      */
     public function find_thumbs($dir, $files)
     {
@@ -1589,14 +1589,14 @@ class Filemanager
 
         return $config;
     }
-    //	Default Callbacks
+    // Default Callbacks
     /**
      * Directories Callback
      *
      * The function that retrieves the actual directory information
      *
-     * @access	private
-     * @return	mixed	directory list
+     * @access private
+     * @return mixed directory list
      */
     private function _directories($params = array())
     {
@@ -1621,8 +1621,8 @@ class Filemanager
      *
      * The function that retrieves the actual files from a directory
      *
-     * @access	private
-     * @return	mixed	directory list
+     * @access private
+     * @return mixed directory list
      */
     public function _directory_contents($dir, $limit, $offset)
     {
@@ -1640,7 +1640,7 @@ class Filemanager
      * @param integer $offset Where to start
      *
      * @access private
-     * @return array	List of files
+     * @return array List of files
      */
     private function _browser_get_files($dir, $limit = 15, $offset = 0)
     {
@@ -1682,12 +1682,12 @@ class Filemanager
 
             // Setup the link
             $file['file_name'] = '
-				<a href="#"
-					title="' . $file['file_name'] . '"
-					onclick="$.ee_filebrowser.placeImage(' . $file['file_id'] . '); return false;"
-				>
-					' . urldecode($file['file_name']) . '
-				</a>';
+                <a href="#"
+                    title="' . $file['file_name'] . '"
+                    onclick="$.ee_filebrowser.placeImage(' . $file['file_id'] . '); return false;"
+                >
+                    ' . urldecode($file['file_name']) . '
+                </a>';
 
             $file['short_name'] = ellipsize($file['title'], 13, 0.5);
             $file['file_size'] = byte_format($file['file_size']);
@@ -1705,7 +1705,7 @@ class Filemanager
      * @access private
      * @param $dir Directory array, containing at least the id
      * @return array Array with the category group name as the key and the
-     *		categories as the values (see above)
+     *  categories as the values (see above)
      */
     private function _get_category_dropdown($dir)
     {
@@ -1735,7 +1735,7 @@ class Filemanager
      * the content-length of the request is larger than PHP's post_max_size
      *
      *
-     * @return	bool
+     * @return bool
      */
     public function validate_post_data()
     {
@@ -1817,18 +1817,18 @@ class Filemanager
      *
      * The function that handles the file upload logic (allowed upload? etc.)
      *
-     *	1. Establish the allowed types for the directory
-     *		- If the field is a custom field, make sure it's permissions aren't stricter
-     *	2. Upload the file
-     *		- Checks to see if XSS cleaning needs to be on
-     *		- Returns errors
-     *	3. Send file to save_file, which does more security, creates thumbs
-     *		and adds it to the database.
+     * 1. Establish the allowed types for the directory
+     *  - If the field is a custom field, make sure it's permissions aren't stricter
+     * 2. Upload the file
+     *  - Checks to see if XSS cleaning needs to be on
+     *  - Returns errors
+     * 3. Send file to save_file, which does more security, creates thumbs
+     *  and adds it to the database.
      *
-     * @access	private
-     * @param	object 	$dir 		Directory information from the database in array form
-     * @param	string	$field_name	Provide the field name in case it's a custom field
-     * @return 	array 	Array of file_data sent to Filemanager->save_file
+     * @access private
+     * @param object  $dir   Directory information from the database in array form
+     * @param string $field_name Provide the field name in case it's a custom field
+     * @return  array  Array of file_data sent to Filemanager->save_file
      */
     private function _upload_file($dir, $field_name, $directory_id = 0)
     {
@@ -1898,8 +1898,8 @@ class Filemanager
         }
 
         /* -------------------------------------------
-        /*	Hidden Configuration Variable
-        /*	- channel_form_overwrite => Allow authors to overwrite their own files via Channel Form
+        /* Hidden Configuration Variable
+        /* - channel_form_overwrite => Allow authors to overwrite their own files via Channel Form
         /* -------------------------------------------*/
 
         if (bool_config_item('channel_form_overwrite')) {
@@ -1974,8 +1974,8 @@ class Filemanager
         );
 
         /* -------------------------------------------
-        /*	Hidden Configuration Variable
-        /*	- channel_form_overwrite => Allow authors to overwrite their own files via Channel Form
+        /* Hidden Configuration Variable
+        /* - channel_form_overwrite => Allow authors to overwrite their own files via Channel Form
         /* -------------------------------------------*/
 
         if (isset($config['overwrite']) && $config['overwrite'] === true) {
@@ -2061,7 +2061,7 @@ class Filemanager
     /**
      * Overwrite OR Rename Files Manually
      *
-     * @access	public
+     * @access public
      * @param integer $file_id The ID of the file in exp_files
      * @param string $new_file_name The new file name for the file
      * @param string $replace_file_name The temporary replacement name for the file
@@ -2172,7 +2172,7 @@ class Filemanager
      *
      * @param object $new_file The data coming from the database for the deleted file
      * @param string $file_name The file name, the existing files are deleted
-     * 	and the new files are renamed within Filemanager::rename_file
+     *  and the new files are renamed within Filemanager::rename_file
      * @param integer $directory_id The directory ID where the file is located
      * @return object Object from database representing the data of the old item
      */
@@ -2252,8 +2252,8 @@ class Filemanager
     /**
      * Handle the edit actions
      *
-     * @access	public
-     * @return	mixed
+     * @access public
+     * @return mixed
      */
     public function edit_image()
     {
@@ -2330,7 +2330,7 @@ class Filemanager
             $config['new_image'] = $new_filename;
         }
 
-        //		$config['dynamic_output'] = TRUE;
+        //  $config['dynamic_output'] = TRUE;
 
         ee()->load->library('image_lib', $config);
 
@@ -2481,10 +2481,10 @@ class Filemanager
      *
      * This is a helper wrapper around the zip lib and download helper
      *
-     * @param 	mixed   string or array of urlencoded file names
-     * @param 	string	file directory the files are located in.
-     * @param 	string	optional name of zip file to download
-     * @return 	mixed 	nuttin' or boolean false if everything goes wrong.
+     * @param  mixed   string or array of urlencoded file names
+     * @param  string file directory the files are located in.
+     * @param  string optional name of zip file to download
+     * @return  mixed  nuttin' or boolean false if everything goes wrong.
      */
     public function download_files($files, $zip_name = 'downloaded_files.zip')
     {
@@ -2548,8 +2548,8 @@ class Filemanager
      * It's here to make things forward compatible for if/when image uploads
      * could be tossed in the database.
      *
-     * @param 	string		full system path to the image to examine
-     * @return 	array
+     * @param  string  full system path to the image to examine
+     * @return  array
      */
     public function get_file_info($file)
     {
@@ -2564,8 +2564,8 @@ class Filemanager
      * This function has been lifted from the CI file upload class, and tweaked
      * just a bit.
      *
-     * @param 	string 		path to file
-     * @return 	boolean		TRUE if image, FALSE if not
+     * @param  string   path to file
+     * @return  boolean  TRUE if image, FALSE if not
      */
     public function is_image($mime)
     {
@@ -2577,7 +2577,7 @@ class Filemanager
      *
      * Retrieves available font file names, returns associative array
      *
-     * @return 	array
+     * @return  array
      */
     public function fetch_fontlist()
     {
@@ -2608,9 +2608,9 @@ class Filemanager
      * method to process the image.
      *
      * Needs a few POST variables:
-     * 	- file_id: ID of the file
-     * 	- file_name: name of the file without full path
-     * 	- upload_dir: Directory ID
+     *  - file_id: ID of the file
+     *  - file_name: name of the file without full path
+     *  - upload_dir: Directory ID
      */
     public function _do_image_processing($redirect = true)
     {

--- a/system/ee/legacy/libraries/Filemanager.php
+++ b/system/ee/legacy/libraries/Filemanager.php
@@ -2762,8 +2762,7 @@ class Filemanager
                 'dimensions' => ee()->image_lib->get_image_properties($new['path'], true),
                 'file_info' => get_file_info($new['path'])
             );
-            $filesystem->delete($file_path);
-            $filesystem->writeStream($file_path, fopen($new['path'], 'r+'));
+            ee('Filesystem')->forceCopy($new['path'], $file_path, $filesystem);
         }
 
         ee()->image_lib->clear();
@@ -2810,8 +2809,7 @@ class Filemanager
                 'dimensions' => ee()->image_lib->get_image_properties($new['path'], true),
                 'file_info' => get_file_info($new['path'])
             );
-            $filesystem->delete($file_path);
-            $filesystem->writeStream($file_path, fopen($new['path'], 'r+'));
+            ee('Filesystem')->forceCopy($new['path'], $file_path, $filesystem);
         }
 
         ee()->image_lib->clear();
@@ -2865,8 +2863,7 @@ class Filemanager
                 'dimensions' => ee()->image_lib->get_image_properties($new['path'], true),
                 'file_info' => get_file_info($new['path'])
             );
-            $filesystem->delete($file_path);
-            $filesystem->writeStream($file_path, fopen($new['path'], 'r+'));
+            ee('Filesystem')->forceCopy($new['path'], $file_path, $filesystem);
         }
 
         ee()->image_lib->clear();


### PR DESCRIPTION
This update fixes a bug where performing a crop or resize on an image through the 'edit' view would fail when using a non-local filesystem.  Changing the file manager methods to accept an optional filesystem object allow us to ensure the transformations happen locally in temp files and then are moved to the appropriate destination.