### PR TITLE
Resolved #3035 where enabling front-end editing on very complex templates could cause some tags to be not parsed

### DIFF
--- a/system/ee/legacy/libraries/api/Api_channel_fields.php
+++ b/system/ee/legacy/libraries/api/Api_channel_fields.php
@@ -1392,11 +1392,11 @@ class Api_channel_fields extends Api
      */
     public function get_pair_field($tagdata, $field_name, $prefix = '')
     {
-        //in complex cases, Pro edit link might sneak into tagdata. It's causing regex issues, remove it.
-        $tagdata = str_replace('{' . $field_name . ':frontedit}', '', $tagdata);
         $pfield_chunk = array();
         $offset = 0;
         $field_name = $prefix . $field_name;
+        //in complex cases, Pro edit link might sneak into tagdata. It's causing regex issues, remove it.
+        $tagdata = str_replace('{' . $field_name . ':frontedit}', '', $tagdata);
         $end = strpos($tagdata, LD . '/' . $field_name, $offset);
 
         while ($end !== false) {


### PR DESCRIPTION
Resolved #3035 where enabling front-end editing on very complex templates could cause some tags to be not parsed