### PR TITLE
Added `primary_role_id` parameter for `exp:channel:entries` to work same as older `group_id`; #1353

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -91,7 +91,7 @@ class Channel
         $this->_dynamic_parameters = array('channel', 'entry_id', 'category', 'orderby',
             'sort', 'sticky', 'show_future_entries', 'show_expired', 'entry_id_from',
             'entry_id_to', 'not_entry_id', 'start_on', 'stop_before', 'year', 'month',
-            'day', 'display_by', 'limit', 'username', 'status', 'group_id', 'cat_limit',
+            'day', 'display_by', 'limit', 'username', 'status', 'group_id', 'primary_role_id', 'cat_limit',
             'month_limit', 'offset', 'author_id', 'url_title');
     }
 
@@ -1680,7 +1680,8 @@ class Channel
         /**  Add Group ID clause
         /**------*/
 
-        if ($group_id = ee()->TMPL->fetch_param('group_id')) {
+        $group_id = ee()->TMPL->fetch_param('primary_role_id') ?: ee()->TMPL->fetch_param('group_id');
+        if ($group_id) {
             $join_member_table = true;
             $sql .= ee()->functions->sql_andor_string($group_id, 'm.role_id');
         }


### PR DESCRIPTION
Added `primary_role_id` parameter for `exp:channel:entries` to work same as older `group_id`; closes #1353

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3376

User Guide https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/651