### PR TITLE
Resolved #3174 where min height of RTE field could be wrong when using different CKEditor configurations for same entry

### DIFF
--- a/system/ee/ExpressionEngine/Addons/rte/Service/CkeditorService.php
+++ b/system/ee/ExpressionEngine/Addons/rte/Service/CkeditorService.php
@@ -178,7 +178,7 @@ class CkeditorService extends AbstractRteService implements RteService
         static::$_includedConfigs[] = $configHandle;
 
         if (isset($config['height']) && !empty($config['height'])) {
-            ee()->cp->add_to_head('<style type="text/css">.ck-editor__editable_inline { min-height: ' . $config['height'] . 'px; }</style>');
+            ee()->cp->add_to_head('<style type="text/css">.rte_' . $configHandle . '.ck-editor__editable_inline { min-height: ' . $config['height'] . 'px; }</style>');
         }
 
         if (isset($config['css_template']) && !empty($config['css_template'])) {


### PR DESCRIPTION
Resolved #3174 where min height of RTE field could be wrong when using different CKEditor configurations for same entry
