### PR TITLE
Resolved #2112 where deleting too many logs could cause the system go out of memory

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Logs/Logs.php
+++ b/system/ee/ExpressionEngine/Controller/Logs/Logs.php
@@ -112,7 +112,7 @@ class Logs extends CP_Controller
         $query = ee('Model')->get($model, $id);
 
         $count = $query->count();
-        $query->all()->delete();
+        $query->delete();
 
         $message = sprintf(lang('logs_deleted_desc'), $count, lang($log_type));
 


### PR DESCRIPTION
Resolved #2112 where deleting too many logs could cause the system go out of memory

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3307