### PR TITLE
Resolved the issue where `{exp:member:memberlist}` might not render properly in some cases

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_memberlist.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_memberlist.php
@@ -704,6 +704,8 @@ class Member_memberlist extends Member
                     /** ----------------------------------------*/
                     if (isset($fields[$val]) and isset($row['m_field_id_' . $fields[$val]])) {
                         $temp = $this->_var_swap_single($val, $row['m_field_id_' . $fields[$val]], $temp);
+                    } elseif (isset($fields[$val]) and !isset($row['m_field_id_' . $fields[$val]])) {
+                        $temp = $this->_var_swap_single($val, '', $temp);
                     }
                 }
 

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_memberlist.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_memberlist.php
@@ -702,10 +702,12 @@ class Member_memberlist extends Member
                     /** ----------------------------------------
                     /**  parse custom member fields
                     /** ----------------------------------------*/
-                    if (isset($fields[$val]) and isset($row['m_field_id_' . $fields[$val]])) {
-                        $temp = $this->_var_swap_single($val, $row['m_field_id_' . $fields[$val]], $temp);
-                    } elseif (isset($fields[$val]) and !isset($row['m_field_id_' . $fields[$val]])) {
-                        $temp = $this->_var_swap_single($val, '', $temp);
+                    if (isset($fields[$val])) {
+                        if (isset($row['m_field_id_' . $fields[$val]])) {
+                            $temp = $this->_var_swap_single($val, $row['m_field_id_' . $fields[$val]], $temp);
+                        } else {
+                            $temp = $this->_var_swap_single($val, '', $temp);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Current `{exp:member:memberlist}{/exp:member:memberlist}` tag behavior will print custom member fields within `{member_rows}{/member_rows}` tags but if the custom field is blank for a certain user then it just leaves the holding tag from the template e.g. `{custom_member_field}`. This PR checks for these cases and replaces the holding tag with an empty string.