### PR TITLE
Resolved #3397 where Template Routes page was showing deprecation notices when using PHP 8.2

### DIFF
--- a/system/ee/legacy/libraries/template_router/Converters.php
+++ b/system/ee/legacy/libraries/template_router/Converters.php
@@ -80,7 +80,7 @@ class EE_Template_router_converters
     /**
      * Register a converter
      *
-     * @param String	Class name of new converter
+     * @param string Class name of new converter
      */
     public function register($name, $class)
     {
@@ -97,7 +97,7 @@ interface EE_Template_router_converter
      * Return a regular expression for validation
      *
      * @access public
-     * @return string	The compiled regular expression
+     * @return string The compiled regular expression
      */
     public function validator();
 }

--- a/system/ee/legacy/libraries/template_router/Part.php
+++ b/system/ee/legacy/libraries/template_router/Part.php
@@ -13,6 +13,10 @@
  */
 class EE_Route_segment_part
 {
+    public $name = '';
+    public $rules = array();
+    public $value;
+
     public function __construct($name, $rules = array())
     {
         $this->name = $name;

--- a/system/ee/legacy/libraries/template_router/Route.php
+++ b/system/ee/legacy/libraries/template_router/Route.php
@@ -198,9 +198,9 @@ class EE_Route
      * @param string $route
      * @access public
      * @return array
-     *			- variable : Segment's variable name
-     *			- rules : Segment's list of validators
-     *			- static : Bare segment string, only set if segment is static text
+     *      - variable : Segment's variable name
+     *      - rules : Segment's list of validators
+     *      - static : Bare segment string, only set if segment is static text
      */
     public function parse_segments($route)
     {
@@ -282,7 +282,7 @@ class EE_Route
      * Parse a URL segment for a list of validators and convert to a regular expression
      *
      * @param $rules string  An EE formatted validation string e.g.:
-     *						   "rule1[arg1,arg2...]|rule2|..."
+     *        "rule1[arg1,arg2...]|rule2|..."
      * @access public
      * @return EE_Template_router_converter[]  An array of initialized validation rules
      */
@@ -308,11 +308,11 @@ class EE_Route
             if ($matches['rule'] == 'regex') {
                 $index = $pos + 7;
                 $regex = substr($matches[0], 6, 1);
-                $valid = @preg_match("/$regex/", null);
+                $valid = @preg_match("/$regex/", '');
 
                 while ($valid === false) {
                     $regex .= substr($rules, $index, 1);
-                    $valid = @preg_match("/$regex/", null);
+                    $valid = @preg_match("/$regex/", '');
                     $index++;
 
                     if ($end < $index) {

--- a/system/ee/legacy/libraries/template_router/converters/Max_length.php
+++ b/system/ee/legacy/libraries/template_router/converters/Max_length.php
@@ -13,6 +13,8 @@
  */
 class EE_Template_router_max_length_converter implements EE_Template_router_converter
 {
+    protected $length;
+
     public function __construct($length)
     {
         $this->length = $length;

--- a/system/ee/legacy/libraries/template_router/converters/Min_length.php
+++ b/system/ee/legacy/libraries/template_router/converters/Min_length.php
@@ -13,6 +13,8 @@
  */
 class EE_Template_router_min_length_converter implements EE_Template_router_converter
 {
+    protected $length;
+
     public function __construct($length)
     {
         $this->length = $length;

--- a/system/ee/legacy/libraries/template_router/converters/Regex.php
+++ b/system/ee/legacy/libraries/template_router/converters/Regex.php
@@ -13,6 +13,8 @@
  */
 class EE_Template_router_regex_converter implements EE_Template_router_converter
 {
+    protected $regex;
+
     public function __construct($regex)
     {
         $this->regex = $regex;


### PR DESCRIPTION
Resolved #3397 where Template Routes page was showing deprecation notices when using PHP 8.2

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3400