### PR TITLE
Resolved #3402 where PHP 8.1 deprecation noticed were shown when bulk editing entries without Pages URL set but Pages module installed

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pages/tab.pages.php
+++ b/system/ee/ExpressionEngine/Addons/pages/tab.pages.php
@@ -236,6 +236,9 @@ class Pages_tab
     private function makeValidURIRule()
     {
         return function ($field, $value) {
+            if (empty($value)) {
+                return true;
+            }
             $c_page_uri = preg_replace(
                 "#[^a-zA-Z0-9_\-/\.]+$#i",
                 '',
@@ -259,6 +262,9 @@ class Pages_tab
     private function makeValidSegmentCountRule()
     {
         return function ($field, $value) {
+            if (empty($value)) {
+                return true;
+            }
             $value_segs = substr_count(trim($value, '/'), '/');
 
             // More than 9 pages URI segs?  goodbye
@@ -279,6 +285,9 @@ class Pages_tab
     private function makeNotDuplicatedRule($entry)
     {
         return function ($field, $value) use ($entry) {
+            if (empty($value)) {
+                return true;
+            }
             $static_pages = ee()->config->item('site_pages');
             $uris = $static_pages[ee()->config->item('site_id')]['uris'];
 


### PR DESCRIPTION
Resolved #3402 where PHP 8.1 deprecation noticed were shown when bulk editing entries without Pages URL set but Pages module installed

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3406