### PR TITLE
Resolved an issue where the author filter could have a missing label.

### DIFF
--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -372,7 +372,7 @@ class EntryListing
     private function createAuthorFilter($channel_id = null)
     {
         $db = ee('db')->distinct()
-            ->select('t.author_id, m.screen_name')
+            ->select('t.author_id, m.screen_name, m.username')
             ->from('channel_titles t')
             ->join('members m', 'm.member_id = t.author_id', 'LEFT')
             ->order_by('screen_name', 'asc');

--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -385,7 +385,7 @@ class EntryListing
 
         $author_filter_options = [];
         foreach ($authors_query->result() as $row) {
-            $author_filter_options[$row->author_id] = $row->screen_name;
+            $author_filter_options[$row->author_id] = (!empty($row->screen_name)) ? $row->screen_name : $row->username;
         }
 
         // Put the current user at the top of the author list


### PR DESCRIPTION
If no screen name was set, you'd end up with author filters on edit entries and files where nothing showed in cases where screen name was missing.

You could also throw a php error in php 8.1+

htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated ee/ExpressionEngine/Service/Filter/Filter.php, line 227

see also #2848

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
