### PR TITLE
Resolved issue where Structure would show deprecation notice when using PHP 8.2

### DIFF
--- a/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
@@ -19,11 +19,11 @@ class Sql_structure
     public $lcids = array();
     public $cache;
 	
-	require_once PATH_ADDONS . 'structure/helper.php';
-	require_once PATH_ADDONS . 'structure/addon.setup.php';	
-
     public function __construct()
     {
+        require_once PATH_ADDONS . 'structure/helper.php';
+        require_once PATH_ADDONS . 'structure/addon.setup.php';	
+		
         ee()->load->add_package_path(PATH_ADDONS . 'structure/');
         ee()->load->library('sql_helper');
         ee()->load->library('general_helper');

--- a/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
@@ -755,7 +755,7 @@ class Sql_structure
             }
 
             // Build id string if any exist
-            $ids = count($tree[$i]['ids']) > 0 ? ' id="' . implode(' ', $tree[$i]['ids']) . '"' : null;
+            $ids = count($tree[$i]['ids']) > 0 ? ' id="' . implode(' ', $tree[$i]['ids']) . '"' : '';
 
             // Title field: custom|title
             $title = $custom_title_fields !== false ? $custom_title_fields[$tree[$i]['entry_id']] : $tree[$i]['title'];

--- a/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once PATH_ADDONS . 'structure/helper.php';
-require_once PATH_ADDONS . 'structure/addon.setup.php';
-
 use ExpressionEngine\Structure\Conduit\StaticCache;
 use ExpressionEngine\Structure\Conduit\PersistentCache;
 
@@ -21,6 +18,9 @@ class Sql_structure
     public $cids = array();
     public $lcids = array();
     public $cache;
+	
+	require_once PATH_ADDONS . 'structure/helper.php';
+	require_once PATH_ADDONS . 'structure/addon.setup.php';	
 
     public function __construct()
     {

--- a/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
@@ -748,7 +748,7 @@ class Sql_structure
             // }
 
             // Build class string if any exist
-            $classes = count($tree[$i]['classes']) > 0 ? ' class="' . implode(' ', $tree[$i]['classes']) . '"' : null;
+            $classes = count($tree[$i]['classes']) > 0 ? ' class="' . implode(' ', $tree[$i]['classes']) . '"' : '';
 
             if ($show_overview) {
                 $classes = str_replace("first", "", $classes);

--- a/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
@@ -18,12 +18,12 @@ class Sql_structure
     public $cids = array();
     public $lcids = array();
     public $cache;
-	
+
     public function __construct()
     {
         require_once PATH_ADDONS . 'structure/helper.php';
-        require_once PATH_ADDONS . 'structure/addon.setup.php';	
-		
+        require_once PATH_ADDONS . 'structure/addon.setup.php';
+
         ee()->load->add_package_path(PATH_ADDONS . 'structure/');
         ee()->load->library('sql_helper');
         ee()->load->library('general_helper');

--- a/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/sql.structure.php
@@ -1,8 +1,4 @@
 <?php
-
-use ExpressionEngine\Structure\Conduit\StaticCache;
-use ExpressionEngine\Structure\Conduit\PersistentCache;
-
 /**
  * This source file is part of the open source project
  * ExpressionEngine (https://expressionengine.com)
@@ -11,6 +7,13 @@ use ExpressionEngine\Structure\Conduit\PersistentCache;
  * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
  * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
  */
+
+require_once PATH_ADDONS . 'structure/helper.php';
+require_once PATH_ADDONS . 'structure/addon.setup.php';
+
+use ExpressionEngine\Structure\Conduit\StaticCache;
+use ExpressionEngine\Structure\Conduit\PersistentCache;
+
 class Sql_structure
 {
     public $site_id;
@@ -21,9 +24,6 @@ class Sql_structure
 
     public function __construct()
     {
-        require_once PATH_ADDONS . 'structure/helper.php';
-        require_once PATH_ADDONS . 'structure/addon.setup.php';
-
         ee()->load->add_package_path(PATH_ADDONS . 'structure/');
         ee()->load->library('sql_helper');
         ee()->load->library('general_helper');


### PR DESCRIPTION
str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
