### PR TITLE
Resolved #3123 where having template records without template group in database would case PHP notices in template editor

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Design/Template.php
+++ b/system/ee/ExpressionEngine/Controller/Design/Template.php
@@ -1059,6 +1059,7 @@ class Template extends AbstractDesignController
         $templates = ee('Model')->get('Template')
             ->with('TemplateGroup')
             ->with('Site')
+            ->filter('TemplateGroup.group_id', 'IS NOT', null)
             ->order('TemplateGroup.group_name')
             ->order('Template.template_name');
 


### PR DESCRIPTION
Resolved #3123 where having template records without template group in database would case PHP notices in template editor