### PR TITLE
Resolved #3445 where wrong error message could be shown when creating a grid field

### DIFF
--- a/system/ee/ExpressionEngine/Addons/grid/views/settings.php
+++ b/system/ee/ExpressionEngine/Addons/grid/views/settings.php
@@ -1,9 +1,12 @@
 <div class="fields-grid-setup" data-group="<?=$group?>">
+	<?php if ($group !== 'grid'): ?>
 	<?=$this->embed('ee:_shared/form/no_results', [
 	    'text' => sprintf(lang('no_found'), lang('columns')),
 	    'link_href' => '#',
 	    'link_text' => lang('add_new')
 	])?>
+	<?php endif; ?>
+
 	<?php foreach ($columns as $column): ?>
 		<?=$column?>
 	<?php endforeach ?>


### PR DESCRIPTION
Resolved #3445  where UX Bug when creating a grid field
In this PR I check and don't show `no columns found` part when the grid field is created

EE7 version of #3447 

