### PR TITLE
Resolved #3135, #3047 where the columns in Entry Manager did not dynamically update if some column is not available

### DIFF
--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
@@ -84,9 +84,16 @@ class ColumnFactory
      */
     private static function getStandardColumns()
     {
-        return array_map(function ($identifier, $column) {
-            return self::getColumn($identifier);
-        }, array_keys(self::$standard_columns), self::$standard_columns);
+        return array_filter(
+            array_map(function ($identifier, $column) {
+                if ($identifier != 'comments' || bool_config_item('enable_comments')) {
+                    return static::getColumn($identifier);
+                }
+            }, array_keys(static::$standard_columns), static::$standard_columns),
+            function ($column) {
+                return (! empty($column));
+            }
+        );
     }
 
     /**

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnFactory.php
@@ -66,10 +66,15 @@ class ColumnFactory
      */
     public static function getAvailableColumns($channel = false)
     {
-        return array_merge(
-            self::getStandardColumns(),
-            self::getChannelFieldColumns($channel)
+        $columns = array_merge(
+            static::getStandardColumns(),
+            static::getCustomFieldColumns($channel)
         );
+        $availableColumns = [];
+        foreach ($columns as $column) {
+            $availableColumns[$column->getTableColumnIdentifier()] = $column;
+        }
+        return $availableColumns;
     }
 
     /**
@@ -89,7 +94,7 @@ class ColumnFactory
      *
      * @return array[Column]
      */
-    private static function getChannelFieldColumns($channel = false)
+    protected static function getCustomFieldColumns($channel = false)
     {
         // Grab all the applicable fields based on the channel if there is one.
         if (! empty($channel)) {

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnRenderer.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/ColumnRenderer.php
@@ -24,7 +24,13 @@ class ColumnRenderer
      */
     public function __construct(array $columns)
     {
-        $this->columns = $columns;
+        $availableColumnKeys = array_keys(ColumnFactory::getAvailableColumns());
+        foreach ($columns as $key => $column) {
+            if (!in_array($key, $availableColumnKeys)) {
+                continue;
+            }
+            $this->columns[$key] = $column;
+        }
     }
 
     /**


### PR DESCRIPTION
Resolved #3135 where the columns in Entry Manager did not dynamically update if some column is not available

fixes #3047

EE6 version of #3140 