### PR TITLE
Resolved #758 where installation wizard did not work when PHP was configured to have no memory limit

### DIFF
--- a/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/RequirementsChecker.php
+++ b/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/RequirementsChecker.php
@@ -74,6 +74,9 @@ class RequirementsChecker
             'ExpressionEngine requires at least 32MB of memory allocated to PHP.',
             function () {
                 $memory_limit = @ini_get('memory_limit');
+                if ($memory_limit == '-1') {
+                    return true;
+                }
                 sscanf($memory_limit, "%d%s", $limit, $unit);
 
                 if (strtolower($unit) == 'm') {


### PR DESCRIPTION
Resolved #758 where installation wizard did not work when PHP was configured to have no memory limit

EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3338