### PR TITLE
Resolved #200 where template layouts did not properly work with channel form

### DIFF
--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -922,6 +922,8 @@ class EE_Template
         $open_tag = LD . 'layout:set';
         $close_tag = LD . '/layout:set' . RD;
 
+        $template = $this->decode_channel_form_ee_tags($template);
+
         $open_tag_len = strlen($open_tag);
         $close_tag_len = strlen($close_tag);
 


### PR DESCRIPTION
Resolved #200 where template layouts did not properly work with channel form

The provided is fixing the original issue, but I also don't know why those `CFORM-ENCODE-LEFT-BRACKET` tags were added in the first place, so I don't know what this might break.

Also it definitely is creating a little bit overhead because the replacement is now taking place several times. Ideally, we'd just get rid of `CFORM-ENCODE` tags - but again, I don't know why those exist

@robinsowell specifically asking you to check this