### PR TITLE
Resolved #3246 where not all checks for empty Grid or Fluid field worked correctly in templates when using PHP 8.1

### DIFF
--- a/system/ee/legacy/libraries/channel_entries_parser/Parser.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/Parser.php
@@ -547,20 +547,14 @@ class EE_Channel_data_parser
 
                             $cond[$key . ':' . $modifier] = $result;
 
-                            // If this key also happens to be a Grid field with the modifier
+                            // If this key also happens to be a Grid / Fluid field with the modifier
                             // "total_rows", make it the default value for evaluating
                             // conditionals
-                            if (isset($channel->gfields[$row['site_id']][$key]) &&
-                                $modifier == 'total_rows') {
-                                $cond[$key] = (int) $result;
-                            }
-
-                            // If this key also happens to be a Fluid field with the modifier
-                            // "total_fields", make it the default value for evaluating
-                            // conditionals
-                            if (isset($channel->ffields[$row['site_id']][$key]) &&
-                                $modifier == 'total_fields') {
-                                $cond[$key] = (int) $result;
+                            if (
+                                (isset($channel->gfields[$row['site_id']][$key]) && $modifier == 'total_rows') ||
+                                (isset($channel->ffields[$row['site_id']][$key]) && $modifier == 'total_fields')
+                            ) {
+                                $cond[$key] = $result !== 0 ? $result : '';
                             }
                         }
                     }


### PR DESCRIPTION
Resolved #3246 where not all checks for empty Grid or Fluid field worked correctly in templates when using PHP 8.1

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3251