### PR TITLE
Added `primary_role_id` parameter for `exp:channel:entries` to work same as older `group_id`; #1353

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -95,7 +95,7 @@ class Channel
         $this->_dynamic_parameters = array('channel', 'entry_id', 'category', 'orderby',
             'sort', 'sticky', 'show_future_entries', 'show_expired', 'entry_id_from',
             'entry_id_to', 'not_entry_id', 'start_on', 'stop_before', 'year', 'month',
-            'day', 'display_by', 'limit', 'username', 'status', 'group_id', 'cat_limit',
+            'day', 'display_by', 'limit', 'username', 'status', 'group_id', 'primary_role_id', 'cat_limit',
             'month_limit', 'offset', 'author_id', 'url_title');
     }
 
@@ -1693,7 +1693,8 @@ class Channel
         /**  Add Group ID clause
         /**------*/
 
-        if ($group_id = ee()->TMPL->fetch_param('group_id')) {
+        $group_id = ee()->TMPL->fetch_param('primary_role_id') ?: ee()->TMPL->fetch_param('group_id');
+        if ($group_id) {
             $join_member_table = true;
             $sql .= ee()->functions->sql_andor_string($group_id, 'm.role_id');
         }

--- a/tests/cypress/cypress/integration/content/channel_entries_params.ee6.js
+++ b/tests/cypress/cypress/integration/content/channel_entries_params.ee6.js
@@ -1,0 +1,26 @@
+/// <reference types="Cypress" />
+const { _, $ } = Cypress
+
+
+context('Channel Entries tag parameters', () => {
+
+    before(function() {
+        cy.task('db:seed')
+
+        cy.eeConfig({ item: 'save_tmpl_files', value: 'y' })
+
+        //copy templates
+        cy.task('filesystem:copy', { from: 'support/templates/*', to: '../../system/user/templates/' }).then(() => {
+            cy.authVisit('admin.php?/cp/design')
+        })
+    })
+
+    it('primary_role_id', function() {
+        cy.task('db:query', 'UPDATE exp_channel_titles SET author_id=6 WHERE entry_id=1').then(() => {
+            cy.authVisit('index.php/entries/params');
+            cy.get('#primary_role_id').should('contain', '1 - Getting to Know ExpressionEngine')
+            cy.get('#primary_role_id').should('not.contain', '2 - Welcome to the Example Site!')
+        })
+    })
+
+})

--- a/tests/cypress/support/templates/default_site/entries.group/params.html
+++ b/tests/cypress/support/templates/default_site/entries.group/params.html
@@ -1,0 +1,7 @@
+{layout="cypress/layout"}
+
+<div id="primary_role_id">
+{exp:channel:entries channel="news" dynamic="no" primary_role_id="5" disable="frontedit"}
+<p>{entry_id} - {title}</p>
+{/exp:channel:entries}
+</div>


### PR DESCRIPTION
Added `primary_role_id` parameter for `exp:channel:entries` to work same as older `group_id`; closes #1353

User Guide https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/650

EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3377