### PR TITLE
Do not join on field data tables, if no custom fields exist on model

### DIFF
--- a/system/ee/ExpressionEngine/Library/Data/Entity.php
+++ b/system/ee/ExpressionEngine/Library/Data/Entity.php
@@ -133,7 +133,7 @@ abstract class Entity extends MixableImpl implements Publisher
         // special case for custom fields
         // if those don't exist, don't try to query
         // less JOINs, faster EE!
-        if ($key == 'field_data' && isset($result['field_model'])) {
+        if ($key == 'field_data' && isset($result['field_model']) && $result['field_model'] != 'ChannelField') {
             $fieldsExist = ee('Model')->get($result['field_model'])->count(true);
             if ($fieldsExist == 0) {
                 return $cached_values[$class][$key] = null;

--- a/system/ee/ExpressionEngine/Library/Data/Entity.php
+++ b/system/ee/ExpressionEngine/Library/Data/Entity.php
@@ -34,7 +34,7 @@ abstract class Entity extends MixableImpl implements Publisher
     protected $_filters = array();
 
     /**
-     * @var Backup of clean values
+     * @var Array Backup of clean values
      */
     protected $_clean_backups = array();
 
@@ -130,6 +130,16 @@ abstract class Entity extends MixableImpl implements Publisher
             }
         }
 
+        // special case for custom fields
+        // if those don't exist, don't try to query
+        // less JOINs, faster EE!
+        if ($key == 'field_data' && isset($result['field_model'])) {
+            $fieldsExist = ee('Model')->get($result['field_model'])->count(true);
+            if ($fieldsExist == 0) {
+                return $cached_values[$class][$key] = null;
+            }
+        }
+
         return $cached_values[$class][$key] = $result;
     }
 
@@ -158,8 +168,10 @@ abstract class Entity extends MixableImpl implements Publisher
             }
 
             $child = $class;
-        } while (($class = get_parent_class($class))
-            && $child != 'ExpressionEngine\Service\Model\Model');
+        } while (
+            ($class = get_parent_class($class))
+            && $child != 'ExpressionEngine\Service\Model\Model'
+        );
 
         return array_reverse($values);
     }

--- a/system/ee/ExpressionEngine/Model/Category/Gateway/CategoryFieldDataGateway.php
+++ b/system/ee/ExpressionEngine/Model/Category/Gateway/CategoryFieldDataGateway.php
@@ -19,6 +19,7 @@ class CategoryFieldDataGateway extends VariableColumnGateway
 {
     protected static $_table_name = 'category_field_data';
     protected static $_primary_key = 'cat_id';
+    protected static $_gateway_model = 'CategoryField'; // model that defines elements fetched by this gateway
 
     protected static $_related_gateways = array(
         'cat_id' => array(

--- a/system/ee/ExpressionEngine/Model/Channel/Gateway/ChannelDataGateway.php
+++ b/system/ee/ExpressionEngine/Model/Channel/Gateway/ChannelDataGateway.php
@@ -19,6 +19,7 @@ class ChannelDataGateway extends VariableColumnGateway
 {
     protected static $_table_name = 'channel_data';
     protected static $_primary_key = 'entry_id';
+    protected static $_gateway_model = 'ChannelField'; // model that defines elements fetched by this gateway
 
     // Properties
     public $entry_id;

--- a/system/ee/ExpressionEngine/Model/File/Gateway/FileFieldDataGateway.php
+++ b/system/ee/ExpressionEngine/Model/File/Gateway/FileFieldDataGateway.php
@@ -19,6 +19,7 @@ class FileFieldDataGateway extends VariableColumnGateway
 {
     protected static $_table_name = 'file_data';
     protected static $_primary_key = 'file_id';
+    protected static $_gateway_model = 'FileField'; // model that defines elements fetched by this gateway
 
     protected static $_related_gateways = array(
         'file_id' => array(

--- a/system/ee/ExpressionEngine/Model/Member/Gateway/MemberFieldDataGateway.php
+++ b/system/ee/ExpressionEngine/Model/Member/Gateway/MemberFieldDataGateway.php
@@ -19,6 +19,7 @@ class MemberFieldDataGateway extends VariableColumnGateway
 {
     protected static $_table_name = 'member_data';
     protected static $_primary_key = 'member_id';
+    protected static $_gateway_model = 'MemberField'; // model that defines elements fetched by this gateway
 
     protected static $_related_gateways = array(
         'member_id' => array(

--- a/system/ee/ExpressionEngine/Service/Model/Gateway.php
+++ b/system/ee/ExpressionEngine/Service/Model/Gateway.php
@@ -17,6 +17,7 @@ class Gateway
 {
     protected static $_field_list_cache;
     protected $_values = array();
+    protected static $_gateway_model;
 
     /**
      *
@@ -73,6 +74,14 @@ class Gateway
     public function getPrimaryKey()
     {
         return static::$_primary_key;
+    }
+
+    /**
+     * model that defines elements fetched by this gateway
+     */
+    public function getGatewayModel()
+    {
+        return static::$_gateway_model;
     }
 
     /**

--- a/system/ee/ExpressionEngine/Service/Model/MetaDataReader.php
+++ b/system/ee/ExpressionEngine/Service/Model/MetaDataReader.php
@@ -128,9 +128,19 @@ class MetaDataReader
 
         $prefix = $this->getNamespacePrefix();
 
-        foreach ($gateway_names as $name) {
+        foreach ($gateway_names as $i => $name) {
             $gateway_class = $prefix . '\\Gateway\\' . $name;
-            $gateways[$name] = new $gateway_class();
+            $gateway = new $gateway_class();
+            $gateway_model = $gateway->getGatewayModel();
+            if ($i > 0 && ! is_null($gateway_model)) {
+                // if the gateway model is defined, check if it has any objects (e.g. custom fields)
+                // if none defined, no reason to query on this gateway
+                $fieldsExist = ee('Model')->get($gateway_model)->count(true);
+                if ($fieldsExist == 0) {
+                    continue;
+                }
+            }
+            $gateways[$name] = $gateway;
         }
 
         return $gateways;

--- a/system/ee/ExpressionEngine/Service/Model/MetaDataReader.php
+++ b/system/ee/ExpressionEngine/Service/Model/MetaDataReader.php
@@ -132,7 +132,7 @@ class MetaDataReader
             $gateway_class = $prefix . '\\Gateway\\' . $name;
             $gateway = new $gateway_class();
             $gateway_model = $gateway->getGatewayModel();
-            if ($i > 0 && ! is_null($gateway_model)) {
+            if ($i > 0 && ! is_null($gateway_model) && $gateway_model != 'ChannelField') {
                 // if the gateway model is defined, check if it has any objects (e.g. custom fields)
                 // if none defined, no reason to query on this gateway
                 $fieldsExist = ee('Model')->get($gateway_model)->count(true);


### PR DESCRIPTION
> Do not join on field data tables, if no custom fields exist on model
> Allow `select()` queries to be cached

This is further stop in code optimization process, and is aimed to improve SQL queries done for Models that are using Gateways (which are mostly used when custom fields can exist)

It making extra check whether custom fields exist (the check is cached) before running the main model query. If no custom fields have been defined, it does not perform JOIN on `_field_data` table (the legacy one; it is joined always even if there are no fields). It's not doing that check for entry custom fields though - we expect those to always exists, so extra query would not make much sense

This would potentially resolve #316 and similar issues

