### PR TITLE
Resolved issue where File module could show PHP error when using PHP 8.2

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/mod.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/mod.file.php
@@ -15,6 +15,7 @@ class File
 {
     public $reserved_cat_segment = '';
     public $use_category_names = false;
+    public $enable = array();
     public $categories = array();
     public $catfields = array();
     public $valid_thumbs = array();


### PR DESCRIPTION
Fixes the file:enable deprecation notice in php 8.2+