### PR TITLE
Resolved #3191 where PHP errors could be shown when installing add-on that has fieldtype and module

### DIFF
--- a/system/ee/legacy/libraries/addons/Addons_installer.php
+++ b/system/ee/legacy/libraries/addons/Addons_installer.php
@@ -320,11 +320,15 @@ class Addons_installer
                         }
                     }
                 } else {
-                    ee()->load->add_package_path(ee()->addons->_packages[$addon][$type]['path'], false);
+                    if (isset(ee()->addons->_packages[$addon][$type])) {
+                        ee()->load->add_package_path(ee()->addons->_packages[$addon][$type]['path'], false);
+                    }
 
                     $this->$method($addon);
 
-                    ee()->load->remove_package_path(ee()->addons->_packages[$addon][$type]['path']);
+                    if (isset(ee()->addons->_packages[$addon][$type])) {
+                        ee()->load->remove_package_path(ee()->addons->_packages[$addon][$type]['path']);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Resolved #3191 where PHP errors could be shown when installing add-on that has fieldtype and module