### PR TITLE
Bug/7.x/channel sets

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Channels/Sets.php
+++ b/system/ee/ExpressionEngine/Controller/Channels/Sets.php
@@ -195,10 +195,10 @@ class Sets extends AbstractChannelsController
             $set->cleanUpSourceFiles();
             $errors = $result->getErrors();
             $model_errors = $result->getModelErrors();
-            foreach (array('Channel Field', 'Category', 'Category Group', 'Status') as $type) {
+            foreach (array('Channel Field', 'Category', 'Category Group', 'Status', 'Upload Destination') as $type) {
                 if (isset($model_errors[$type])) {
                     foreach ($model_errors[$type][0][2] as $error) {
-                        $errors[] = $error->getLanguageKey();
+                        $errors[] = $type . ': ' . $model_errors[$type][0][1] . ' &mdash; ' . $error->getLanguageKey();
                     }
                 }
             }

--- a/system/ee/ExpressionEngine/Service/ChannelSet/Export.php
+++ b/system/ee/ExpressionEngine/Service/ChannelSet/Export.php
@@ -344,6 +344,10 @@ class Export
     {
         $dir = ee('Model')->get('UploadDestination', $id)->first();
 
+        if (is_null($dir)) {
+            return 'all';
+        }
+
         $result = new StdClass();
         $result->name = $dir->name;
         $result->adapter = $dir->adapter;

--- a/system/ee/ExpressionEngine/Service/ChannelSet/Export.php
+++ b/system/ee/ExpressionEngine/Service/ChannelSet/Export.php
@@ -346,6 +346,9 @@ class Export
 
         $result = new StdClass();
         $result->name = $dir->name;
+        $result->adapter = $dir->adapter;
+        $result->server_path = $dir->server_path;
+        $result->url = $dir->url;
 
         $this->upload_destinations[$dir->name] = $result;
 
@@ -478,8 +481,10 @@ class Export
             $result->channels = array();
 
             foreach ($settings['channels'] as $id) {
-                $channel = $this->channels[$id];
-                $result->channels[] = $channel->channel_title;
+                if (array_key_exists($id, $this->channels)) {
+                    $channel = $this->channels[$id];
+                    $result->channels[] = $channel->channel_title;
+                }
             }
         }
 

--- a/system/ee/ExpressionEngine/Service/ChannelSet/Set.php
+++ b/system/ee/ExpressionEngine/Service/ChannelSet/Set.php
@@ -801,7 +801,7 @@ class Set
 
         foreach ($data as $key => $value) {
             if (($type == 'grid' || $type == 'file_grid') && $key == 'columns') {
-                $this->importGrid($field, $value);
+                $this->importGrid($field, $value, $type);
 
                 continue;
             }
@@ -890,11 +890,11 @@ class Set
      * @param Array $columns The columns defined in the field.type file
      * @return void
      */
-    private function importGrid($field, $columns)
+    private function importGrid($field, $columns, $type = 'grid')
     {
         $that = $this;
-        $fn = function () use ($columns, $that) {
-            unset($_POST['grid']);
+        $fn = function () use ($columns, $that, $type) {
+            unset($_POST[$type]);
 
             // grid[cols][new_0][col_label]
             foreach ($columns as $i => $column) {
@@ -906,7 +906,7 @@ class Set
                 }
 
                 foreach ($column as $col_label => $col_value) {
-                    $_POST['grid']['cols']["new_{$i}"]['col_' . $col_label] = $col_value;
+                    $_POST[$type]['cols']["new_{$i}"]['col_' . $col_label] = $col_value;
                 }
             }
         };

--- a/system/ee/ExpressionEngine/Service/ChannelSet/Set.php
+++ b/system/ee/ExpressionEngine/Service/ChannelSet/Set.php
@@ -443,6 +443,7 @@ class Set
             $destination->name = $upload_data->name;
             $destination->adapter = isset($upload_data->adapter) ? $upload_data->adapter : 'local';
             $destination->url = isset($upload_data->url) ? $upload_data->url : '{base_url}';
+            $destination->server_path = isset($upload_data->server_path) ? $upload_data->server_path : null;
 
             $this->applyOverrides($destination, $upload_data->name);
 

--- a/system/ee/ExpressionEngine/Service/ChannelSet/Set.php
+++ b/system/ee/ExpressionEngine/Service/ChannelSet/Set.php
@@ -441,6 +441,8 @@ class Set
             $destination = ee('Model')->make('UploadDestination');
             $destination->site_id = $this->site_id;
             $destination->name = $upload_data->name;
+            $destination->adapter = isset($upload_data->adapter) ? $upload_data->adapter : 'local';
+            $destination->url = isset($upload_data->url) ? $upload_data->url : '{base_url}';
 
             $this->applyOverrides($destination, $upload_data->name);
 


### PR DESCRIPTION
Resolved #2627; #1623 when importing Channel Set that includes File field caused validation error

Resolved #1645 where Channel Sets with File Grid field were not properly imported

closes #1623

EE7 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3434