### PR TITLE
Added validation for image manipulation names to not be numeric; #2884

### DIFF
--- a/system/ee/ExpressionEngine/Model/File/FileDimension.php
+++ b/system/ee/ExpressionEngine/Model/File/FileDimension.php
@@ -42,7 +42,7 @@ class FileDimension extends Model
     );
 
     protected static $_validation_rules = array(
-        'short_name' => 'required|xss|alphaDash|uniqueWithinSiblings[UploadDestination,FileDimensions]',
+        'short_name' => 'required|xss|alphaDash|notNumeric|uniqueWithinSiblings[UploadDestination,FileDimensions]',
         'resize_type' => 'enum[crop,constrain]',
         'width' => 'isNatural|validateDimension',
         'height' => 'isNatural|validateDimension',

--- a/system/ee/ExpressionEngine/Service/Validation/Rule/NotNumeric.php
+++ b/system/ee/ExpressionEngine/Service/Validation/Rule/NotNumeric.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Service\Validation\Rule;
+
+use ExpressionEngine\Service\Validation\ValidationRule;
+
+/**
+ * Not Number Validation Rule
+ */
+class NotNumeric extends ValidationRule
+{
+    public function validate($key, $value)
+    {
+        return ! (bool) preg_match('/^[0-9.-]+$/', (string) $value);
+    }
+
+    public function getLanguageKey()
+    {
+        return 'is_not_numeric';
+    }
+}

--- a/system/ee/language/english/form_validation_lang.php
+++ b/system/ee/language/english/form_validation_lang.php
@@ -34,6 +34,8 @@ $lang = array(
 
     'is_natural_no_zero' => 'This field must contain a number greater than zero.',
 
+    'is_not_numeric' => 'This field can not be a number.',
+
     'is_numeric' => 'This field must contain only numeric characters.',
 
     'less_than' => 'This field must be less than: %s',


### PR DESCRIPTION
Added validation for image manipulation names to not be numeric; closes #2884

Adds `notNumeric` validation rule

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3366