### PR TITLE
Resolved issue when saving Grid field from third-party code could behave incorrectly

### DIFF
--- a/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
+++ b/system/ee/ExpressionEngine/Addons/relationship/ft.relationship.php
@@ -163,9 +163,9 @@ class Relationship_ft extends EE_Fieldtype implements ColumnInterface
 
         if (isset($this->settings['grid_field_id'])) {
             // grid takes the parent grid's field id and sticks it into "grid_field_id"
-            $all_rows_where['grid_col_id'] = $this->settings['col_id'];
-            $all_rows_where['grid_field_id'] = $this->settings['grid_field_id'];
-            $all_rows_where['grid_row_id'] = $this->settings['grid_row_id'];
+            $all_rows_where['grid_col_id'] = $this->settings['col_id'] ?? 0;
+            $all_rows_where['grid_field_id'] = $this->settings['grid_field_id'] ?? 0;
+            $all_rows_where['grid_row_id'] = $this->settings['grid_row_id'] ?? 0;
         }
 
         // clear old stuff


### PR DESCRIPTION
The `Grid_lib->save()` ends up calling this conditional:

```
if (! empty($rows[$i]['row_id'])) {
    $fieldtype->settings['grid_row_id'] = $rows[$i]['row_id'];
}
``` 

However, if $rows is empty it will not. The `grid_model->get_entry_rows()` function ends up calling the `grid_query` hook, and in my case Publisher uses that hook. There are scenarios where Publisher needs to delete grid rows, only to immediately add them back to properly manage grid rows for translations and drafts, thus it ends up deleting every grid row during the save process, then `Grid_lib->save()` is called and it's iterating over the `$deleted_rows` variable, which ends up making `$rows` an empty array. Meaning, the conditional above never gets called and the `grid_row_id` array key never exists. Publisher then adds back the correct rows for the translation/draft, so later on when the code changed in this PR is called `grid_row_id` does not exist throwing a E_NOTICE error.

Basically there is a brief period in which Grid rows do not exist, some of EE's code is called, then the rows are added back. EE thinks there are no rows when in actuality there are.

Regardless if Publisher being involved, using a default value incase that array key doesn't exist is just a safe bet.

Reference: https://boldminded.com/support/ticket/2583