### PR TITLE
Resolved #3463 where "choose wisely" was a poor choice

### DIFF
--- a/cp-styles/pages/entry.php
+++ b/cp-styles/pages/entry.php
@@ -722,7 +722,7 @@ include(dirname(__FILE__) . '/_wrapper-head.php'); ?>
 					<div class="select">
 						<div class="select__button">
 							<label class="select__button-label">
-								<!-- Choose Wisely -->
+								<!-- Please select -->
 								<div class="status-tag st-open">Open</div>
 								<input type="hidden" name="">
 							</label>
@@ -748,7 +748,7 @@ include(dirname(__FILE__) . '/_wrapper-head.php'); ?>
 					<div class="select">
 						<div class="select__button">
 							<label class="select__button-label">
-								Choose Wisely
+								Please select
 								<input type="hidden" name="">
 							</label>
 						</div>
@@ -773,7 +773,7 @@ include(dirname(__FILE__) . '/_wrapper-head.php'); ?>
 					<div class="select select--open select--open">
 						<div class="select__button">
 							<label class="select__button-label act">
-								Choose Wisely
+								Please select
 								<input type="hidden" name="">
 							</label>
 						</div>

--- a/system/ee/ExpressionEngine/Addons/select/ft.select.php
+++ b/system/ee/ExpressionEngine/Addons/select/ft.select.php
@@ -78,7 +78,7 @@ class Select_ft extends OptionFieldtype
                 'field_name' => $this->field_name,
                 'choices' => $this->_get_field_options($data),
                 'value' => $data,
-                'empty_text' => lang('choose_wisely'),
+                'empty_text' => lang('please_select'),
                 'field_disabled' => $this->get_setting('field_disabled'),
                 'ignoreSectionLabel' => $this->get_setting('ignore_section_label')
             ]);

--- a/system/ee/ExpressionEngine/View/_shared/form/field.php
+++ b/system/ee/ExpressionEngine/View/_shared/form/field.php
@@ -148,7 +148,7 @@ case 'dropdown': ?>
         'limit' => isset($field['limit']) ? $field['limit'] : 100,
         'no_results' => isset($field['no_results']) ? $field['no_results'] : null,
         'group_toggle' => isset($field['group_toggle']) ? $field['group_toggle'] : null,
-        'empty_text' => isset($field['empty_text']) ? lang($field['empty_text']) : lang('choose_wisely'),
+        'empty_text' => isset($field['empty_text']) ? lang($field['empty_text']) : lang('please_select'),
         'class' => $class,
     ]); ?>
 <?php break;

--- a/system/ee/ExpressionEngine/View/_shared/form/fields/dropdown.php
+++ b/system/ee/ExpressionEngine/View/_shared/form/fields/dropdown.php
@@ -1,6 +1,6 @@
 <?php
 $too_many = isset($too_many) ? $too_many : 8;
-$empty_text = isset($empty_text) ? $empty_text : lang('choose_wisely');
+$empty_text = isset($empty_text) ? $empty_text : lang('please_select');
 $field_disabled = isset($field_disabled) ? $field_disabled : false;
 $class = isset($class) ? $class : '';
 

--- a/system/ee/language/english/cp_lang.php
+++ b/system/ee/language/english/cp_lang.php
@@ -157,6 +157,8 @@ $lang = array(
 
     'password_label' => 'Password:',
 
+    'please_select' => 'Please select',
+
     'powered_by' => 'Powered By',
 
     'queries_executed' => '%x SQL queries used',

--- a/tests/cypress/cypress/integration/design/template_routes.ee6.js
+++ b/tests/cypress/cypress/integration/design/template_routes.ee6.js
@@ -31,7 +31,7 @@ context('Template Routes', () => {
             route: 'foo/bar'
         })
 
-        //cy.get('i').filter(':visible').contains('Choose wisely').first().click()
+        //cy.get('i').filter(':visible').contains('Please select').first().click()
         //cy.get('.select--open .select__dropdown-item span').contains('/').first().click()
         //cy.wait(300)
         page.get('update_button').filter(':visible').first().click()


### PR DESCRIPTION
We are changing the blank select state from "Choose wisely" to "Please select" by introducing a new `please_select` language variable.  We are leaving in place the old `choose_wisely` language variable in case it is being used by others but this can be removed in the next major release.