### PR TITLE
Allow custom variable modifiers to work on all field types

### DIFF
--- a/system/ee/ExpressionEngine/Model/Content/FieldFacade.php
+++ b/system/ee/ExpressionEngine/Model/Content/FieldFacade.php
@@ -400,7 +400,7 @@ class FieldFacade
                 $modifiersCounter++;
                 $parse_fnc = ($modifier) ? 'replace_' . $modifier : 'replace_tag';
                 $content_param = ($checkNextModifier && isset($modifiers[$modifiersCounter]) && in_array($modifiers[$modifiersCounter], $modifiersRequireArray)) ? null : $tagdata;
-                if (method_exists($ft, $parse_fnc)) {
+                if (method_exists($ft, $parse_fnc) || ee('Variables/Modifiers')->has($modifier)) {
                     $output = $this->api->apply($parse_fnc, array($output, $params, $content_param));
                 } elseif (method_exists($ft, 'replace_tag_catchall') and $modifier !== '') {
                     // Go to catchall and include modifier
@@ -412,7 +412,7 @@ class FieldFacade
             }
         } else {
             $parse_fnc = ($specificModifier) ? 'replace_' . $specificModifier : 'replace_tag';
-            if (method_exists($ft, $parse_fnc)) {
+            if (method_exists($ft, $parse_fnc) || ee('Variables/Modifiers')->has($modifier)) {
                 $output = $this->api->apply($parse_fnc, array($data, $params, $tagdata));
             } elseif (method_exists($ft, 'replace_tag_catchall') and $specificModifier !== '') {
                 // Go to catchall and include modifier

--- a/system/ee/ExpressionEngine/Model/Content/FieldModel.php
+++ b/system/ee/ExpressionEngine/Model/Content/FieldModel.php
@@ -127,7 +127,7 @@ abstract class FieldModel extends Model
         }
 
         //validate assigned conditions
-        
+
 
         return $result;
     }
@@ -498,7 +498,7 @@ abstract class FieldModel extends Model
         if (isset($variable_mods['all_modifiers']) && !empty($variable_mods['all_modifiers'])) {
             foreach ($variable_mods['all_modifiers'] as $tag_modifier => $modifier_params) {
                 $parse_fnc = ($tag_modifier) ? 'replace_' . $tag_modifier : 'replace_tag';
-                if (method_exists($fieldtype, $parse_fnc)) {
+                if (method_exists($fieldtype, $parse_fnc) || ee('Variables/Modifiers')->has($tag_modifier)) {
                     $data = ee()->api_channel_fields->apply($parse_fnc, array(
                         $data,
                         $modifier_params,
@@ -508,7 +508,7 @@ abstract class FieldModel extends Model
             }
         } else {
             $parse_fnc = ($modifier) ? 'replace_' . $modifier : 'replace_tag';
-            if (method_exists($fieldtype, $parse_fnc)) {
+            if (method_exists($fieldtype, $parse_fnc) || ee('Variables/Modifiers')->has($modifier)) {
                 $data = ee()->api_channel_fields->apply($parse_fnc, array(
                     $data,
                     $params,

--- a/system/ee/legacy/libraries/channel_entries_parser/components/Custom_field.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Custom_field.php
@@ -121,7 +121,7 @@ class EE_Channel_custom_field_parser implements EE_Channel_parser_component
 
                             // if there is next modifier, make sure to return array
                             $content_param = ($checkNextModifier && isset($modifiers[$modifiersCounter]) && in_array($modifiers[$modifiersCounter], $modifiersRequireArray)) ? null : false;
-                            if (method_exists($obj, $parse_fnc)) {
+                            if (method_exists($obj, $parse_fnc) || ee('Variables/Modifiers')->has($modifier)) {
                                 $entry = $ft_api->apply($parse_fnc, array(
                                     $data,
                                     $params,
@@ -146,7 +146,7 @@ class EE_Channel_custom_field_parser implements EE_Channel_parser_component
 
                         $parse_fnc = ($modifier) ? 'replace_' . $modifier : 'replace_tag';
 
-                        if (method_exists($obj, $parse_fnc)) {
+                        if (method_exists($obj, $parse_fnc) || ee('Variables/Modifiers')->has($modifier)) {
                             $entry = (string) $ft_api->apply($parse_fnc, array(
                                 $data,
                                 $field['params'],


### PR DESCRIPTION
Fixes issues where add-on defined variable modifiers did not work on basic field types, as well as field types in a fluid field.

When using a custom variable modifier on, for example, a text field, the field would be replaced with blank text.