### PR TITLE
Resolved #3350 where PHP notice might be shown when parsing empty member field

### DIFF
--- a/system/ee/ExpressionEngine/Model/Content/FieldModel.php
+++ b/system/ee/ExpressionEngine/Model/Content/FieldModel.php
@@ -503,6 +503,9 @@ abstract class FieldModel extends Model
                 false
             ));
         }
+        if (is_null($data)) {
+            $data = '';
+        }
         if ($tag) {
             return str_replace(LD . $tag . RD, $data, $tagdata);
         }


### PR DESCRIPTION
Resolved #3350 where PHP notice might be shown when parsing empty member field

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3361