### PR TITLE
Added `core_cp_boot` extension hook; #1557

### DIFF
--- a/system/ee/ExpressionEngine/Service/Generator/Enums/Hooks.php
+++ b/system/ee/ExpressionEngine/Service/Generator/Enums/Hooks.php
@@ -22,6 +22,12 @@ class Hooks
         'library' => 'Core',
     ];
 
+    public const CORE_CP_BOOT = [
+        'name' => 'core_cp_boot',
+        'params' => '',
+        'library' => 'Core',
+    ];
+
     public const CORE_TEMPLATE_ROUTE = [
         'name' => 'core_template_route',
         'params' => '$uri_string',

--- a/system/ee/legacy/core/Controller.php
+++ b/system/ee/legacy/core/Controller.php
@@ -101,6 +101,18 @@ class CP_Controller extends EE_Controller
     {
         parent::__construct();
         ee()->core->run_cp();
+
+        // -------------------------------------------
+        // 'core_cp_boot' hook.
+        //  - Runs on every Control Panel request
+        //
+        if (ee()->extensions->active_hook('core_cp_boot') === true) {
+            ee()->extensions->call('core_cp_boot');
+            if (ee()->extensions->end_script === true) {
+                return;
+            }
+        }
+        // -------------------------------------------
     }
 
     /**


### PR DESCRIPTION
Added core_cp_boot extension hook; closes https://github.com/ExpressionEngine/ExpressionEngine/issues/1557

User Guide: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/630

On the 7.3 pre-release meeting we decided that this need more think-through, so setting it to draft and not including into 7.3 release just yet