### PR TITLE
Resolved #3135, #3047 where the columns in Entry Manager did not dynamically update if some column is not available

### DIFF
--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
@@ -66,10 +66,15 @@ class ColumnFactory
      */
     public static function getAvailableColumns($channel = false)
     {
-        return array_merge(
+        $columns = array_merge(
             static::getStandardColumns(),
             static::getCustomFieldColumns($channel)
         );
+        $availableColumns = [];
+        foreach ($columns as $column) {
+            $availableColumns[$column->getTableColumnIdentifier()] = $column;
+        }
+        return $availableColumns;
     }
 
     /**

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnRenderer.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnRenderer.php
@@ -15,7 +15,7 @@ namespace ExpressionEngine\Library\CP\EntryManager;
  */
 class ColumnRenderer
 {
-    private $columns = [];
+    protected $columns = [];
 
     /**
      * Constructor

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnRenderer.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnRenderer.php
@@ -24,7 +24,13 @@ class ColumnRenderer
      */
     public function __construct(array $columns)
     {
-        $this->columns = $columns;
+        $availableColumnKeys = array_keys(ColumnFactory::getAvailableColumns());
+        foreach ($columns as $key => $column) {
+            if (!in_array($key, $availableColumnKeys)) {
+                continue;
+            }
+            $this->columns[$key] = $column;
+        }
     }
 
     /**

--- a/system/ee/ExpressionEngine/Library/CP/FileManager/ColumnRenderer.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/ColumnRenderer.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Library\CP\FileManager;
+
+use ExpressionEngine\Library\CP\EntryManager;
+
+/**
+ * File Manager Column Renderer
+ */
+class ColumnRenderer extends EntryManager\ColumnRenderer
+{
+    /**
+     * Constructor
+     *
+     * @param array[ColumnInterface] $columns Array of objects implementing ColumnInterface
+     */
+    public function __construct(array $columns)
+    {
+        $availableColumnKeys = array_keys(ColumnFactory::getAvailableColumns());
+        foreach ($columns as $key => $column) {
+            if (!in_array($key, $availableColumnKeys)) {
+                continue;
+            }
+            $this->columns[$key] = $column;
+        }
+    }
+}

--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
@@ -10,7 +10,7 @@
 
 namespace ExpressionEngine\Library\CP\FileManager\Traits;
 
-use ExpressionEngine\Library\CP\EntryManager;
+use ExpressionEngine\Library\CP\FileManager;
 use ExpressionEngine\Library\CP\FileManager\ColumnFactory;
 
 trait FileManagerTrait
@@ -217,7 +217,7 @@ trait FileManagerTrait
             }
         }
 
-        $column_renderer = new EntryManager\ColumnRenderer($columns);
+        $column_renderer = new FileManager\ColumnRenderer($columns);
         $table_columns = $column_renderer->getTableColumnsConfig();
         $table->setColumns($table_columns);
 


### PR DESCRIPTION
Resolved #3135 where the columns in Entry Manager did not dynamically update if some column is not available

fixes #3047

EE7 version of #3141 