### PR TITLE
Resolved #2087 to allow for class parameter in `{form:custom_profile_field}` tag

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
@@ -583,7 +583,6 @@ class Member_settings extends Member
             /**  Parse single variables
             /** ----------------------------------------*/
             foreach ($this->var_single as $key => $val) {
-
                 // Custom member fields
                 $field = ee('Variables/Parser')->parseVariableProperties($key);
                 $fval = $field['field_name'];
@@ -813,7 +812,7 @@ class Member_settings extends Member
                 $temp = str_replace('{lang:profile_field_shortname}', $field->getShortName(), $temp);
                 $temp = str_replace('{lang:profile_field_description}', $field->get('field_description'), $temp);
                 if ($match[4] != '') {
-                    switch($field->get('field_type')) {
+                    switch ($field->get('field_type')) {
                         case "text":
                             $temp = str_replace(
                                 $match[0],
@@ -981,7 +980,7 @@ class Member_settings extends Member
 
                 // Handle arrays of checkboxes as a special case;
                 if ($row['m_field_type'] == 'checkbox') {
-                    foreach ($row['choices']  as $property => $label) {
+                    foreach ($row['choices'] as $property => $label) {
                         $member->$fname = in_array($property, $post) ? 'y' : 'n';
                     }
                 } else {
@@ -1004,7 +1003,6 @@ class Member_settings extends Member
 
         //if this request initiated from regular EE template, we'll process some additional stuff here
         if (REQ === 'ACTION') {
-
             //email update
             if (ee()->input->post('email') != '' && ee()->input->post('email') != $member->email) {
                 $validator = ee('Validation')->make();
@@ -1720,9 +1718,7 @@ class Member_settings extends Member
         /** -------------------------------------
         /**  Parse the $_POST data
         /** -------------------------------------*/
-        if (ee('Request')->post('screen_name') == '' &&
-            ee('Request')->post('email') == ''
-            ) {
+        if (ee('Request')->post('screen_name') == '' && ee('Request')->post('email') == '') {
             ee()->functions->redirect($redirect_url);
             exit;
         }


### PR DESCRIPTION
Allow for `{form:custom_profile_field}` to take an `input-class` parameter to be added as a class to the resultant `<input>` or `<select>` elements. Likely simple to add for other field types but not attempted here.

Also added variables:
- `{lang:profile_field_clean}` to return label without required prefix
- `{lang:profile_field_name}` to return field name returned by `{form:custom_profile_field}`
- `{lang:profile_field_shortname}` to return field shortname

Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/2087

Documentation to be updated - https://docs.expressionengine.com/latest/member/edit-profile.html#custom-profile-field-variable-pair

Anticipated usage:
```
{custom_profile_fields}
     <div class="form-group">
          <label for="{lang:profile_field_name}" class="col-sm-4 control-label">{lang:profile_field_clean}:</label>
          <div class="col-sm-6">
              {form:custom_profile_field input_class="form-control"}
          </div>
      </div>
{/custom_profile_fields}
```