### PR TITLE
Raise required MySQL version to 5.6.4 in order to support InnoDB engine for Pro Search indexes

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro_search/models/pro_search_index_model.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/models/pro_search_index_model.php
@@ -65,9 +65,6 @@ class Pro_search_index_model extends Pro_search_model
         // Call parent install
         parent::install();
 
-        // Force MyISAM
-        ee()->db->query("ALTER TABLE {$this->table()} ENGINE = MYISAM");
-
         // Add indexes to table
         ee()->db->query("ALTER TABLE {$this->table()} ADD INDEX (`collection_id`)");
         ee()->db->query("ALTER TABLE {$this->table()} ADD INDEX (`site_id`)");

--- a/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/RequirementsChecker.php
+++ b/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/RequirementsChecker.php
@@ -16,13 +16,13 @@ class RequirementsChecker
 {
     private $requirements = [];
     private $minimum_php = '7.2.5';
-    private $minimum_mysql = '5.5.3';
+    private $minimum_mysql = '5.6.4';
     private $db_config = [];
 
     /**
      * Constructor
      *
-     * @param	string	$db_config	Array of DB config info
+     * @param   string  $db_config  Array of DB config info
      */
     public function __construct($db_config)
     {
@@ -118,8 +118,8 @@ class RequirementsChecker
     /**
      * Attempts to connect to a database in the specifed config array
      *
-     * @param	array	Database connection configuration
-     * @return	PDO		PDO connection object
+     * @param   array   Database connection configuration
+     * @return  PDO     PDO connection object
      */
     private function connectToDbUsingConfig($config)
     {
@@ -152,7 +152,7 @@ class RequirementsChecker
      * Gathers all the requirements test results and reports TRUE if good,
      * or returns an array of the failed Requirement objects
      *
-     * @return	mixed	TRUE if good, or array of failed Requirement objects
+     * @return  mixed   TRUE if good, or array of failed Requirement objects
      */
     public function check()
     {
@@ -189,8 +189,8 @@ class Requirement
     /**
      * Constructor
      *
-     * @param	string	$message	Message to display if this requirement fails
-     * @return	mixed	$result		Callable to run to test requirement, or
+     * @param   string  $message    Message to display if this requirement fails
+     * @return  mixed   $result     Callable to run to test requirement, or
      *   pre-derermined boolean of requirement result
      */
     public function __construct($message, $result = false)
@@ -203,7 +203,7 @@ class Requirement
      * Set a different failure message other than the one set in the constructor,
      * handy for conditionally setting messages inside a test callback
      *
-     * @param	string	$message	Message to display if this requirement fails
+     * @param   string  $message    Message to display if this requirement fails
      */
     public function setMessage($message)
     {
@@ -213,7 +213,7 @@ class Requirement
     /**
      * Gets the failure message
      *
-     * @return	string	Message to display if this requirement fails
+     * @return  string  Message to display if this requirement fails
      */
     public function getMessage()
     {
@@ -223,7 +223,7 @@ class Requirement
     /**
      * Gets the result of the requirement test
      *
-     * @return	boolean	Success or failure indicator of requirement test
+     * @return  boolean Success or failure indicator of requirement test
      */
     public function getResult()
     {


### PR DESCRIPTION
Docs: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/602