### PR TITLE
Resolved issues with cache driver not being used

### DIFF
--- a/system/ee/ExpressionEngine/Addons/rte/Service/AbstractRteService.php
+++ b/system/ee/ExpressionEngine/Addons/rte/Service/AbstractRteService.php
@@ -46,7 +46,7 @@ abstract class AbstractRteService implements RteService {
                     $cache_key = '/rte/' . $configHandle . '/css';
                     $cachedCss = ee()->cache->get($cache_key, Cache::GLOBAL_SCOPE);
                     if ($cachedCss !== false) {
-                        $finfo = ee()->cache->file->get_metadata($cache_key, Cache::GLOBAL_SCOPE);
+                        $finfo = ee()->cache->get_metadata($cache_key, Cache::GLOBAL_SCOPE);
                         if ($finfo['mtime'] >= ee()->CSS_TMPL->template_edit_date) {
                             $prefixedCss = $cachedCss;
                         }

--- a/system/ee/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/ExpressionEngine/Controller/Addons/Addons.php
@@ -477,7 +477,7 @@ class Addons extends CP_Controller
             $addon_info->updateProlets();
         }
 
-        ee()->cache->file->delete('/addons-status');
+        ee()->cache->delete('/addons-status');
         ee('CP/JumpMenu')->clearAllCaches();
 
         foreach (array('first', 'third') as $party) {
@@ -661,7 +661,7 @@ class Addons extends CP_Controller
             }
         }
 
-        ee()->cache->file->delete('/addons-status');
+        ee()->cache->delete('/addons-status');
         ee('CP/JumpMenu')->clearAllCaches();
 
         $return = $this->base_url;

--- a/system/ee/ExpressionEngine/Controller/Jumps/Jumps.php
+++ b/system/ee/ExpressionEngine/Controller/Jumps/Jumps.php
@@ -29,7 +29,7 @@ class Jumps extends CP_Controller
         if (! AJAX_REQUEST) {
             $this->invalidRequest();
         }
-        
+
         // Dummy method to make sure it doesn't come up as a 404.
         // Is validated by the `checkRequestSegments()` in the constructor.
     }
@@ -44,8 +44,8 @@ class Jumps extends CP_Controller
         EE.cp.jumpMenuURL = '" . ee('CP/URL', 'JUMPTARGET')->compile() . "';
         EE.cp.JumpMenuCommands = " . json_encode($jumpMenuItems) .";";
 
-        $finfo = ee()->cache->file->get_metadata('jumpmenu/' . md5(ee()->session->getMember()->getId()));
-        ee()->javascript_loader->set_headers('jumpmenu', $finfo['mtime']); 
+        $finfo = ee()->cache->get_metadata('jumpmenu/' . md5(ee()->session->getMember()->getId()));
+        ee()->javascript_loader->set_headers('jumpmenu', $finfo['mtime']);
         ee()->output->set_header('Content-Length: ' . strlen($contents));
         ee()->output->set_output($contents);
     }
@@ -55,7 +55,7 @@ class Jumps extends CP_Controller
         if (! AJAX_REQUEST) {
             $this->invalidRequest();
         }
-        
+
         if (!ee('Permission')->can('access_addons')) {
             $this->sendResponse([]);
         }

--- a/system/ee/ExpressionEngine/Controller/License/License.php
+++ b/system/ee/ExpressionEngine/Controller/License/License.php
@@ -65,7 +65,7 @@ class License extends CP_Controller
         $data['sha'] = hash('sha256', json_encode($data));
 
         $encrypted = ee('Encrypt')->encode(json_encode($data), ee()->config->item('session_crypt_key'));
-        ee()->cache->file->save('/addons-status', $encrypted . '||s=' . hash('sha256', $encrypted), 0);
+        ee()->cache->save('/addons-status', $encrypted . '||s=' . hash('sha256', $encrypted), 0);
 
         return ee()->output->send_ajax_response(array(
             'messageType' => 'success',

--- a/system/ee/ExpressionEngine/Controller/Settings/Settings.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Settings.php
@@ -167,7 +167,7 @@ class Settings extends CP_Controller
     protected function saveSettings($sections)
     {
         // Clear the add-on cache in case they've changed their site license key.
-        ee()->cache->file->delete('/addons-status');
+        ee()->cache->delete('/addons-status');
 
         $fields = array();
 

--- a/system/ee/ExpressionEngine/Model/Member/Member.php
+++ b/system/ee/ExpressionEngine/Model/Member/Member.php
@@ -430,7 +430,7 @@ class Member extends ContentModel
     public function onAfterSave()
     {
         parent::onAfterSave();
-        ee()->cache->file->delete('jumpmenu/' . md5($this->member_id));
+        ee()->cache->delete('jumpmenu/' . md5($this->member_id));
     }
 
     public function onAfterDelete()
@@ -627,7 +627,7 @@ class Member extends ContentModel
         if (!empty($this->_cpHomepageUrl)) {
             return $this->_cpHomepageUrl;
         }
-        
+
         $cp_homepage = null;
         $cp_homepage_custom = 'homepage';
 

--- a/system/ee/ExpressionEngine/Service/Addon/Addon.php
+++ b/system/ee/ExpressionEngine/Service/Addon/Addon.php
@@ -784,13 +784,13 @@ class Addon
     public function checkCachedLicenseResponse()
     {
         // See if we have a cached check.
-        $cached = ee()->cache->file->get('/addons-status');
+        $cached = ee()->cache->get('/addons-status');
 
         if (empty($cached)) {
             return false;
         }
 
-        if (!ee()->cache->file->is_writable('/addons-status')) {
+        if (!ee()->cache->is_writable('/addons-status')) {
             $this->logLicenseError('license_error_file_not_writable');
 
             return false;

--- a/system/ee/ExpressionEngine/Service/JumpMenu/JumpMenu.php
+++ b/system/ee/ExpressionEngine/Service/JumpMenu/JumpMenu.php
@@ -1922,7 +1922,7 @@ class JumpMenu extends AbstractJumpMenu
             return [];
         }
 
-        $items = ee()->cache->file->get('jumpmenu/' . md5(ee()->session->getMember()->getId()));
+        $items = ee()->cache->get('jumpmenu/' . md5(ee()->session->getMember()->getId()));
         if (!empty($items)) {
             return $items;
         }
@@ -1937,7 +1937,7 @@ class JumpMenu extends AbstractJumpMenu
      */
     public function clearAllCaches()
     {
-        ee()->cache->file->delete('/jumpmenu/');
+        ee()->cache->delete('/jumpmenu/');
     }
 
     /**
@@ -1945,7 +1945,7 @@ class JumpMenu extends AbstractJumpMenu
      */
     public function primeCache()
     {
-        ee()->cache->file->delete('jumpmenu/' . md5(ee()->session->getMember()->getId()));
+        ee()->cache->delete('jumpmenu/' . md5(ee()->session->getMember()->getId()));
 
         //load language for all the jumps
         ee()->lang->load('jump_menu');
@@ -2264,7 +2264,7 @@ class JumpMenu extends AbstractJumpMenu
         // Cache our items. We're bypassing the checks for the default
         // cache driver because we want this to be cached and working
         // even if the dev has set caching to disabled.
-        ee()->cache->file->save('jumpmenu/' . md5(ee()->session->getMember()->getId()), $items, 3600);
+        ee()->cache->save('jumpmenu/' . md5(ee()->session->getMember()->getId()), $items, 3600);
 
         // Assign our combined item list back to our static variable.
         self::$items = $items;

--- a/system/ee/legacy/libraries/Cache/Cache.php
+++ b/system/ee/legacy/libraries/Cache/Cache.php
@@ -190,6 +190,20 @@ class Cache extends EE_Driver_Library
     }
 
     /**
+     * Checks whether cache key is writable
+     *
+     * @return	bool
+     */
+    public function is_writable($key = '', $scope = Cache::LOCAL_SCOPE)
+    {
+        if(method_exists($this->{$this->_adapter}, 'is_writable')) {
+            return $this->{$this->_adapter}->is_writable($key, $scope);
+        }
+
+        return true;
+    }
+
+    /**
      * Returns the name of the adapter currently in use
      *
      * @return	string	Name of adapter

--- a/system/ee/legacy/libraries/Cache/drivers/Cache_file.php
+++ b/system/ee/legacy/libraries/Cache/drivers/Cache_file.php
@@ -244,9 +244,9 @@ class EE_Cache_file extends CI_Driver
      *
      * @return	bool
      */
-    public function is_writable($key, $scope = Cache::LOCAL_SCOPE)
+    public function is_writable($key = '', $scope = Cache::LOCAL_SCOPE)
     {
-        $path = $this->_cache_path . $this->_namespaced_key($key, $scope);
+        $path = $this->_cache_path . (empty($key) ? '' : $this->_namespaced_key($key, $scope));
         return is_really_writable($path);
     }
 

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -390,7 +390,7 @@ class Cp
         $notices = array();
 
         // Show a notice if the cache folder is not writeable
-        if (! ee()->cache->file->is_supported()) {
+        if (! ee()->cache->is_writable() && ee()->cache->get_adapter() == 'file') {
             $notices[] = lang('unwritable_cache_folder');
         }
 


### PR DESCRIPTION
There are parts of the core that override the user's choice of cache driver and require the file cache.  This is confusing and particularly problematic in serverless environments where the file driver is not useful.  This change attempts to standardize more functionality and always rely on the user selected cache driver.