### PR TITLE
Resolved #3116 where navigating File Picker from Category edit page caused  PHP error

### DIFF
--- a/system/ee/legacy/libraries/File_field.php
+++ b/system/ee/legacy/libraries/File_field.php
@@ -236,7 +236,8 @@ class File_field
         ee()->cp->add_js_script(array(
             'file' => array(
                 'fields/file/control_panel',
-                'fields/file/file_field_drag_and_drop'
+                'fields/file/file_field_drag_and_drop',
+                'cp/publish/entry-list'
             ),
         ));
 


### PR DESCRIPTION
Resolved #3116 where navigating File Picker from Category edit page caused  PHP error

Added the JS script that is now required for navigating filepicker in CP 
Because the filepicker is CP-only thing, we should fine with adding it always
