### PR TITLE
Added visual indication of future entry date and past expiration date in Entry Manager; #2912

### DIFF
--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/EntryDate.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/EntryDate.php
@@ -19,4 +19,14 @@ class EntryDate extends DateColumn
     {
         return 'column_entry_date';
     }
+
+    public function renderTableCell($data, $field_id, $entry)
+    {
+        $cell = parent::renderTableCell($data, $field_id, $entry);
+        $data = $entry->{$this->identifier};
+        if (!empty($data) && $data > ee()->localize->now) {
+            $cell = '<i class="fal fa-hourglass-start faded" title="' . lang('entry_date_future') . '"></i> ' . $cell;
+        }
+        return $cell;
+    }
 }

--- a/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/ExpirationDate.php
+++ b/system/ee/ExpressionEngine/Library/CP/EntryManager/Columns/ExpirationDate.php
@@ -19,4 +19,14 @@ class ExpirationDate extends DateColumn
     {
         return 'expiration_date';
     }
+
+    public function renderTableCell($data, $field_id, $entry)
+    {
+        $cell = parent::renderTableCell($data, $field_id, $entry);
+        $data = $entry->{$this->identifier};
+        if (!empty($data) && $data <= ee()->localize->now) {
+            $cell = '<i class="fal fa-hourglass-end faded" title="' . lang('expiration_date_past') . '"></i> ' . $cell;
+        }
+        return $cell;
+    }
 }

--- a/system/ee/language/english/content_lang.php
+++ b/system/ee/language/english/content_lang.php
@@ -132,6 +132,8 @@ $lang = array(
 
     'entry_date_desc' => 'Date of publication for this entry.',
 
+    'entry_date_future' => 'Future entry date',
+
     'entry_limit_reached' => 'Channel limit reached',
 
     'entry_limit_reached_desc' => 'This channel is limited to %d entries.',
@@ -147,6 +149,8 @@ $lang = array(
     'expiration_date' => 'Expiration date',
 
     'expiration_date_desc' => 'Date this entry should expire.',
+
+    'expiration_date_past' => 'Past expiration date',
 
     'edit_date' => 'Last edit date',
 


### PR DESCRIPTION
Added visual indication of future entry date and past expiration date in Entry Manager; closes #2912

Based on #1603 by @mithra62 

This PR adds appropriate hourglass icon with a tooltip:
- to entry date column ONLY if entry date is in future
- to expiration date column ONLY if expiration is in the past
![image](https://github.com/ExpressionEngine/ExpressionEngine/assets/752126/e6b1d774-231c-495c-9bf0-13988b96794d)
