### PR TITLE
Resolved #3099, #2178 where existing entries did not show up in Entry Manager if the user did not have editing permission on another channel

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/Edit.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Edit.php
@@ -94,10 +94,6 @@ class Edit extends AbstractPublishController
         }
         $columns = array_filter($columns);
 
-        if (! ee('Permission')->hasAny($this->permissions['others'])) {
-            $entries->filter('author_id', ee()->session->userdata('member_id'));
-        }
-
         $count = $entry_listing->getEntryCount();
 
         // if no entries check to see if we have any channels


### PR DESCRIPTION
Resolved #3099 where existing entries did not show up in Entry Manager if the user did not have editing permission on another channel; closes #2178

closes https://github.com/ExpressionEngine/ExpressionEngine/discussions/3091