### PR TITLE
changed messages when layouts have error due to cloning roles

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Channels/Layouts.php
+++ b/system/ee/ExpressionEngine/Controller/Channels/Layouts.php
@@ -242,10 +242,10 @@ class Layouts extends AbstractChannelsController
             }
         } elseif (ee()->form_validation->errors_exist()) {
                ee('CP/Alert')->makeInline('layout-form')
-                ->asIssue()
-                ->withTitle(lang('create_layout_error'))
-                ->addToBody(lang('create_layout_error_desc'))
-                ->now();
+                    ->asIssue()
+                    ->withTitle(lang('create_layout_error'))
+                    ->addToBody(lang('create_layout_error_desc'))
+                    ->now();
 
             // Error with cloning mode roles?
             if (defined('CLONING_MODE') && CLONING_MODE === true) {
@@ -255,10 +255,10 @@ class Layouts extends AbstractChannelsController
                     // and replace error banner above
 
                     ee('CP/Alert')->makeInline('layout-form')
-                    ->asWarning()
-                    ->withTitle(lang('clone_settings_success'))
-                    ->addToBody(lang('clone_layout_role_error'))
-                    ->now();
+                        ->asWarning()
+                        ->withTitle(lang('clone_settings_success'))
+                        ->addToBody(lang('clone_layout_role_error'))
+                        ->now();
                 }
             }
         }

--- a/system/ee/ExpressionEngine/Controller/Channels/Layouts.php
+++ b/system/ee/ExpressionEngine/Controller/Channels/Layouts.php
@@ -241,17 +241,26 @@ class Layouts extends AbstractChannelsController
                 ee()->functions->redirect(ee('CP/URL')->make('channels/layouts/edit/' . $channel_layout->getId()));
             }
         } elseif (ee()->form_validation->errors_exist()) {
-            $error = lang('create_layout_error_desc');
-            if (defined('CLONING_MODE') && CLONING_MODE === true) {
-                if (ee()->form_validation->error('roles') != '') {
-                    $error = lang('clone_layout_role_error');
-                }
-            }
-            ee('CP/Alert')->makeInline('layout-form')
+               ee('CP/Alert')->makeInline('layout-form')
                 ->asIssue()
                 ->withTitle(lang('create_layout_error'))
-                ->addToBody($error)
+                ->addToBody(lang('create_layout_error_desc'))
                 ->now();
+
+            // Error with cloning mode roles?
+            if (defined('CLONING_MODE') && CLONING_MODE === true) {
+                if (ee()->form_validation->error('roles') != '') {
+                    // Give warning that settings are cloned but
+                    // need to be changed before it can be saved
+                    // and replace error banner above
+
+                    ee('CP/Alert')->makeInline('layout-form')
+                    ->asWarning()
+                    ->withTitle(lang('clone_settings_success'))
+                    ->addToBody(lang('clone_layout_role_error'))
+                    ->now();
+                }
+            }
         }
 
         $vars = array(

--- a/system/ee/language/english/channel_lang.php
+++ b/system/ee/language/english/channel_lang.php
@@ -82,7 +82,7 @@ $lang = array(
 
     'clone_settings_success' => 'Publish Layout Settings Successfully Cloned',
 
-    'clone_layout_role_error' => 'A different role needs to be selected before you can save cloned publish layout',
+    'clone_layout_role_error' => 'A different role needs to be selected before you can save a cloned publish layout',
 
     'custom_fields' => 'Custom Fields',
 

--- a/system/ee/language/english/channel_lang.php
+++ b/system/ee/language/english/channel_lang.php
@@ -80,7 +80,9 @@ $lang = array(
 
     'create_layout_success_desc' => 'The publish layout <b>%s</b> has been created.',
 
-    'clone_layout_role_error' => 'A different role needs to be selected when cloning publish layout',
+    'clone_settings_success' => 'Publish Layout Settings Successfully Cloned',
+
+    'clone_layout_role_error' => 'A different role needs to be selected before you can save cloned publish layout',
 
     'custom_fields' => 'Custom Fields',
 


### PR DESCRIPTION
Changes UX by changing messages when you clone a given channel layout and have to change the role before saving