### PR TITLE
Resolved #3245 where `0` could be displayed as empty string in template variables provided by add-ons

### DIFF
--- a/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
@@ -383,7 +383,11 @@ class EE_Channel_simple_variable_parser implements EE_Channel_parser_component
     {
         if ($raw_val = preg_replace('/^' . $prefix . '/', '', $val)) {
             if (array_key_exists($raw_val, $data)) {
-                $tagdata = str_replace(LD . $val . RD, $data[$raw_val] ?: '', $tagdata);
+                // cast the data to string
+                if (is_null($data[$raw_val]) || $data[$raw_val] === false) {
+                    $data[$raw_val] = '';
+                }
+                $tagdata = str_replace(LD . $val . RD, $data[$raw_val], $tagdata);
             } else {
                 $field = ee('Variables/Parser')->parseVariableProperties($key, $prefix);
                 $method = 'replace_' . $field['modifier'];


### PR DESCRIPTION
Resolved #3245 where `0` could be displayed as empty string in template variables provided by add-ons

EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3254