### PR TITLE
Added support for `STRAIGHT_JOIN` in ActiveRecord; #3073

### DIFF
--- a/system/ee/legacy/database/DB_active_rec.php
+++ b/system/ee/legacy/database/DB_active_rec.php
@@ -32,7 +32,6 @@ class CI_DB_active_record extends CI_DB_driver
     public $ar_wherein = array();
     public $ar_aliased_tables = array();
     public $ar_store_array = array();
-    public $ar_straight = false;
 
     protected $ar_group_count = 0;
     protected $ar_empty_group = true;
@@ -232,22 +231,6 @@ class CI_DB_active_record extends CI_DB_driver
         return $this;
     }
 	
-    /**
-     * STRAIGHT
-     *
-     * Sets a flag which tells the query string compiler to add STRAIGHT_JOIN
-     *
-     * @access	public
-     * @param	bool $val Set to FALSE to remove STRAIGHT from a query
-     * @return	CI_DB_active_record The active record object
-     */
-    public function straight($val = true)
-    {
-        $this->ar_straight = (bool) $val;
-
-        return $this;
-    }
-
     /**
      * From
      *
@@ -1752,9 +1735,6 @@ class CI_DB_active_record extends CI_DB_driver
             $sql = $select_override;
         } else {
             $sql = (! $this->ar_distinct) ? 'SELECT ' : 'SELECT DISTINCT ';
-			if ($this->ar_straight) {
-				$sql .= 'STRAIGHT_JOIN ';
-			}
 
             if (count($this->ar_select) == 0) {
                 $sql .= '*';

--- a/system/ee/legacy/database/DB_active_rec.php
+++ b/system/ee/legacy/database/DB_active_rec.php
@@ -230,7 +230,7 @@ class CI_DB_active_record extends CI_DB_driver
 
         return $this;
     }
-	
+
     /**
      * From
      *
@@ -315,7 +315,7 @@ class CI_DB_active_record extends CI_DB_driver
         if (! empty($alias)) {
             $join_alias = ' ' . $alias . ' ';
         }
-		
+
         // Assemble the JOIN statement
         if (trim($type) == 'STRAIGHT') {
             $join = 'STRAIGHT_JOIN ' . $this->_protect_identifiers($table, true, null, false) . $join_alias . ' ON ' . $cond;

--- a/system/ee/legacy/database/DB_active_rec.php
+++ b/system/ee/legacy/database/DB_active_rec.php
@@ -333,14 +333,14 @@ class CI_DB_active_record extends CI_DB_driver
             $join_alias = ' ' . $alias . ' ';
         }
 		
-		if (trim($type) == 'STRAIGHT') {
-			$join = 'STRAIGHT_JOIN ' . $this->_protect_identifiers($table, true, null, false) . $join_alias . ' ON ' . $cond;
-		}
-		else {
         // Assemble the JOIN statement
-        $join = $type . 'JOIN ' . $this->_protect_identifiers($table, true, null, false) . $join_alias . ' ON ' . $cond;
-		}
-
+        if (trim($type) == 'STRAIGHT') {
+            $join = 'STRAIGHT_JOIN ' . $this->_protect_identifiers($table, true, null, false) . $join_alias . ' ON ' . $cond;
+        }
+        else {
+            $join = $type . 'JOIN ' . $this->_protect_identifiers($table, true, null, false) . $join_alias . ' ON ' . $cond;
+        }
+		
         $this->ar_join[] = $join;
         if ($this->ar_caching === true) {
             $this->ar_cache_join[] = $join;


### PR DESCRIPTION
Added straight as a join type

Not adding it as a flag/keyword, though first commit has both

NOTE - removed the flag from the final commit per discussion

per user request, adding a straight join flag and join type.

used as join('channel_data', "channel_data.entry_id = channel_titles.entry_id", "straight");<br>
SELECT `exp_channel_titles`.`entry_id` FROM (`exp_channel_titles`) STRAIGHT_JOIN `exp_channel_data` ON `exp_channel_data`.`entry_id` 

<br><br>
used as ->straight()<br>
SELECT STRAIGHT_JOIN `exp_channel_titles`.`entry_id` FROM (`exp_channel_titles`

docs pr: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/678