### PR TITLE
Enabled File field to be used as Pro Variable; #2498

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -165,6 +165,15 @@ class File_ft extends EE_Fieldtype implements ColumnInterface
     }
 
     /**
+     * Display the field for Pro Variables
+     *
+     */
+    public function var_display_field($data)
+    {
+        return $this->display_field($data);
+    }
+
+    /**
      * Return a status of "warning" if the file is missing, otherwise "ok"
      *
      * @return string "warning" if the file is missing, "ok" otherwise

--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -338,6 +338,23 @@ JSC;
     }
 
     /**
+     * Display the field for Pro Variables
+     *
+     */
+    public function var_replace_tag($data, $params = array(), $tagdata = false)
+    {
+        $data = $this->pre_process($data);
+        if ($tagdata === '') {
+            $tagdata = false;
+        }
+        $fn = 'replace_' . ee()->TMPL->fetch_param('modifier', 'tag');
+        if (! method_exists($this, $fn)) {
+            $fn = 'replace_tag';
+        }
+        return $this->$fn($data, $params, $tagdata);
+    }
+
+    /**
      * Resize an image
      *
      * Supported parameters:

--- a/system/ee/ExpressionEngine/Addons/pro_variables/mcp.pro_variables.php
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/mcp.pro_variables.php
@@ -1930,6 +1930,26 @@ class Pro_variables_mcp
             $choices[$key] = $type['name']; // .' &mdash; <i>'.$type['version'].'</i>';
         }
 
+        // if there is variable named `file` we can't allow file field
+        $partials = ee('Model')->get('Snippet')->all()->pluck('snippet_name');
+        $global_variables = ee('Model')->get('GlobalVariable')->all()->pluck('variable_name');
+        $usedVarNameFile = false;
+        if (in_array('file', $partials)) {
+            $usedVarNameFile = 'partial';
+        }
+        if (in_array('file', $global_variables)) {
+            $usedVarNameFile = 'variable';
+        }
+        if ($usedVarNameFile !== false) {
+            unset($choices['file']);
+            ee()->lang->load('design');
+            ee('CP/Alert')->makeInline('shared-form')
+                ->asWarning()
+                ->withTitle(sprintf(lang('var_type_disabled'), 'File'))
+                ->addToBody(sprintf(lang('var_exists_same_name'), lang($usedVarNameFile)))
+                ->now();
+        }
+
         $value = $this->settings->get('enabled_types');
 
         if (! in_array(Pro_variables_types::DEFAULT_TYPE, $value)) {

--- a/system/ee/ExpressionEngine/Addons/pro_variables/mcp.pro_variables.php
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/mcp.pro_variables.php
@@ -1163,6 +1163,11 @@ class Pro_variables_mcp
             if ($this->vars->var_exists($name, $var_id)) {
                 $errors[] = lang('variable_name_already_exists') . ': ' . $name;
             }
+
+            if (in_array($name, ee()->cp->invalid_custom_field_names())) {
+                ee()->lang->load('design');
+                $errors[] = lang('reserved_name');
+            }
         }
 
         if ($errors) {
@@ -1928,26 +1933,6 @@ class Pro_variables_mcp
 
         foreach ($this->types->load_all() as $key => $type) {
             $choices[$key] = $type['name']; // .' &mdash; <i>'.$type['version'].'</i>';
-        }
-
-        // if there is variable named `file` we can't allow file field
-        $partials = ee('Model')->get('Snippet')->all()->pluck('snippet_name');
-        $global_variables = ee('Model')->get('GlobalVariable')->all()->pluck('variable_name');
-        $usedVarNameFile = false;
-        if (in_array('file', $partials)) {
-            $usedVarNameFile = 'partial';
-        }
-        if (in_array('file', $global_variables)) {
-            $usedVarNameFile = 'variable';
-        }
-        if ($usedVarNameFile !== false) {
-            unset($choices['file']);
-            ee()->lang->load('design');
-            ee('CP/Alert')->makeInline('shared-form')
-                ->asWarning()
-                ->withTitle(sprintf(lang('var_type_disabled'), 'File'))
-                ->addToBody(sprintf(lang('var_exists_same_name'), lang($usedVarNameFile)))
-                ->now();
         }
 
         $value = $this->settings->get('enabled_types');

--- a/system/ee/language/english/pro_variables_lang.php
+++ b/system/ee/language/english/pro_variables_lang.php
@@ -242,7 +242,7 @@ $lang = array(
     'Variable suffix',
 
     'variable_suffix_help' =>
-    'If entered, Low Variables will create a new variable for each given suffix.<br />Separate suffixes with spaces, e.g.: <em>en es nl</em>',
+    'If entered, Pro Variables will create a new variable for each given suffix.<br />Separate suffixes with spaces, e.g.: <em>en es nl</em>',
 
     'wide_field' =>
     'Display wide field',

--- a/system/ee/language/english/pro_variables_lang.php
+++ b/system/ee/language/english/pro_variables_lang.php
@@ -645,12 +645,6 @@ $lang = array(
     'settings_saved' =>
     'Settings saved',
 
-    'var_type_disabled' =>
-    'Variable type <code>%s</code> disabled',
-
-    'var_exists_same_name' =>
-    '%s already exists with same name',
-
     //----------------------------------------
     // Required for FIELDTYPE page
     //----------------------------------------

--- a/system/ee/language/english/pro_variables_lang.php
+++ b/system/ee/language/english/pro_variables_lang.php
@@ -645,6 +645,12 @@ $lang = array(
     'settings_saved' =>
     'Settings saved',
 
+    'var_type_disabled' =>
+    'Variable type <code>%s</code> disabled',
+
+    'var_exists_same_name' =>
+    '%s already exists with same name',
+
     //----------------------------------------
     // Required for FIELDTYPE page
     //----------------------------------------

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -1081,7 +1081,7 @@ class Cp
         );
 
         $prefixes = array(
-            'parents', 'siblings'
+            'parents', 'siblings', 'file'
         );
 
         $control_structures = array(

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3260,6 +3260,12 @@ class EE_Template
             $str = preg_replace_callback("/" . LD . "\s*route=(.*?)" . RD . "/", array( & ee()->functions, 'create_route'), $str);
         }
 
+        // Pase `{file:XX:url}` variables
+        if (strpos($str, LD . 'filedir_') !== false || strpos($str, LD . 'file:') !== false) {
+            ee()->load->library('file_field');
+            $str = ee()->file_field->parse_string($str);
+        }
+
         // Add security hashes to forms
         // We do this here to keep the security hashes from being cached
         if (defined('CSRF_TOKEN')) {

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3260,12 +3260,6 @@ class EE_Template
             $str = preg_replace_callback("/" . LD . "\s*route=(.*?)" . RD . "/", array( & ee()->functions, 'create_route'), $str);
         }
 
-        // Pase `{file:XX:url}` variables
-        if (strpos($str, LD . 'filedir_') !== false || strpos($str, LD . 'file:') !== false) {
-            ee()->load->library('file_field');
-            $str = ee()->file_field->parse_string($str);
-        }
-
         // Add security hashes to forms
         // We do this here to keep the security hashes from being cached
         if (defined('CSRF_TOKEN')) {


### PR DESCRIPTION
Enabled File field to be used as Pro Variable; closes #2498

Docs: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/626

added `file` as reserved field name

------

This PR is allowing File fields to be used as Pro Variables. The variable always needs to be addressed with a pro_variables tag, not just with name.

Due to how "Select File" field is built (allows both single and multiple file selection) we can't just replace the fieldtypes, as data might get lost

This PR adds `file` as reserved word to prevent unexpected behavior when someone still tries to access File variable by name