### PR TITLE
Resolved #2312 where conditional fields depending on radio button could be not loaded correctly when creating new entry

### DIFF
--- a/system/ee/ExpressionEngine/Addons/radio/EvaluationRules/Matches.php
+++ b/system/ee/ExpressionEngine/Addons/radio/EvaluationRules/Matches.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Addons\RadioButtons\EvaluationRules;
+use ExpressionEngine\Service\ConditionalFields\EvaluationRules\EvaluationRuleInterface;
+use ExpressionEngine\Service\ConditionalFields\EvaluationRules;
+
+/**
+ * Radio Matches Rule
+ */
+class Matches extends EvaluationRules\Matches implements EvaluationRuleInterface
+{
+    // for radio buttons, empty value is same as selecting first value
+    public function evaluate($fieldValue, $expectedValue, $fieldSettings)
+    {
+        if (is_null($fieldValue) && isset($fieldSettings['options']) && !empty($fieldSettings['options']) && $expectedValue === array_key_first($fieldSettings['options'])) {
+            return true;
+        }
+        return parent::evaluate($fieldValue, $expectedValue, $fieldSettings);
+    }
+}

--- a/system/ee/ExpressionEngine/Addons/radio/EvaluationRules/NotMatches.php
+++ b/system/ee/ExpressionEngine/Addons/radio/EvaluationRules/NotMatches.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Addons\RadioButtons\EvaluationRules;
+use ExpressionEngine\Service\ConditionalFields\EvaluationRules\EvaluationRuleInterface;
+use ExpressionEngine\Service\ConditionalFields\EvaluationRules;
+
+/**
+ * Radio NotMatches Rule
+ */
+class NotMatches extends EvaluationRules\NotMatches implements EvaluationRuleInterface
+{
+    // for radio buttons, empty value is same as selecting first value
+    public function evaluate($fieldValue, $expectedValue, $fieldSettings)
+    {
+        if (is_null($fieldValue) && isset($fieldSettings['options']) && !empty($fieldSettings['options']) && $expectedValue === array_key_first($fieldSettings['options'])) {
+            return false;
+        }
+        return parent::evaluate($fieldValue, $expectedValue, $fieldSettings);
+    }
+}

--- a/system/ee/ExpressionEngine/Service/ConditionalFields/EvaluationRules/EvaluationRuleInterface.php
+++ b/system/ee/ExpressionEngine/Service/ConditionalFields/EvaluationRules/EvaluationRuleInterface.php
@@ -22,6 +22,7 @@ interface EvaluationRuleInterface
      *
      * @param mixed $fieldValue
      * @param mixed $expectedValue
+     * @param array $fieldSettings
      * @return bool whether the condition is met
      */
     public function evaluate($fieldValue, $expectedValue, $fieldSettings);
@@ -32,7 +33,7 @@ interface EvaluationRuleInterface
      * @return string
      */
     public function getLanguageKey();
-    
+
     /**
      * The input type for the expected value (text, select, etc)
      * If returning NULL, the field is not displayed

--- a/system/ee/ExpressionEngine/Service/ConditionalFields/Evaluator.php
+++ b/system/ee/ExpressionEngine/Service/ConditionalFields/Evaluator.php
@@ -46,10 +46,17 @@ class Evaluator
         }
 
         // Get the conditional field
-        $evaluationRule = ee('ConditionalFields')->make($condition->evaluation_rule, $this->channelFields[$condition->condition_field_id]->getType());
+        $fieldTypeName = $this->channelFields[$condition->condition_field_id]->getType();
+        $fieldSettings = $this->channelFields[$condition->condition_field_id]->getSettings();
+        $evaluationRule = ee('ConditionalFields')->make($condition->evaluation_rule, $fieldTypeName);
+
+        // Radio field is special, we need to get options
+        if ($fieldTypeName == 'radio') {
+            $fieldSettings['options'] = $this->channelFields[$condition->condition_field_id]->getPossibleValuesForEvaluation();
+        }
 
         // Now lets evaluate the condition_field value and the rule value
-        return $evaluationRule->evaluate($this->channelFields[$condition->condition_field_id]->getData(), $condition->value, $this->channelFields[$condition->condition_field_id]->getSettings());
+        return $evaluationRule->evaluate($this->channelFields[$condition->condition_field_id]->getData(), $condition->value, $fieldSettings);
     }
 
     public function evaluateConditionSet(ConditionalFields\FieldConditionSet $set)

--- a/system/ee/ExpressionEngine/Service/ConditionalFields/Factory.php
+++ b/system/ee/ExpressionEngine/Service/ConditionalFields/Factory.php
@@ -17,22 +17,19 @@ class Factory
 {
     protected static $evaluationRules;
     protected static $installedFieldtypes;
-    
+
     /**
      * Make new or use existing evaluation rule
-     * 
+     *
      * @param string $ruleName
      * @param string $fieldTypeName
      * @return EvaluationRules\EvaluationRuleInterface
      */
     public function make($ruleName, $fieldTypeName = '')
     {
-        $ruleClass = "\\ExpressionEngine\\Service\\ConditionalFields\\EvaluationRules\\" . ucfirst($ruleName);
-        if (isset($evaluationRules[$ruleClass])) {
-            return $evaluationRules[$ruleClass];
-        }
-
-        if (!class_exists($ruleClass) && $fieldTypeName != '') {
+        $ruleClass = '';
+        // addons can overwrite the rules, so we check those first
+        if ($fieldTypeName != '') {
             if (empty(self::$installedFieldtypes)) {
                 ee()->load->library('api');
                 ee()->legacy_api->instantiate('channel_fields');
@@ -42,6 +39,13 @@ class Factory
             if (!empty($addon)) {
                 $ruleClass = $addon->getEvaluationRuleClass($ruleName);
             }
+            if (isset($evaluationRules[$ruleClass])) {
+                return $evaluationRules[$ruleClass];
+            }
+        }
+
+        if (empty($ruleClass) || !class_exists($ruleClass)) {
+            $ruleClass = "\\ExpressionEngine\\Service\\ConditionalFields\\EvaluationRules\\" . ucfirst($ruleName);
             if (isset($evaluationRules[$ruleClass])) {
                 return $evaluationRules[$ruleClass];
             }
@@ -59,7 +63,7 @@ class Factory
             );
         }
 
-        $evaluationRules[$ruleClass] = new $ruleClass;
+        $evaluationRules[$ruleClass] = new $ruleClass();
 
         return $evaluationRules[$ruleClass];
     }
@@ -76,7 +80,6 @@ class Factory
 
         return isset($interfaces[EvaluationRules\EvaluationRuleInterface::class]);
     }
-
 }
 
 // EOF


### PR DESCRIPTION
Resolved #2312 where conditional fields depending on radio button could be not loaded correctly when creating new entry

EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/2810