### PR TITLE
Resolved #2808 where some servers did not accept SVG files to be uploaded into image-only directory

### DIFF
--- a/system/ee/ExpressionEngine/Library/Mime/MimeType.php
+++ b/system/ee/ExpressionEngine/Library/Mime/MimeType.php
@@ -193,9 +193,9 @@ class MimeType
             return false;
         }
 
-        if ($mime == 'image/svg+xml') {
+        if (strpos($mime, 'image/svg') === 0) {
             $file = file_get_contents($path);
-            if ((strpos($file, '<?xml') !==0 && strpos($file, '<svg') !== 0) || strpos($file, '<svg') === false) {
+            if ((strpos($file, '<?xml') !== 0 && strpos($file, '<svg') !== 0) || strpos($file, '<svg') === false) {
                 return false;
             }
             return true;


### PR DESCRIPTION
Resolved #2808 where some servers did not accept SVG files to be uploaded into image-only directory

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/2811