### PR TITLE
Resolved #3429 where `channel="not X` parameter did not work correctly if channel X did not exist

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -1214,7 +1214,9 @@ class Channel
             }
 
             if (empty($channel_ids)) {
-                return '';
+                if ($channelInOperator == 'IN') {
+                    return '';
+                }
             } else {
                 $sql .= "AND t.channel_id " . $channelInOperator . " (" . implode(',', $channel_ids) . ") ";
             }


### PR DESCRIPTION
Resolved #3429 where `channel="not X` parameter did not work correctly if channel X did not exist

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3454