### PR TITLE
Resolved issue where some errors did not render properly when using custom error template

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -2007,7 +2007,7 @@ class Channel
         /**  Add Limits to query
         /**------*/
 
-        if (ee('LivePreview')->hasEntryData()) {
+        if (isset(ee()->session) && ee('LivePreview')->hasEntryData()) {
             $parts = explode(' WHERE ', $sql);
             $this->preview_conditions = explode(' AND ', $parts[1]);
         }
@@ -2088,8 +2088,10 @@ class Channel
         $this->sql .= $this->generateSQLForEntries($entries, $channel_ids);
 
         //cache the entry_id
-        ee()->session->cache['channel']['entry_ids'] = $entries;
-        ee()->session->cache['channel']['channel_ids'] = $channel_ids;
+        if (isset(ee()->session)) {
+            ee()->session->cache['channel']['entry_ids'] = $entries;
+            ee()->session->cache['channel']['channel_ids'] = $channel_ids;
+        }
 
         $end = "ORDER BY FIELD(t.entry_id, " . implode(',', $entries) . ")";
 
@@ -2216,6 +2218,10 @@ class Channel
     {
         $return = false;
 
+        if (!isset(ee()->session)) {
+            return $return;
+        }
+
         if (ee('LivePreview')->hasEntryData()) {
             $data = ee('LivePreview')->getEntryData();
             if (in_array($this->query_string, [$data['entry_id'], $data['url_title']])) {
@@ -2235,6 +2241,10 @@ class Channel
 
     private function overrideWithPreviewData($result_array)
     {
+        if (!isset(ee()->session)) {
+            return $result_array;
+        }
+
         if (ee('LivePreview')->hasEntryData()) {
             $found = false;
             $show_closed = false;
@@ -2489,7 +2499,9 @@ class Channel
 
         $this->cacheCategoryFieldModels();
 
-        ee()->session->set_cache('mod_channel', 'active', $this);
+        if (isset(ee()->session)) {
+            ee()->session->set_cache('mod_channel', 'active', $this);
+        }
         $this->return_data = $parser->parse($this, $data, $config);
 
         unset($parser, $entries, $data);
@@ -3998,7 +4010,11 @@ class Channel
      */
     private function cacheCategoryFieldModels()
     {
-        $this->cat_field_models = ee()->session->cache(__CLASS__, 'cat_field_models') ?: array();
+        if (isset(ee()->session)) {
+            $this->cat_field_models = ee()->session->cache(__CLASS__, 'cat_field_models') ?: array();
+        } else {
+            $this->cat_field_models = [];
+        }
 
         ee()->load->library('api');
         ee()->legacy_api->instantiate('channel_fields');
@@ -4027,7 +4043,9 @@ class Channel
             ->all()
             ->indexBy('field_id');
 
-        ee()->session->set_cache(__CLASS__, 'cat_field_models', $this->cat_field_models);
+        if (isset(ee()->session)) {
+            ee()->session->set_cache(__CLASS__, 'cat_field_models', $this->cat_field_models);
+        }
     }
 
     /**

--- a/system/ee/ExpressionEngine/Model/Template/GlobalVariable.php
+++ b/system/ee/ExpressionEngine/Model/Template/GlobalVariable.php
@@ -147,13 +147,15 @@ class GlobalVariable extends FileSyncedModel
             return $basepath . '_global_variables';
         }
 
-        if (! $site = ee()->session->cache('site/id/' . $this->site_id, 'site')) {
+        if (!isset(ee()->session) || ! $site = ee()->session->cache('site/id/' . $this->site_id, 'site')) {
             $sites = ee('Model')->get('Site')
                 ->fields('site_id', 'site_name')
                 ->all(true);
             $site = $sites->filter('site_id', $this->site_id)->first();
 
-            ee()->session->set_cache('site/id/' . $this->site_id, 'site', $site);
+            if (isset(ee()->session)) {
+                ee()->session->set_cache('site/id/' . $this->site_id, 'site', $site);
+            }
         }
 
         return $basepath . $site->site_name . '/_variables';

--- a/system/ee/ExpressionEngine/Model/Template/Snippet.php
+++ b/system/ee/ExpressionEngine/Model/Template/Snippet.php
@@ -148,13 +148,15 @@ class Snippet extends FileSyncedModel
             return $basepath . '_global_partials';
         }
 
-        if (! $site = ee()->session->cache('site/id/' . $this->site_id, 'site')) {
+        if (!isset(ee()->session) || ! $site = ee()->session->cache('site/id/' . $this->site_id, 'site')) {
             $sites = ee('Model')->get('Site')
                 ->fields('site_id', 'site_name')
                 ->all(true);
             $site = $sites->filter('site_id', $this->site_id)->first();
 
-            ee()->session->set_cache('site/id/' . $this->site_id, 'site', $site);
+            if (isset(ee()->session)) {
+                ee()->session->set_cache('site/id/' . $this->site_id, 'site', $site);
+            }
         }
 
         return $basepath . $site->site_name . '/_partials';

--- a/system/ee/ExpressionEngine/Service/Template/Variables/StandardGlobals.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/StandardGlobals.php
@@ -50,8 +50,8 @@ class StandardGlobals extends Variables
             'build' => APP_BUILD,
             'captcha' => $this->getCaptcha($this->legacy_tmpl_obj->template),
             'charset' => ee()->config->item('output_charset'),
-            'cp_session_id' => (ee()->session->access_cp === true) ? ee()->session->session_id() : 0,
-            'cp_url' => (ee()->session->access_cp === true) ? ee()->config->item('cp_url') : '',
+            'cp_session_id' => (isset(ee()->session) && ee()->session->access_cp === true) ? ee()->session->session_id() : 0,
+            'cp_url' => (isset(ee()->session) && ee()->session->access_cp === true) ? ee()->config->item('cp_url') : '',
             'current_path' => (ee()->uri->uri_string) ? str_replace(array('"', "'"), array('%22', '%27'), ee()->uri->uri_string) : '/',
             'current_query_string' => http_build_query($_GET), // GET has been sanitized!
             'current_url' => ee()->functions->fetch_current_uri(),
@@ -108,7 +108,7 @@ class StandardGlobals extends Variables
      */
     private function getMemberProfileLink()
     {
-        if (ee()->session->userdata('member_id') != 0) {
+        if (isset(ee()->session) && ee()->session->userdata('member_id') != 0) {
             $name = (ee()->session->userdata['screen_name'] == '') ? ee()->session->userdata['username'] : ee()->session->userdata['screen_name'];
 
             $path = "<a href='" . ee()->functions->create_url(ee()->config->item('profile_trigger') . '/' . ee()->session->userdata('member_id')) . "'>" . $name . "</a>";

--- a/system/ee/legacy/libraries/Csrf.php
+++ b/system/ee/legacy/libraries/Csrf.php
@@ -24,7 +24,7 @@ class Csrf
 
     public function __construct()
     {
-        $session_id = ee()->session->userdata('session_id');
+        $session_id = isset(ee()->session) ? ee()->session->userdata('session_id') : 0;
         $backend = ($session_id === 0) ? 'cookie' : 'database';
 
         require_once APPPATH . 'libraries/csrf/Storage_backend_interface.php';

--- a/system/ee/legacy/libraries/Functions.php
+++ b/system/ee/legacy/libraries/Functions.php
@@ -1126,6 +1126,10 @@ class EE_Functions
      */
     public function add_form_security_hash($str)
     {
+        if (!defined('CSRF_TOKEN')) {
+            ee()->security->have_valid_xid();
+        }
+        
         // Add security hash. Need to replace the legacy XID one as well.
         $str = str_replace('{csrf_token}', CSRF_TOKEN, $str);
         $str = str_replace('{XID_HASH}', CSRF_TOKEN, $str);

--- a/system/ee/legacy/libraries/Localize.php
+++ b/system/ee/legacy/libraries/Localize.php
@@ -257,7 +257,11 @@ class Localize
 
         // Localize to member's timezone or leave as GMT
         if (is_bool($timezone)) {
-            $timezone = ($timezone) ? ee()->session->userdata('timezone', ee()->config->item('default_site_timezone')) : 'UTC';
+            if ($timezone) {
+                $timezone = isset(ee()->session) ? ee()->session->userdata('timezone', ee()->config->item('default_site_timezone')) : ee()->config->item('default_site_timezone');
+            } else {
+                $timezone = 'UTC';
+            }
         }
 
         // If timezone isn't known by PHP, it may be our legacy timezone

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -342,7 +342,7 @@ class EE_Template
             'template_id' => $this->template_id,
             'template_type' => $this->embed_type ?: $this->template_type,
             'is_ajax_request' => AJAX_REQUEST,
-            'is_live_preview_request' => ee('LivePreview')->hasEntryData(),
+            'is_live_preview_request' => isset(ee()->session) ? ee('LivePreview')->hasEntryData() : false,
         ];
 
         //Pro conditionals
@@ -449,7 +449,7 @@ class EE_Template
         }
 
         // Parse error conditinal tags
-        $errors = ee()->session->flashdata('errors');
+        $errors = isset(ee()->session) ? ee()->session->flashdata('errors') : [];
 
         // Make sure to age the flashdata so it doesn't appear on the next request accidentally.
         // ee()->session->_age_flashdata();
@@ -3064,7 +3064,9 @@ class EE_Template
         // Restore XML declaration if it was encoded
         $str = $this->restore_xml_declaration($str);
 
-        ee()->session->userdata['member_group'] = ee()->session->userdata['role_id'];
+        if (isset(ee()->session)) {
+            ee()->session->userdata['member_group'] = ee()->session->userdata['role_id'];
+        }
         $this->user_vars[] = 'member_group';
 
         // parse all standard global variables
@@ -4398,9 +4400,9 @@ class EE_Template
 
     protected function getMemberVariables()
     {
-        static $vars;
+        static $vars = [];
 
-        if (empty($vars)) {
+        if (empty($vars) && isset(ee()->session)) {
             foreach ($this->user_vars as $user_var) {
                 $vars['logged_in_' . $user_var] = ee()->session->userdata[$user_var];
             }

--- a/system/ee/legacy/libraries/Typography.php
+++ b/system/ee/legacy/libraries/Typography.php
@@ -1382,7 +1382,7 @@ class EE_Typography
         $this->html_format = $existing_format;
 
         // hit emoji shortands
-        if (bool_config_item('disable_emoji_shorthand') === false) {
+        if (bool_config_item('disable_emoji_shorthand') === false && isset(ee()->session)) {
             $title = ee('Format')->make('Text', $title)->emojiShorthand();
         }
 

--- a/system/ee/legacy/libraries/channel_entries_parser/Parser.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/Parser.php
@@ -213,12 +213,12 @@ class EE_Channel_data_parser
             $row['absolute_reverse_count'] = $row['absolute_results'] - $row['absolute_count'] + 1;
             $row['comment_subscriber_total'] = (isset($subscriber_totals[$row['entry_id']])) ? $subscriber_totals[$row['entry_id']] : 0;
             $row['has_categories'] = ! empty($data['categories'][$row['entry_id']]);
-            $row['cp_edit_entry_url'] = ee('CP/URL')
+            $row['cp_edit_entry_url'] = isset(ee()->session) ? ee('CP/URL')
                 ->make(
                     'publish/edit/entry/' . $row['entry_id'],
                     array('site_id' => $row['site_id']),
                     ee()->config->item('cp_url')
-                );
+                ) : '';
 
             if ($site_pages !== false && isset($site_pages[$row['site_id']]['uris'][$row['entry_id']])) {
                 $row['page_uri'] = $site_pages[$row['site_id']]['uris'][$row['entry_id']];
@@ -473,8 +473,8 @@ class EE_Channel_data_parser
         $pre = $this->_preparser;
 
         $cond = $row;
-        $cond['logged_in'] = (ee()->session->userdata('member_id') == 0) ? false : true;
-        $cond['logged_out'] = (ee()->session->userdata('member_id') != 0) ? false : true;
+        $cond['logged_in'] = (isset(ee()->session) && ee()->session->userdata('member_id') == 0) ? false : true;
+        $cond['logged_out'] = (isset(ee()->session) && ee()->session->userdata('member_id') != 0) ? false : true;
 
         foreach (array('avatar_filename', 'photo_filename', 'sig_img_filename') as $pv) {
             if (! isset($row[$pv])) {


### PR DESCRIPTION
If you are using custom error template and you have an error because of missing extension you don't get the correct error, but rather generic PHP Exceptions screen saying 'session' is not defined

![image](https://github.com/ExpressionEngine/ExpressionEngine/assets/752126/a9d2d4a8-45a1-4076-b634-820828b48928)

This can be replicating by installing Structure on EE7 and switching codebase to EE6

This is an attempt to fix that by adding several `isset` checks (auto-loading session at that point does not seem to be working)