### PR TITLE
Resolved issue when deprecation message was shown by `exp:channel:entries` tag when using PHP 8.1

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -4184,7 +4184,7 @@ class Channel
             return ee()->TMPL->no_results();
         }
 
-        $cat_id = ctype_digit(ee()->TMPL->fetch_param('category_id')) ? ee()->TMPL->fetch_param('category_id') : $match[2];
+        $cat_id = ee()->TMPL->fetch_param('category_id') !== false && ctype_digit(ee()->TMPL->fetch_param('category_id')) ? ee()->TMPL->fetch_param('category_id') : $match[2];
 
         // fetch category field names and id's
 


### PR DESCRIPTION
Resolved issue when deprecation message was shown by `exp:channel:entries` tag when using PHP 8.1

#3147