### PR TITLE
Reduced the number of SQL queries when performing search in Entry Manager

### DIFF
--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -175,9 +175,11 @@ class EntryListing
     {
         static $channel = null;
 
-        if (is_null($channel)
+        if (
+            is_null($channel)
             && $this->channel_filter
-            && $this->channel_filter->value()) {
+            && $this->channel_filter->value()
+        ) {
             $channel = ee('Model')->get('Channel', $this->channel_filter->value())
                 ->first();
         }
@@ -285,10 +287,9 @@ class EntryListing
             } else {
                 show_error(lang('unauthorized_access'), 403);
             }
-        }
-        // If we have no selected channel filter, and we are not an admin, we
-        // need to filter via WHERE IN
-        else {
+        } else {
+            // If we have no selected channel filter, and we are not an admin, we
+            // need to filter via WHERE IN
             if (! $this->is_admin) {
                 if (empty($this->allowed_channels)) {
                     show_error(lang('no_channels'));
@@ -350,7 +351,7 @@ class EntryListing
                         break;
                 }
 
-                $entries->search($search_fields, $this->search_value);
+                $entries->search(array_unique($search_fields), $this->search_value);
             }
         }
 

--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -312,42 +312,44 @@ class EntryListing
         }
 
         if (! empty($this->search_value)) {
-            // setup content fields to use in search
-            $content_fields = [];
-            if (isset($channel)) {
-                $custom_fields = $channel->getAllCustomFields();
-            } else {
-                $custom_fields = array();
-
-                foreach ($this->getChannels() as $channel) {
-                    $custom_fields = array_merge($custom_fields, $channel->getAllCustomFields()->asArray());
-                }
-            }
-
-            foreach ($custom_fields as $cf) {
-                $content_fields[] = 'field_id_' . $cf->getId();
-            }
-
-            $search_fields = [];
-
-            switch ($this->search_in) {
-                case 'titles_and_content':
-                    $search_fields = array_merge(['title', 'url_title', 'entry_id'], $content_fields);
-
-                    break;
-                case 'content':
-                    $search_fields = $content_fields;
-
-                    break;
-                case 'titles':
-                    $search_fields = ['title', 'url_title', 'entry_id'];
-
-                    break;
-            }
-
             if (is_numeric($this->search_value) && strlen($this->search_value) < 3) {
                 $entries->filter('entry_id', $this->search_value);
             } else {
+                // setup content fields to use in search
+                $content_fields = [];
+                if ($this->search_in == 'titles_and_content' || $this->search_in == 'content') {
+                    if (!empty($channel)) {
+                        $custom_fields = $channel->getAllCustomFields();
+                    } else {
+                        $custom_fields = array();
+
+                        foreach ($this->getChannels() as $channel) {
+                            $custom_fields = array_merge($custom_fields, $channel->getAllCustomFields()->asArray());
+                        }
+                    }
+
+                    foreach ($custom_fields as $cf) {
+                        $content_fields[] = 'field_id_' . $cf->getId();
+                    }
+                }
+
+                $search_fields = [];
+
+                switch ($this->search_in) {
+                    case 'titles_and_content':
+                        $search_fields = array_merge(['title', 'url_title', 'entry_id'], $content_fields);
+
+                        break;
+                    case 'content':
+                        $search_fields = $content_fields;
+
+                        break;
+                    case 'titles':
+                        $search_fields = ['title', 'url_title', 'entry_id'];
+
+                        break;
+                }
+
                 $entries->search($search_fields, $this->search_value);
             }
         }
@@ -433,7 +435,7 @@ class EntryListing
      */
     protected function getChannels()
     {
-        if (! isset($this->channels)) {
+        if (empty($this->channels)) {
             $allowed_channel_ids = ($this->is_admin) ? null : $this->allowed_channels;
             $this->channels = ee('Model')->get('Channel', $allowed_channel_ids)
                 ->fields('channel_id', 'channel_title')


### PR DESCRIPTION
This PR is doing 2 things:

- replacing `isset` with `empty` checks for variables that always exist but are null (to avoid same query run twice)
- avoid fetching channel custom fields if the search input is numeric, or done in titles only