### PR TITLE
Resolved #3421 where CLI extension hook generator had wrong info for `relationship_query`

### DIFF
--- a/system/ee/ExpressionEngine/Service/Generator/Enums/Hooks.php
+++ b/system/ee/ExpressionEngine/Service/Generator/Enums/Hooks.php
@@ -150,7 +150,7 @@ class Hooks
 
     public const RELATIONSHIPS_QUERY = [
         'name' => 'relationships_query',
-        'params' => '$field_name, $entry',
+        'params' => '$field_name, $entry_ids, $depths, $sql',
         'library' => 'Relationships Fieldtype Extension Hooks_ids, $depths, $sql',
     ];
 


### PR DESCRIPTION
Fixes relationship_query hook in CLI generator to have properly documented params.

Resolved #3421 where CLI extension hook generator had wrong info for relationship_query 