### PR TITLE
Resolved #3425 File:query deprecation notice in PHP 8.2

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/mod.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/mod.file.php
@@ -18,6 +18,7 @@ class File
     public $categories = array();
     public $catfields = array();
     public $valid_thumbs = array();
+    public $query;	
     public $return_data = '';
 
     /**


### PR DESCRIPTION
Bug in php 8.2

 Creation of dynamic property File::$query is deprecated php 8.2 see #3425


