### PR TITLE
Resolved #3274 where special characters in URL for on-the-fly manipulated images were encoded twice

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -515,7 +515,7 @@ JSC;
         $new = $data['filesystem']->createTempFile();
 
         $destination_path = $new_image_dir . $new_image;
-        $destination_url = $data['filesystem']->getUrl("_{$function}/" . rawurlencode($new_image));
+        $destination_url = $data['filesystem']->getUrl("_{$function}/" . $new_image);
         $props = null;
 
         if (!$data['filesystem']->exists($destination_path)) {


### PR DESCRIPTION
Resolved #3274 where special characters in URL for on-the-fly manipulated images were encoded twice