### PR TITLE
Resolved #595 where the message about invalid theme folder path was not clear when performing 1-click update

### DIFF
--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Preflight.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Preflight.php
@@ -104,13 +104,13 @@ class Preflight
     {
         $this->logger->log('Checking file permissions needed to complete the update');
 
-        $theme_paths = array_map(function ($path) {
-            return preg_replace("#/+#", "/", rtrim($path, DIRECTORY_SEPARATOR) . '/ee/');
-        }, $this->getThemePaths());
-
+        $theme_paths = $this->getThemePaths();
         foreach ($theme_paths as $theme_path) {
             $this->validateThemePath($theme_path);
         }
+        $theme_paths = array_map(function ($path) {
+            return preg_replace("#/+#", "/", rtrim($path, DIRECTORY_SEPARATOR) . '/ee/');
+        }, $theme_paths);
 
         $paths = array_merge(
             [

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Preflight.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Preflight.php
@@ -108,6 +108,10 @@ class Preflight
             return preg_replace("#/+#", "/", rtrim($path, DIRECTORY_SEPARATOR) . '/ee/');
         }, $this->getThemePaths());
 
+        foreach ($theme_paths as $theme_path) {
+            $this->validateThemePath($theme_path);
+        }
+
         $paths = array_merge(
             [
                 $this->path(),

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Updater/Downloader/PreflightTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Updater/Downloader/PreflightTest.php
@@ -130,6 +130,7 @@ class PreflightTest extends TestCase
             ->andReturn(true)
             ->once();
 
+        $this->filesystem->shouldReceive('exists')->andReturn(true);
         $this->preflight->checkPermissions();
 
         $this->filesystem->shouldReceive('isWritable')


### PR DESCRIPTION
Resolved #595 where the message about invalid theme folder path was not clear when performing 1-click update

EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3389