### PR TITLE
Resolved issue where image manipulation could malfunction if the resize protocol was not set

### DIFF
--- a/system/ee/legacy/libraries/Image_lib.php
+++ b/system/ee/legacy/libraries/Image_lib.php
@@ -149,7 +149,7 @@ class EE_Image_lib
             return false;
         }
 
-        $this->image_library = strtolower($this->image_library);
+        $this->image_library = ($this->image_library) ? strtolower($this->image_library) : 'gd2';
 
         /*
          * Set the full server path


### PR DESCRIPTION
I'm proposing this as a simpler alternative to https://github.com/ExpressionEngine/ExpressionEngine/pull/3323 

During EE_Image_lib::initialize() the `image_library` property could be overwritten with an empty value.  This change will default back to `gd2` if an empty value was passed through in a config setting.  

I think this solution should address the root of the problem where the Image lib should never allow an empty value here.