### PR TITLE
Resolved an issue where the author filter could have a missing label.

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -150,7 +150,7 @@ jobs:
                 composer require overtrue/phplint --dev --no-progress --no-suggest --prefer-dist
 
             - name: Run PHPLint
-              run: ./system/ee/ExpressionEngine/Tests/vendor/bin/phplint ./ --exclude=system/ee/ExpressionEngine/Tests/vendor --exclude=system/ee/installer/config/config_tmpl.php --exclude=system/ee/ExpressionEngine/Service/Generator/stubs
+              run: ./system/ee/ExpressionEngine/Tests/vendor/bin/phplint --no-configuration ./ --exclude=system/ee/ExpressionEngine/Tests/vendor --exclude=system/ee/installer/config/config_tmpl.php --exclude=system/ee/ExpressionEngine/Service/Generator/stubs
 
             - name: Configure matchers
               uses: mheap/phpunit-matcher-action@v1

--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -372,7 +372,7 @@ class EntryListing
     private function createAuthorFilter($channel_id = null)
     {
         $db = ee('db')->distinct()
-            ->select('t.author_id, m.screen_name')
+            ->select('t.author_id, m.screen_name, m.username')
             ->from('channel_titles t')
             ->join('members m', 'm.member_id = t.author_id', 'LEFT')
             ->order_by('screen_name', 'asc');

--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -385,7 +385,7 @@ class EntryListing
 
         $author_filter_options = [];
         foreach ($authors_query->result() as $row) {
-            $author_filter_options[$row->author_id] = $row->screen_name;
+            $author_filter_options[$row->author_id] = (!empty($row->screen_name)) ? $row->screen_name : $row->username;
         }
 
         // Put the current user at the top of the author list

--- a/tests/cypress/cypress/integration/field/field_combinations.ee6.js
+++ b/tests/cypress/cypress/integration/field/field_combinations.ee6.js
@@ -26,6 +26,10 @@ context('Create combinations of field', () => {
 
 		cy.auth()
 
+		cy.window().then((win) => { 
+			win.parent.document.getElementsByClassName('reporter-wrap')[0].style.width = '70%';
+		});
+
 		cy.log('verifies fields page exists')
 		cy.visit('admin.php?/cp/fields')
 		cy.get('.main-nav__title > h1').contains('Field')
@@ -39,8 +43,18 @@ context('Create combinations of field', () => {
 		}
 
 		cy.log('Creates a bunch of Template Groups')
-		for(let j = 0 ; j < GroupName.length; j++){
-			addGroup(GroupName[j])
+		for(let j = 0; j < GroupName.length; j++){
+			cy.visit('admin.php?/cp/design/group/create', {
+				onBeforeLoad(win) {
+					cy.spy(win.console, 'log').as('spyWinConsoleLog');
+					cy.spy(win.console, 'error').as('spyWinConsoleError');
+				}
+			})
+			let title = 'aa' + GroupName[j];
+			cy.get('input[name="group_name"]').eq(0).type(title)
+			cy.wait(1000)
+			cy.get('[value="Save Template Group"]').eq(0).click()
+			cy.get('p').contains('has been created')
 		}
 
 		cy.log('Creates a Channel to work in')


### PR DESCRIPTION
If no screen name was set, you'd end up with author filters on edit entries and files where nothing showed in cases where screen name was missing.

You could also throw a php error in php 8.1+

```
htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated
ee/ExpressionEngine/Service/Filter/Filter.php, line 227```

