### PR TITLE
Resolved #3174 where min height of RTE field could be wrong when using different CKEditor configurations for same entry

### DIFF
--- a/system/ee/ExpressionEngine/Addons/rte/Service/CkeditorService.php
+++ b/system/ee/ExpressionEngine/Addons/rte/Service/CkeditorService.php
@@ -202,7 +202,7 @@ class CkeditorService implements RteService
         static::$_includedConfigs[] = $configHandle;
 
         if (isset($config['height']) && !empty($config['height'])) {
-            ee()->cp->add_to_head('<style type="text/css">.ck-editor__editable_inline { min-height: ' . $config['height'] . 'px; }</style>');
+            ee()->cp->add_to_head('<style type="text/css">.rte_' . $configHandle . '.ck-editor__editable_inline { min-height: ' . $config['height'] . 'px; }</style>');
         }
 
         return $configHandle;


### PR DESCRIPTION
Resolved #3174 where min height of RTE field could be wrong when using different CKEditor configurations for same entry

(cherry picked from commit ae1a8bdb287a45096152aec13ab75e0be6674a3b)
