### PR TITLE
Resolved #3371 where Grid fields could show PHP error when ExpressionEngine was updated from older version

### DIFF
--- a/system/ee/ExpressionEngine/Addons/grid/ft.grid.php
+++ b/system/ee/ExpressionEngine/Addons/grid/ft.grid.php
@@ -177,8 +177,8 @@ class Grid_ft extends EE_Fieldtype
         $grid = ee('CP/GridInput', array(
             'field_name' => $this->name(),
             'lang_cols' => false,
-            'grid_min_rows' => $this->settings['grid_min_rows'],
-            'grid_max_rows' => $this->settings['grid_max_rows'],
+            'grid_min_rows' => isset($this->settings['grid_min_rows']) ? $this->settings['grid_min_rows'] : 0,
+            'grid_max_rows' => isset($this->settings['grid_max_rows']) ? $this->settings['grid_max_rows'] : '',
             'reorder' => isset($this->settings['allow_reorder'])
                 ? get_bool_from_string($this->settings['allow_reorder'])
                 : true,


### PR DESCRIPTION
EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3373

Resolved #3371 where Grid fields could show PHP error when ExpressionEngine was updated from older version