### PR TITLE
Resolved install issues on PHP 8.2

### DIFF
--- a/system/ee/ExpressionEngine/Service/Database/Query.php
+++ b/system/ee/ExpressionEngine/Service/Database/Query.php
@@ -25,6 +25,7 @@ require_once BASEPATH . "database/drivers/mysqli/mysqli_driver.php";
 class Query extends \CI_DB_mysqli_driver
 {
     protected $connection;
+    public $save_queries;
 
     public function __construct(Connection $connection)
     {

--- a/system/ee/installer/controllers/wizard.php
+++ b/system/ee/installer/controllers/wizard.php
@@ -131,6 +131,8 @@ class Wizard extends CI_Controller
         // Enabled for cleaner view files and compatibility
         'rewrite_short_tags' => true
     );
+	
+	public $db_connect_attempt;
 
     /**
      * Constructor

--- a/system/ee/installer/schema/mysql_schema.php
+++ b/system/ee/installer/schema/mysql_schema.php
@@ -21,6 +21,8 @@ class EE_Schema
     public $default_entry = '';
     public $theme_path = '';
     public $version;
+    public $userdata;
+
 
     private $default_engine = 'InnoDB';
 


### PR DESCRIPTION
Fixed some 'Dynamic Properties are deprecated' issues installing when running php 8.2