### PR TITLE
Resolved #2822, #2678 where some custom fields were not properly parsed in Live Preview mode

### DIFF
--- a/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
+++ b/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
@@ -1301,6 +1301,8 @@ class ChannelEntry extends ContentModel
 
                 if (! array_key_exists($key, $data)) {
                     $data[$key] = null;
+                } elseif ($field->field_type == 'date') {
+                    $data[$key] = $this->stringToTimestamp($data[$key]);
                 }
             }
         }

--- a/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
+++ b/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
@@ -1301,8 +1301,6 @@ class ChannelEntry extends ContentModel
 
                 if (! array_key_exists($key, $data)) {
                     $data[$key] = null;
-                } elseif ($field->field_type == 'date') {
-                    $data[$key] = $this->stringToTimestamp($data[$key]);
                 }
             }
         }

--- a/system/ee/ExpressionEngine/Service/LivePreview/LivePreview.php
+++ b/system/ee/ExpressionEngine/Service/LivePreview/LivePreview.php
@@ -101,6 +101,24 @@ class LivePreview
 
         $entry->set($_POST);
         $data = $entry->getModChannelResultsArray();
+        // because the template parser operates with saved data, and we have only raw data
+        // we need to normalize those first
+        // the data passed with POST can be different (array, or formatting applied)
+        // so we pass it through save() function of the fieldtypes
+        // which normally returns the field's to-be-saved content
+        ee()->legacy_api->instantiate('channel_fields');
+        foreach ($entry->getStructure()->getAllCustomFields() as $field) {
+            $key = 'field_id_' . $field->getId();
+            if (array_key_exists($key, $_POST) && !empty($data[$key])) {
+                $ftClass = ucfirst($field->field_type) . '_ft';
+                ee()->api_channel_fields->include_handler($field->field_type);
+                $justTheFt = new $ftClass();
+                $saved = $justTheFt->save($_POST[$key]);
+                if (!empty($saved)) {
+                    $data[$key] = $saved;
+                }
+            }
+        }
         $data['entry_site_id'] = $entry->site_id;
         if (isset($_POST['categories'])) {
             $data['categories'] = $_POST['categories'];


### PR DESCRIPTION
Resolved #2822 where Date fields were not properly parsed in Live Preview mode

Resolved #2678 where Checkboxes field was not rendered properly in Live Preview mode

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3085