### PR TITLE
Added config overrides for user and Control Panel session length; #3114

### DIFF
--- a/system/ee/legacy/libraries/Session.php
+++ b/system/ee/legacy/libraries/Session.php
@@ -103,6 +103,14 @@ class EE_Session
         ee()->load->library('remember');
         ee()->load->library('localize');
 
+        if (ee()->config->item('user_session_len')) {
+            $this->user_session_len = ee()->config->item('user_session_len');
+        }
+
+        if (ee()->config->item('cpan_session_len')) {
+            $this->cpan_session_len = ee()->config->item('cpan_session_len');
+        }
+
         $this->session_length = $this->_setup_session_length();
 
         $this->cookie_ttl = $this->_setup_cookie_ttl();

--- a/system/ee/legacy/libraries/Session.php
+++ b/system/ee/legacy/libraries/Session.php
@@ -103,12 +103,12 @@ class EE_Session
         ee()->load->library('remember');
         ee()->load->library('localize');
 
-        if (ee()->config->item('user_session_len')) {
-            $this->user_session_len = ee()->config->item('user_session_len');
+        if (ee()->config->item('user_session_length')) {
+            $this->user_session_len = ee()->config->item('user_session_length');
         }
 
-        if (ee()->config->item('cpan_session_len')) {
-            $this->cpan_session_len = ee()->config->item('cpan_session_len');
+        if (ee()->config->item('cpan_session_length')) {
+            $this->cpan_session_len = ee()->config->item('cpan_session_length');
         }
 
         $this->session_length = $this->_setup_session_length();


### PR DESCRIPTION
Resolves https://github.com/ExpressionEngine/ExpressionEngine/discussions/3114.

Adds the ability to add config overrides for the user TTL and CP TTL, to lengthen or shorten the time the session time.