### PR TITLE
Resolved #2705 where "minimum rows" setting was not respected by File Grid fields

### DIFF
--- a/system/ee/ExpressionEngine/Addons/grid/ft.file_grid.php
+++ b/system/ee/ExpressionEngine/Addons/grid/ft.file_grid.php
@@ -229,6 +229,16 @@ class file_grid_ft extends Grid_ft
 
         parent::post_save_settings($data);
     }
+
+    // for File Grid, we need to validate grid_min_rows
+    public function validate($data)
+    {
+        if (!ee('Request')->isAjax() && !empty($this->settings['grid_min_rows']) && (empty($data) || count($data) < $this->settings['grid_min_rows'])) {
+            return sprintf(lang('grid_min_rows_required'), $this->settings['grid_min_rows']);
+        }
+
+        return parent::validate($data);
+    }
 }
 
 // EOF

--- a/system/ee/language/english/fieldtypes_lang.php
+++ b/system/ee/language/english/fieldtypes_lang.php
@@ -260,6 +260,8 @@ $lang = array(
 
     'grid_min_rows_desc' => 'Sets the minumum amount of data rows this grid will accept',
 
+    'grid_min_rows_required' => 'This grid requires at least %d rows.',
+
     'grid_order_by' => 'Order by',
 
     'grid_output_format' => 'Output formatting?',


### PR DESCRIPTION
Resolved #2705 where "minimum rows" setting was not respected by File Grid fields

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3368