### PR TITLE
Bug/6.x/status update (see description)

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/Edit.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Edit.php
@@ -355,7 +355,7 @@ class Edit extends AbstractPublishController
         }
 
         $entry = ee('Model')->get('ChannelEntry', $id)
-            ->with('Channel', 'Autosaves')
+            ->with('Channel', 'Status', 'Autosaves')
             ->all()
             ->first();
 

--- a/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
+++ b/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
@@ -475,12 +475,15 @@ class ChannelEntry extends ContentModel
 
     private function ensureStatusSynced($update_by_name)
     {
-        if ($update_by_name) {
+        // if selected status is new one, but has the same name as the one that was deleted
+        // then there's no change and $update_by_name would be false
+        // so additional check if Status (by status_id) actually exists
+        if ($update_by_name === false && !is_null($this->Status)) {
+            $this->setProperty('status', $this->Status->status);
+        } else {
             $this->Status = $this->getModelFacade()->get('Status')
                 ->filter('status', $this->getProperty('status'))
                 ->first();
-        } else {
-            $this->setProperty('status', $this->Status->status);
         }
     }
 

--- a/system/ee/ExpressionEngine/Model/Channel/Display/DefaultChannelLayout.php
+++ b/system/ee/ExpressionEngine/Model/Channel/Display/DefaultChannelLayout.php
@@ -214,6 +214,7 @@ class DefaultChannelLayout extends DefaultLayout
     {
         $display = parent::transform($fields);
 
+        // show message if there are no category groups assigned
         $tab = $display->getTab('categories');
         $fields = $tab->getFields();
         if (count($fields) == 0) {

--- a/system/ee/ExpressionEngine/Model/Content/Display/FieldDisplay.php
+++ b/system/ee/ExpressionEngine/Model/Content/Display/FieldDisplay.php
@@ -37,6 +37,11 @@ class FieldDisplay
         return $this->field->getId();
     }
 
+    public function getData()
+    {
+        return $this->field->getData();
+    }
+
     public function getType()
     {
         return $this->field->getItem('field_type');

--- a/system/ee/ExpressionEngine/Model/Content/Display/LayoutTab.php
+++ b/system/ee/ExpressionEngine/Model/Content/Display/LayoutTab.php
@@ -43,6 +43,20 @@ class LayoutTab
 
     public function addField($field)
     {
+        // not sure this is the best place for this check, but:
+        // we need to show alert if the status is not available,
+        // and this is the point where we for sure have all data
+        if ($field->getId() == 'status') {
+            if (! array_key_exists($field->getData(), $field->get('field_list_items'))) {
+                ee('CP/Alert')->makeInline('status-not-available')
+                    ->asWarning()
+                    ->cannotClose()
+                    ->withTitle(lang('status_not_available'))
+                    ->addToBody(sprintf(lang('status_not_available_desc'), $field->getData()))
+                    ->now();
+            }
+        }
+
         $this->fields[] = $field;
 
         return $this;

--- a/system/ee/ExpressionEngine/Model/Status/Status.php
+++ b/system/ee/ExpressionEngine/Model/Status/Status.php
@@ -63,7 +63,9 @@ class Status extends Model
     );
 
     protected static $_events = array(
-        'beforeInsert'
+        'beforeInsert',
+        'afterInsert',
+        'afterUpdate'
     );
 
     protected $status_id;
@@ -96,6 +98,31 @@ class Status extends Model
         if (empty($status_order)) {
             $count = $this->getModelFacade()->get('Status')->count();
             $this->setProperty('status_order', $count + 1);
+        }
+    }
+
+    /**
+     * New status might have same name as the one that was deleted
+     * and the entries were left orphan
+     * In that case, we establish relationship
+     */
+    public function onAfterInsert()
+    {
+        //direct SQL, as we need it to be fast
+        ee('db')->where('status', $this->getProperty('status'))->update('channel_titles', ['status_id' => $this->getId()]);
+    }
+
+    /**
+     * Update the existing entries using this status
+     *
+     * @param array $previous
+     * @return void
+     */
+    public function onAfterUpdate($previous)
+    {
+        if ($previous['status'] != $this->status) {
+            //direct SQL, as we need it to be fast
+            ee('db')->where('status', $previous['status'])->update('channel_titles', ['status' => $this->status]);
         }
     }
 

--- a/system/ee/language/english/content_lang.php
+++ b/system/ee/language/english/content_lang.php
@@ -715,6 +715,10 @@ $lang = array(
 
     'status_changed_desc' => 'Entry status has been changed to <b>%s</b>',
 
+    'status_not_available' => 'Status not available',
+
+    'status_not_available_desc' => 'Current entry status is <b>%s</b> cannot be accessed. <br /> It is either deleted, not assigned to this channel, or you don\'t have permissions for it.',
+
     'tab_count_zero' => 'There needs to be at least one tab available to hold fields.',
 
     'tab_has_req_field' => 'The tab may not be deleted while it contains the following required fields: ',


### PR DESCRIPTION
Resolved #2148 where entry status was not updated after change of status name
Resolved #477 where no information was provided when editing entry with status that's not accessible to member

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3334