### PR TITLE
Resolved #3272 where parsing order was not correct for add-ons that contain both module and plugin file

### DIFF
--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -2992,7 +2992,8 @@ class EE_Template
                 if ($info->isInstalled()) {
                     $this->module_data[ucfirst($name)] = $name;
                 }
-            } elseif ($info->hasPlugin() && $info->isInstalled()) {
+            }
+            if ($info->hasPlugin() && $info->isInstalled()) {
                 $this->plugins[] = $name;
             }
         }


### PR DESCRIPTION
Resolved #3272 where parsing order was not correct for add-ons that contain both module and plugin file

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3295