### PR TITLE
Added separate list with selected categories for Entry page Category tab #2807

### DIFF
--- a/cp-styles/app/styles/components/_checkboxes-and-radios.scss
+++ b/cp-styles/app/styles/components/_checkboxes-and-radios.scss
@@ -283,6 +283,36 @@ $radio-size: 15px;
   padding: 5px 15px 15px;
 }
 
+.lots-of-checkboxes .splitForTwo {
+  display: inline-block;
+  vertical-align: top;
+  width: 50%;
+  border-right: 2px solid var(--ee-border);
+
+  h3 {
+  	display: none;
+    color: var(--ee-text-normal);
+    margin-bottom: 5px;
+    font-weight: 500;
+    font-size: 1em;
+  }
+
+  @include m-tablet-down {
+  	display: block;
+  	width: 100%;
+  	border-right: none;
+  	border-bottom: 2px solid var(--ee-border);
+
+  	h3 {
+  		display: block;
+  	}
+  }
+}
+
+.lots-of-checkboxes .second-list {
+  border: none;
+}
+
 .lots-of-checkboxes__items--too-many {
 	height: 250px;
     max-height: 1000px;

--- a/system/ee/ExpressionEngine/Addons/checkboxes/ft.checkboxes.php
+++ b/system/ee/ExpressionEngine/Addons/checkboxes/ft.checkboxes.php
@@ -143,7 +143,8 @@ class Checkboxes_ft extends OptionFieldtype implements ColumnInterface
                 'manage_label' => $this->get_setting('manage_toggle_label', lang('manage')),
                 'reorder_ajax_url' => $this->get_setting('reorder_ajax_url', null),
                 'auto_select_parents' => $this->get_setting('auto_select_parents', false),
-                'no_results' => $this->get_setting('no_results', ['text' => sprintf(lang('no_found'), lang('choices'))])
+                'no_results' => $this->get_setting('no_results', ['text' => sprintf(lang('no_found'), lang('choices'))]),
+                'split_for_two' => $this->get_setting('split_for_two', null)
             ]);
         }
 

--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -101,6 +101,7 @@ abstract class AbstractPublish extends CP_Controller
             'lang.close' => lang('close'),
             'lang.confirm_exit' => lang('confirm_exit'),
             'lang.loading' => lang('loading'),
+            'lang.extra_title' => lang('extra_title'),
             'publish.autosave.interval' => (int) $autosave_interval_seconds,
             'publish.autosave.URL' => ee('CP/URL')->make('publish/autosave/' . $channel_id . '/' . $entry_id)->compile(),
             'publish.channel_title' => ee('Format')->make('Text', $entry->Channel->channel_title)

--- a/system/ee/ExpressionEngine/Model/Category/CategoryGroup.php
+++ b/system/ee/ExpressionEngine/Model/Category/CategoryGroup.php
@@ -182,7 +182,8 @@ class CategoryGroup extends StructureModel
                 ? ee('CP/URL')->make('categories/reorder/' . $this->getId())->compile()
                 : '',
             'auto_select_parents' => ee()->config->item('auto_assign_cat_parents') == 'y',
-            'no_results' => $no_results
+            'no_results' => $no_results,
+            'split_for_two' => true
         );
 
         return $metadata;

--- a/system/ee/ExpressionEngine/View/_shared/form/fields/select.php
+++ b/system/ee/ExpressionEngine/View/_shared/form/fields/select.php
@@ -147,7 +147,8 @@ else:
         'jsonify' => isset($jsonify) ? $jsonify : false,
         'manageLabel' => isset($manage_label) ? $manage_label : null,
         'reorderAjaxUrl' => isset($reorder_ajax_url) ? $reorder_ajax_url : null,
-        'noResults' => isset($no_results['text']) ? lang($no_results['text']) : null
+        'noResults' => isset($no_results['text']) ? lang($no_results['text']) : null,
+        'splitForTwo' => isset($split_for_two) ? $split_for_two : null
     ];
     ?>
 	<div data-select-react="<?=base64_encode(json_encode($component))?>" data-input-value="<?=$field_name?>" class="<?=$class?>">

--- a/system/ee/language/english/content_lang.php
+++ b/system/ee/language/english/content_lang.php
@@ -379,6 +379,8 @@ $lang = array(
 
     'exact_match' => 'Exact Match',
 
+    'extra_title' => 'List of selected categories:',
+
     'field_blank' => 'You left a field blank.',
 
     'fields' => 'Fields',

--- a/themes/ee/asset/javascript/src/components/select_list.js
+++ b/themes/ee/asset/javascript/src/components/select_list.js
@@ -1,8 +1,8 @@
 "use strict";
 
-function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
-
 function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -30,9 +30,7 @@ function _defineProperty(obj, key, value) { if (key in obj) { Object.definePrope
  * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
-var SelectList =
-/*#__PURE__*/
-function (_React$Component) {
+var SelectList = /*#__PURE__*/function (_React$Component) {
   _inherits(SelectList, _React$Component);
 
   function SelectList(props) {
@@ -411,7 +409,11 @@ function (_React$Component) {
         }
       }))), React.createElement(FieldInputs, {
         nested: props.nested,
-        tooMany: props.tooMany
+        tooMany: props.tooMany,
+        splitForTwo: props.splitForTwo,
+        list: props.items,
+        selectedItems: props.selected,
+        handle: this.handleSelect
       }, !props.loading && props.items.length == 0 && React.createElement(NoResults, {
         text: props.noResults
       }), props.loading && React.createElement(Loading, {
@@ -539,6 +541,32 @@ _defineProperty(SelectList, "defaultProps", {
 function FieldInputs(props) {
   var divClass = props.tooMany ? ' lots-of-checkboxes__items--too-many' : '';
 
+  if (props.tooMany && props.splitForTwo && props.nested) {
+    return React.createElement(React.Fragment, null, React.createElement("ul", {
+      className: 'field-inputs lots-of-checkboxes__items field-nested splitForTwo' + divClass
+    }, props.children), React.createElement("ul", {
+      className: 'field-inputs lots-of-checkboxes__items field-nested splitForTwo second-list' + divClass
+    }, React.createElement("h3", null, EE.lang.extra_title), props.list.map(function (item, index) {
+      return React.createElement(ListOfSelectedCategories, {
+        key: item.value,
+        item: item,
+        name: props.name,
+        selected: props.selectedItems,
+        disabledChoices: props.disabledChoices,
+        nested: props.nested,
+        selectable: true,
+        reorderable: false,
+        removable: false,
+        editable: false,
+        handleSelect: props.handle,
+        handleRemove: function handleRemove(e, item) {
+          return props.handleRemove(e, item);
+        },
+        groupToggle: props.groupToggle
+      });
+    })));
+  }
+
   if (props.nested) {
     return React.createElement("ul", {
       className: 'field-inputs lots-of-checkboxes__items field-nested' + divClass
@@ -550,9 +578,7 @@ function FieldInputs(props) {
   }, props.children);
 }
 
-var SelectItem =
-/*#__PURE__*/
-function (_React$Component2) {
+var SelectItem = /*#__PURE__*/function (_React$Component2) {
   _inherits(SelectItem, _React$Component2);
 
   function SelectItem() {
@@ -652,9 +678,7 @@ function (_React$Component2) {
   return SelectItem;
 }(React.Component);
 
-var SelectedItem =
-/*#__PURE__*/
-function (_React$Component3) {
+var SelectedItem = /*#__PURE__*/function (_React$Component3) {
   _inherits(SelectedItem, _React$Component3);
 
   function SelectedItem() {
@@ -683,4 +707,74 @@ function (_React$Component3) {
   }]);
 
   return SelectedItem;
+}(React.Component); // This class we will use only for Entry page
+// Category tab, to show selected category as a single list
+// add don't break the main category order
+
+
+var ListOfSelectedCategories = /*#__PURE__*/function (_React$Component4) {
+  _inherits(ListOfSelectedCategories, _React$Component4);
+
+  function ListOfSelectedCategories() {
+    _classCallCheck(this, ListOfSelectedCategories);
+
+    return _possibleConstructorReturn(this, _getPrototypeOf(ListOfSelectedCategories).apply(this, arguments));
+  }
+
+  _createClass(ListOfSelectedCategories, [{
+    key: "checked",
+    value: function checked(value) {
+      return this.props.selected.find(function (item) {
+        return item.value == value;
+      });
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var props = this.props;
+      var checked = this.checked(props.item.value);
+      var label = props.item.label;
+      var disabled = props.disabledChoices && props.disabledChoices.includes(props.item.value);
+      var listItem;
+
+      if (checked) {
+        listItem = React.createElement("label", {
+          className: 'checkbox-label',
+          "data-id": props.item.value
+        }, props.selectable && checked && React.createElement("input", {
+          type: "checkbox",
+          value: props.item.value,
+          checked: 'checked',
+          onChange: function onChange(e) {
+            return props.handleSelect(e, props.item);
+          },
+          "data-group-toggle": props.groupToggle ? JSON.stringify(props.groupToggle) : '[]'
+        }), React.createElement("div", {
+          className: props.editable ? "checkbox-label__text checkbox-label__text-editable" : "checkbox-label__text"
+        }, !props.editable && React.createElement("div", {
+          dangerouslySetInnerHTML: {
+            __html: label
+          }
+        }), " "));
+      }
+
+      if (props.nested) {
+        return React.createElement("li", {
+          className: "nestable-item",
+          "data-id": props.item.value
+        }, listItem, props.item.children && React.createElement("ul", {
+          className: "field-nested"
+        }, props.item.children.map(function (item, index) {
+          return React.createElement(ListOfSelectedCategories, _extends({}, props, {
+            key: item.value,
+            item: item
+          }));
+        })));
+      }
+
+      return listItem;
+    }
+  }]);
+
+  return ListOfSelectedCategories;
 }(React.Component);

--- a/themes/ee/cp/css/common.min.css
+++ b/themes/ee/cp/css/common.min.css
@@ -30387,6 +30387,35 @@ input[type=checkbox].checkbox--small:active:not(:disabled) {
   padding: 5px 15px 15px;
 }
 
+.lots-of-checkboxes .splitForTwo {
+  display: inline-block;
+  vertical-align: top;
+  width: 50%;
+  border-right: 2px solid var(--ee-border);
+}
+.lots-of-checkboxes .splitForTwo h3 {
+  display: none;
+  color: var(--ee-text-normal);
+  margin-bottom: 5px;
+  font-weight: 500;
+  font-size: 1em;
+}
+@media (max-width: 767px) {
+  .lots-of-checkboxes .splitForTwo {
+    display: block;
+    width: 100%;
+    border-right: none;
+    border-bottom: 2px solid var(--ee-border);
+  }
+  .lots-of-checkboxes .splitForTwo h3 {
+    display: block;
+  }
+}
+
+.lots-of-checkboxes .second-list {
+  border: none;
+}
+
 .lots-of-checkboxes__items--too-many {
   height: 250px;
   max-height: 1000px;


### PR DESCRIPTION
Added separate list with selected categories for Entry page Category tab; closes #2807

The main idea of this second list is to show selected categories without breaking the main category ordering.
Works only for the list that has more than `tooMany` properties items (by default 8)