### PR TITLE
Resolved issue where saving Fluid without fields could result in PHP error

### DIFF
--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -540,7 +540,7 @@ class Fluid_field_ft extends EE_Fieldtype
         }
 
         if (isset($this->settings['field_channel_fields'])) {
-            $this->settings['field_channel_fields'] = array_filter($this->settings['field_channel_fields'], function ($value) {
+            $this->settings['field_channel_fields'] = array_filter((array) $this->settings['field_channel_fields'], function ($value) {
                 return is_numeric($value);
             });
 

--- a/system/ee/ExpressionEngine/Controller/Fields/Fields.php
+++ b/system/ee/ExpressionEngine/Controller/Fields/Fields.php
@@ -834,7 +834,7 @@ class Fields extends AbstractFieldsController
         $fieldFluidFields = ee('Model')->get('ChannelField')->filter('field_type', 'fluid_field')->all();
         if (!is_null($fieldFluidFields)) {
             foreach ($fieldFluidFields as $fieldFluidField) {
-                if (!empty($fieldFluidField->field_settings) && in_array($field->getId(), $fieldFluidField->field_settings['field_channel_fields'])) {
+                if (!empty($fieldFluidField->field_settings) && in_array($field->getId(), (array) $fieldFluidField->field_settings['field_channel_fields'])) {
                     $this->_getFieldChannels($fieldFluidField, lang('via') . ' ' . $fieldFluidField->field_name . ' (' . lang('fluid_field') . ')');
                 }
             }


### PR DESCRIPTION
If you create a new fluid field but do not attach any fields to it the settings for that field may be saved as a string.  This update forces it to be treated as an array.