### PR TITLE
Resolved #3522 where grid fields in a pro variable would not parse when set to early parsing

### DIFF
--- a/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
@@ -418,6 +418,19 @@ class LegacyParser
                     $content = $value;
                     $var_props = $this->parseVariableProperties($modified_var, $prefix);
 
+                    // Is pro variables installed?
+                    if (ee('Addon')->get('pro_variables')->isInstalled()) {
+                        // Get early parsed pro variables
+                        $early = ee()->pro_variables_variable_model->get_early();
+                        $early = pro_flatten_results($early, 'variable_data', 'variable_name');
+
+                        // If this is an early parsed pro variable, we skip it for now
+                        // and let it get parsed later
+                        if (array_key_exists($var_props['field_name'], $early)) {
+                            continue;
+                        }
+                    }
+
                     // in order to support multiple modifiers, we'll do this in a loop
                     if (isset($var_props['all_modifiers']) && !empty($var_props['all_modifiers'])) {
                         foreach ($var_props['all_modifiers'] as $modifier => $params) {


### PR DESCRIPTION
In EE 7.3+, the template parser sees `{lv_gridtest:g_text}` in the template, and also sees that `lv_gridtest` is a global variable.

It thinks that `g_text` is a modifier to `lv_gridtest`, and processes it as such. Since `lv_gridtest` is a global variable at this point, but it is a grid, the value is set to `''`.

The template parser processes the tag here and ends up stripping the tag out before it ever makes it to pro vars.

Resolved #3522 where grid fields in a pro variable would not parse when set to early parsing




