### PR TITLE
Resolved #3331 Where Categories tab shows empty alert when no category groups assigned

### DIFF
--- a/cp-styles/app/styles/components/_alerts.scss
+++ b/cp-styles/app/styles/components/_alerts.scss
@@ -217,6 +217,7 @@ $alert-padding-x: 20px;
 	p {
 		margin: 0;
     color: color(text-tertiary);
+    font-size: initial;
 
     &.alert__title {
       color: color(text-primary);

--- a/themes/ee/cp/css/common.min.css
+++ b/themes/ee/cp/css/common.min.css
@@ -23011,6 +23011,7 @@ dialog {
 .alert__content p {
   margin: 0;
   color: var(--ee-text-tertiary);
+  font-size: initial;
 }
 .app-notice__content p.alert__title,
 .alert__content p.alert__title {


### PR DESCRIPTION
Resolved #3331 Where the Categories tab shows an empty alert when no category groups are assigned
