### PR TITLE
Resolved PHP8.1 compatibility issue

### DIFF
--- a/system/ee/legacy/libraries/channel_entries_parser/components/Custom_field_pair.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Custom_field_pair.php
@@ -209,7 +209,9 @@ class EE_Channel_custom_field_pair_parser implements EE_Channel_parser_component
                         if (!$frontedit_disabled) {
                             $frontEditLink = ee('pro:FrontEdit')->entryFieldEditLink($data['site_id'], $data['channel_id'], $data['entry_id'], $field_id);
                         }
-                        $tpl_chunk = str_replace(LD . $prefix . $field_name . ($modifier != 'frontedit' ? ':frontedit' : '') . RD, $frontEditLink, $tpl_chunk);
+                        if (! empty($tpl_chunk)) {
+                            $tpl_chunk = str_replace(LD . $prefix . $field_name . ($modifier != 'frontedit' ? ':frontedit' : '') . RD, $frontEditLink, $tpl_chunk);
+                        }
                     }
 
                     // $tpl_chunk can be a str or array, but not null


### PR DESCRIPTION
<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
