### PR TITLE
Wrap Structure global functions to avoid conflict

### DIFF
--- a/system/ee/ExpressionEngine/Addons/structure/helper.php
+++ b/system/ee/ExpressionEngine/Addons/structure/helper.php
@@ -129,17 +129,19 @@ function structure_array_get($array, $key, $default = null)
  *
  * @return mixed
  */
-function pick()
-{
-    $args = func_get_args();
+if (!function_exists('pick')) {
+    function pick()
+    {
+        $args = func_get_args();
 
-    if (!is_array($args) || !count($args)) {
-        return null;
-    }
+        if (!is_array($args) || !count($args)) {
+            return null;
+        }
 
-    foreach ($args as $arg) {
-        if (!is_null($arg) && $arg !== '') {
-            return $arg;
+        foreach ($args as $arg) {
+            if (!is_null($arg) && $arg !== '') {
+                return $arg;
+            }
         }
     }
 }
@@ -164,10 +166,12 @@ function structure_dd($value)
  * @param  mixed  $value
  * @return void
  */
-function rd($value)
-{
-    echo "<pre>";
-    print_r($value);
-    echo "</pre>";
-    die;
+if (!function_exists('rd')) {
+    function rd($value)
+    {
+        echo "<pre>";
+        print_r($value);
+        echo "</pre>";
+        die;
+    }
 }


### PR DESCRIPTION
This change wraps a few of the more generically named global functions defined by Structure with a `function_exists()` check to avoid errors when a collision occurs.  We might also want to consider renaming these functions or moving them under the `Structure_Helper` class like other helper functions in this file.

The issue was originally pointed out by a user when attempting to run ExpressionEngine with Coilpack alongside the Spatie Ray package which defines a global function `rd()` and errors due to this conflict.

https://eecms.slack.com/archives/C04J9UD9W7M/p1682615947912179?thread_ts=1682614273.683059&cid=C04J9UD9W7M