### PR TITLE
Resolved #723 where some language strings were still using "member groups" instead of "roles"

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member.php
@@ -456,7 +456,7 @@ class Member
         }
 
         if (! EE_Messages::can_send_pm()) {
-            return;
+            return '';
         }
 
         $MESS = new EE_Messages();

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_memberlist.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_memberlist.php
@@ -360,7 +360,9 @@ class Member_memberlist extends Member
             }
         }
 
-        $result_page = str_replace(trim($search_path, '/'), '', $result_page);
+        if (!empty($result_page)) {
+            $result_page = str_replace(trim($search_path, '/'), '', $result_page);
+        }
 
         /** ----------------------------------------
         /**  Parse the request URI

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -102,39 +102,12 @@ $lang = array(
     'uninstalled' => 'Uninstalled',
 
     /* 2.x */
-    'addons_extensions' => 'Extensions',
-
-    'addons_fieldtypes' => 'Fieldtypes',
-
-    'addons_modules' => 'Modules',
-
-    'addons_plugins' => 'Plugins',
-
-    'and_more' => 'and %x more...',
-
-    'available_to_member_groups' => 'Available to Member Groups',
-
-    'component' => 'Component',
 
     'configuration' => 'Configuration',
 
-    'current_status' => 'Current Status',
-
-    'delete_fieldtype' => 'Remove Fieldtype',
-
-    'delete_fieldtype_confirm' => 'Are you sure you want to remove this fieldtype?',
-
     'description' => 'Description',
 
-    'ext_disabled_short' => 'disabled',
-
-    'ext_enabled_short' => 'enabled',
-
     'extension' => 'Extension',
-
-    'extension_disabled' => 'Extension Disabled',
-
-    'extension_enabled' => 'Extension Enabled',
 
     'extensions' => 'Extensions',
 
@@ -157,8 +130,6 @@ $lang = array(
     'fieldtype_name' => 'Fieldtype Name',
 
     'global_settings_saved' => 'Settings Saved',
-
-    'member_group_assignment' => 'Assigned Member Groups',
 
     'module' => 'Module',
 

--- a/system/ee/language/english/admin_content_lang.php
+++ b/system/ee/language/english/admin_content_lang.php
@@ -604,10 +604,6 @@ $lang = array(
 
     'manage_custom_fields' => 'Manage Category Fields',
 
-    'member_group' => 'Member Group',
-
-    'member_groups' => 'Member Groups',
-
     'missing_required_fields' => 'You Are Missing Required Field(s):',
 
     'name_of_category_group' => 'Name of category group',

--- a/system/ee/language/english/admin_lang.php
+++ b/system/ee/language/english/admin_lang.php
@@ -34,8 +34,6 @@ $lang = array(
     /* Explanatory Blurbs */
     'channel_administration_blurb' => 'This area enables you to manage your channels, preferences, and content-related sub-systems.',
 
-    'members_and_groups_blurb' => 'This area allows you to manage members, member groups, and membership-related features.',
-
     'search' => 'Search',
 
     'search_preferences' => 'Search Preferences',
@@ -303,8 +301,6 @@ $lang = array(
     'debug_zero' => '0: No PHP/SQL error messages generated',
 
     'default_html_buttons' => 'Default HTML Buttons',
-
-    'default_primary_role' => 'Default Member Group Assigned to New Members',
 
     'default_site_timezone' => 'Site Timezone',
 

--- a/system/ee/language/english/channel_lang.php
+++ b/system/ee/language/english/channel_lang.php
@@ -138,8 +138,6 @@ $lang = array(
 
     'maximum_channels_reached' => 'You have reached the maximum number of Channels allowed.',
 
-    'member_group' => 'Member group',
-
     'rename_tab' => 'Rename tab',
 
     'roles_desc' => 'Choose the member role(s) to apply this layout to.',
@@ -360,7 +358,7 @@ $lang = array(
 
     'moderate_comments' => 'Moderate comments?',
 
-    'moderate_comments_desc' => 'When enabled, submitted comments will be put into a moderation queue, and must be approved by a Super Admin or other member group with moderation permissions.',
+    'moderate_comments_desc' => 'When enabled, submitted comments will be put into a moderation queue, and must be approved by a Super Admin or member in role with moderation permissions.',
 
     'notifications' => 'Notifications',
 
@@ -534,8 +532,6 @@ $lang = array(
     'edit_category_field' => 'Edit Category Field',
 
     'edit_category_group' => 'Edit Category Group',
-
-    'edit_member_groups' => 'Edit Member Groups',
 
     'exclude_group_form' => 'Exclude group from?',
 

--- a/system/ee/language/english/channel_lang.php
+++ b/system/ee/language/english/channel_lang.php
@@ -358,7 +358,7 @@ $lang = array(
 
     'moderate_comments' => 'Moderate comments?',
 
-    'moderate_comments_desc' => 'When enabled, submitted comments will be put into a moderation queue, and must be approved by a Super Admin or member in role with moderation permissions.',
+    'moderate_comments_desc' => 'When enabled, submitted comments will be put into a moderation queue, and must be approved by a Super Admin or member with a role that has moderation permissions.',
 
     'notifications' => 'Notifications',
 

--- a/system/ee/language/english/communicate_lang.php
+++ b/system/ee/language/english/communicate_lang.php
@@ -90,7 +90,7 @@ $lang = array(
 
     'not_allowed_to_email_cache' => 'You are not allowed to view the email cache.',
 
-    'not_allowed_to_email_member_groups' => 'You are not allowed to email Member Groups',
+    'not_allowed_to_email_member_groups' => 'You are not allowed to email Member Roles',
 
     'not_allowed_to_email_members' => 'You are not allowed to email members',
 
@@ -111,8 +111,6 @@ $lang = array(
     'problem_with_id' => 'A problem was encountered with the ID number needed to send emails',
 
     'recipient' => 'Recipient',
-
-    'recipient_group' => 'Send to Member Groups',
 
     'remove' => 'Remove',
 

--- a/system/ee/language/english/content_lang.php
+++ b/system/ee/language/english/content_lang.php
@@ -918,8 +918,6 @@ $lang = array(
 
     'maintain_ratio' => 'Maintain Aspect Ratio',
 
-    'member_group' => 'Member Group',
-
     'no_entry_to_update' => 'You have tried to update an entry that does not exist.',
 
     'no_templates' => 'No Templates',

--- a/system/ee/language/english/core_lang.php
+++ b/system/ee/language/english/core_lang.php
@@ -169,7 +169,7 @@ If you made these changes, please accept the modifications on the Control Panel 
     'license_error_file_not_writable' => 'The cache folder needs to be writable in order for ExpressionEngine Pro to work',
     'license_error_file_broken' => 'There has been an error validating ExpressionEngine Pro license status',
 
-    /* Member Groups */
+    /* Roles */
     'banned' => 'Banned',
 
     'guests' => 'Guests',

--- a/system/ee/language/english/cp_lang.php
+++ b/system/ee/language/english/cp_lang.php
@@ -279,7 +279,7 @@ $lang = array(
 
     'member_changed_email' => 'Changed email for "%s" (%d) from "%s" to "%s"',
 
-    'member_changed_member_group' => 'Changed member group to "%s" for "%s" (%d)',
+    'member_changed_member_group' => 'Changed primary role to "%s" for "%s" (%d)',
 
     'member_changed_password' => 'Changed password for "%s" (%d)',
 

--- a/system/ee/language/english/cp_search_lang.php
+++ b/system/ee/language/english/cp_search_lang.php
@@ -42,8 +42,6 @@ $lang = array(
 
     'member_custom_profile_fields' => 'Custom Member Fields',
 
-    'member_group_manager' => 'Member Group Manager',
-
     'member_ip_search' => 'Member IP Search',
 
     'member_register_member' => 'Register Member',
@@ -55,8 +53,6 @@ $lang = array(
     'member_view_members' => 'View Members',
 
     'members_custom_profile_fields' => 'Custom Member Profile Fields',
-
-    'members_member_group_manager' => 'Member Group Management',
 
     'modu_index' => 'Modules',
 

--- a/system/ee/language/english/design_lang.php
+++ b/system/ee/language/english/design_lang.php
@@ -524,8 +524,6 @@ $lang = array(
 
     'medium' => 'Medium',
 
-    'member_group' => 'Member Group',
-
     'missing_name' => 'Your template must have a name',
 
     'name_of_template' => 'Template Name',
@@ -848,8 +846,6 @@ $lang = array(
     'forgot_form' => 'Forgot Password Form',
 
     'full_profile' => 'Full Profile Page',
-
-    'group_description' => 'Member Group Description',
 
     'home_page' => 'Member Profile Home Page',
 

--- a/system/ee/language/english/filemanager_lang.php
+++ b/system/ee/language/english/filemanager_lang.php
@@ -497,10 +497,6 @@ $lang = array(
 
     'upload_manage' => 'Manage',
 
-    'upload_member_groups' => 'Allowed member groups',
-
-    'upload_member_groups_desc' => 'The following user groups are allowed to upload to this directory.</em><br /><em>Super Administrators are <b>always</b> allowed.',
-
     'upload_roles' => 'Allowed member roles',
 
     'upload_roles_desc' => 'The following member roles are allowed to upload to this directory.<br />Super Administrators are <b>always</b> allowed.',
@@ -793,8 +789,6 @@ $lang = array(
 
     'max_width' => 'Maximum Image Width (in pixels)',
 
-    'member_group' => 'Member Group',
-
     'new_file_upload_created' => 'New File Upload Created',
 
     'new_file_upload_preferences' => 'New File Upload Preferences',
@@ -806,8 +800,6 @@ $lang = array(
     'no_edit_selected' => 'No Edit Operation Selected',
 
     'no_errors' => 'No errors',
-
-    'no_results' => 'No available member groups.',
 
     'no_sync_title' => 'No Results', // @todo, this phrase should change, just not sure what to put -ga
     'no_upload_directories_for_fieldtype' => 'There are currently no upload directories available. Please <a href="%s" rel="external">add one or more upload directories</a> to use the File fieldtype.',
@@ -849,14 +841,6 @@ $lang = array(
     'resize_type' => 'Resize Type',
 
     'resize_width' => 'Width',
-
-    'restrict_notes_1' => 'These radio buttons let you to specify which Member Groups are allowed to upload files.',
-
-    'restrict_notes_2' => 'Super Admins can always upload files',
-
-    'restrict_notes_3' => 'Note: File uploading is currently only allowed via the control panel',
-
-    'restrict_to_group' => 'Restrict file uploading to select member groups',
 
     'rotate' => 'Rotate',
 

--- a/system/ee/language/english/member_import_lang.php
+++ b/system/ee/language/english/member_import_lang.php
@@ -74,7 +74,7 @@ $lang = array(
 
     'file_loc_blurb' => 'The location of the file must be relative to your site\'s control panel folder. e.g.: ../members.txt, if placed at the site root.',
 
-    'group_id' => 'Default Member Group',
+    'group_id' => 'Default Primary Role',
 
     'import' => 'Import!',
 

--- a/system/ee/language/english/member_lang.php
+++ b/system/ee/language/english/member_lang.php
@@ -276,7 +276,7 @@ $lang = array(
 
     'mbr_may_now_log_in' => 'You may now log in and begin using it.',
 
-    'mbr_member_group' => 'Member Group:',
+    'mbr_member_group' => 'Primary Role:',
 
     'mbr_member_local_time' => 'Member Local Time',
 

--- a/system/ee/language/english/members_lang.php
+++ b/system/ee/language/english/members_lang.php
@@ -470,7 +470,7 @@ $lang = array(
 
     'username_banning_instructions' => '<b>Place each username on a separate line</b><br> These usernames will not be allowed.',
 
-    /* Member group settings */
+    /* Role settings */
     'access_privilege_caution' => 'Any setting marked with <span class="icon--caution" title="exercise caution"></span> should only be granted to people you trust implicitly.',
 
     'access_privilege_warning' => '<b>Warning</b>: Please be very careful with the access privileges you grant.',

--- a/system/ee/language/english/messages_lang.php
+++ b/system/ee/language/english/messages_lang.php
@@ -126,7 +126,7 @@ $lang = array(
 
     'member_description' => 'Description',
 
-    'member_group' => 'Member Group',
+    'member_group' => 'Primary Role',
 
     'member_name' => 'Member Name',
 

--- a/system/ee/language/english/metaweblog_api_lang.php
+++ b/system/ee/language/english/metaweblog_api_lang.php
@@ -34,7 +34,7 @@ $lang = array(
 
     'edit_metaweblog' => 'Edit MetaWeblog',
 
-    'entry_uneditable' => 'You do not have permission to edit this entry. Please check member group permissions',
+    'entry_uneditable' => 'You do not have permission to edit this entry. Please consult your role permissions',
 
     'invalid_access' => 'Invalid Access',
 

--- a/system/ee/language/english/myaccount_lang.php
+++ b/system/ee/language/english/myaccount_lang.php
@@ -278,11 +278,7 @@ $lang = array(
 
     'member_email' => 'Email Member',
 
-    'member_group_assignment' => 'Member Group Assignment',
-
-    'member_group_default' => 'Member group default',
-
-    'member_group_warning' => 'Be very careful assigning this',
+    'member_group_default' => 'Role\'s default',
 
     'user_ip_address' => 'IP Address',
 
@@ -473,8 +469,6 @@ $lang = array(
     'subscriptions' => 'Current Subscriptions',
 
     'subscriptions_removed' => 'Subscriptions have been removed',
-
-    'super_admin_demotion_alert' => 'As a Super Admin, you are not allowed to change your member group assignment',
 
     'system_offline_indicator' => 'System offline indicator',
 

--- a/system/ee/language/english/pro_search_lang.php
+++ b/system/ee/language/english/pro_search_lang.php
@@ -521,9 +521,6 @@ of these words.",
     "filters_help" =>
     "Available filters. Uncheck to disable a filter.",
 
-    "member_group" =>
-    "Member group",
-
     "can_manage" =>
     "Can manage collections",
 

--- a/system/ee/language/english/pro_variables_lang.php
+++ b/system/ee/language/english/pro_variables_lang.php
@@ -580,7 +580,7 @@ $lang = array(
     'Select Variable Managers',
 
     'can_manage_help' =>
-    'Select member groups allowed to manage the variables.',
+    'Select roles allowed to manage the variables.',
 
     'clear_cache' =>
     'Clear cache',

--- a/system/ee/language/english/search_lang.php
+++ b/system/ee/language/english/search_lang.php
@@ -44,7 +44,7 @@ $lang = array(
 
     'search_by_keyword' => 'Search by Keyword',
 
-    'search_by_member_group' => 'Search by Member Group',
+    'search_by_member_group' => 'Search by Primary Role',
 
     'search_by_member_name' => 'Search by Member Name',
 

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -72,7 +72,7 @@ $lang = array(
 
     'enable_msm' => 'Enable Site Manager (MSM)?',
 
-    'enable_msm_desc' => 'When enabled, Super Admins and members in roles with proper permissions will be able to manage additional websites from the <abbr title="Control Panel">CP</abbr>.',
+    'enable_msm_desc' => 'When enabled, Super Admins and members with roles that have proper permissions will be able to manage additional websites from the <abbr title="Control Panel">CP</abbr>.',
 
     'error_getting_version' => 'You are using ExpressionEngine %s. Unable to determine if a newer version is available at this time.',
 
@@ -98,7 +98,7 @@ $lang = array(
 
     'site_online' => 'Website online?',
 
-    'site_online_desc' => 'When disabled, only Super Admins and member with roles that have proper permissions will be able to browse this website.',
+    'site_online_desc' => 'When disabled, only Super Admins and members with roles that have proper permissions will be able to browse this website.',
 
     'site_short_name' => 'Short name',
 

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -72,7 +72,7 @@ $lang = array(
 
     'enable_msm' => 'Enable Site Manager (MSM)?',
 
-    'enable_msm_desc' => 'When enabled, Super Admins and member groups with permissions will be able to manage additional websites from the <abbr title="Control Panel">CP</abbr>.',
+    'enable_msm_desc' => 'When enabled, Super Admins and members in roles with proper permissions will be able to manage additional websites from the <abbr title="Control Panel">CP</abbr>.',
 
     'error_getting_version' => 'You are using ExpressionEngine %s. Unable to determine if a newer version is available at this time.',
 
@@ -98,7 +98,7 @@ $lang = array(
 
     'site_online' => 'Website online?',
 
-    'site_online_desc' => 'When disabled, only Super Admins and member groups with permissions will be able to browse your website.',
+    'site_online_desc' => 'When disabled, only Super Admins and member with roles that have proper permissions will be able to browse this website.',
 
     'site_short_name' => 'Short name',
 

--- a/system/ee/language/english/sites_lang.php
+++ b/system/ee/language/english/sites_lang.php
@@ -52,7 +52,7 @@ $lang = array(
 
     'site_online' => 'Website online?',
 
-    'site_online_desc' => 'When disabled, only Super Admins and member groups with permissions will be able to browse this website.',
+    'site_online_desc' => 'When disabled, only Super Admins and member with roles that have proper permissions will be able to browse this website.',
 
     'site_updated' => 'Site Updated',
 

--- a/system/ee/language/english/sites_lang.php
+++ b/system/ee/language/english/sites_lang.php
@@ -52,7 +52,7 @@ $lang = array(
 
     'site_online' => 'Website online?',
 
-    'site_online_desc' => 'When disabled, only Super Admins and member with roles that have proper permissions will be able to browse this website.',
+    'site_online_desc' => 'When disabled, only Super Admins and members with roles that have proper permissions will be able to browse this website.',
 
     'site_updated' => 'Site Updated',
 

--- a/system/ee/language/english/structure_lang.php
+++ b/system/ee/language/english/structure_lang.php
@@ -24,8 +24,6 @@ $lang = array(
                                 <li>Use the Content > Publish tab to create your first top level pages
                             </ol>',
     'no_weblogs'        => 'Please create a Channel before using Structure',
-    'no_groups'         => 'No member groups have been given access to Structure yet',
-    'no_groups_add'     => 'Manage member group access',
     'groups'            => 'Group',
     'no_roles'         => 'No member roles have been given access to Structure yet',
     'no_roles_add'     => 'Manage member roles access',

--- a/system/ee/language/english/utilities_lang.php
+++ b/system/ee/language/english/utilities_lang.php
@@ -354,8 +354,6 @@ $lang = array(
 
     'mbr_xml_file' => '<abbr title="Extensible Markup Language">XML</abbr> file location',
 
-    'member_group' => 'Member group',
-
     'role' => 'Role',
 
     'member_import_error' => 'Attention: Import not completed',


### PR DESCRIPTION
Resolved #723 where some language strings were still using "member groups" instead of "roles"

Also removes some language strings that have only been relevant for EE2

Fixes PHP 8.2 compatibility for Member module
