### PR TITLE
Resolved #3489 where `member_rows` variable in `exp:member:memberlist` did not support `backspace` parameter

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_memberlist.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_memberlist.php
@@ -258,10 +258,12 @@ class Member_memberlist extends Member
 
         // Find out if we have sub-tag data for our `member_rows` tag. If not, use the legacy speciality template.
         if (strpos($template, '{/member_rows}') !== false) {
-            $member_rows_tag_length = strlen(LD . 'member_rows' . RD);
+
+            $member_rows_opening = ee('Variables/Parser')->getFullTag($template, 'member_rows');
+            $member_rows_tag_length = strlen(LD . $member_rows_opening);
 
             // Find the starting and ending position of our subtag and calculate the difference so we can grab it.
-            $member_rows_start = strpos($template, LD . 'member_rows' . RD) + $member_rows_tag_length;
+            $member_rows_start = strpos($template, LD . $member_rows_opening) + $member_rows_tag_length;
             $member_rows_end = strpos($template, LD . '/member_rows' . RD);
             $member_rows_diff = $member_rows_end - $member_rows_start;
 
@@ -887,12 +889,12 @@ class Member_memberlist extends Member
             $template = str_replace(LD . "form:form_declaration:do_member_search" . RD, $form_open_member_search, $template);
         }
 
-        if (! empty($member_rows_diff)) {
-            $member_rows_start = strpos($template, LD . 'member_rows' . RD);
-            $member_rows_end = strpos($template, LD . '/member_rows' . RD) + $member_rows_tag_length + 1;
-            $member_rows_diff = $member_rows_end - $member_rows_start;
-
-            $template = substr_replace($template, $str, $member_rows_start, $member_rows_diff);
+        if (isset($member_rows_diff) && ! empty($member_rows_diff)) {
+            $params = ee('Variables/Parser')->parseTagParameters($member_rows_opening);
+            if (isset($params['backspace']) && is_numeric($params['backspace'])) {
+                $str = substr($str, 0, - $params['backspace']);
+            }
+            $template = str_replace(LD . $member_rows_opening . $memberlist_rows . LD . '/member_rows' . RD, $str, $template);
         } else {
             $template = str_replace(LD . "member_rows" . RD, $str, $template);
         }

--- a/tests/cypress/cypress/integration/members/member_list.ee6.js
+++ b/tests/cypress/cypress/integration/members/member_list.ee6.js
@@ -103,6 +103,12 @@ context('Member List frontend', () => {
     cy.logFrontendPerformance()
   })
 
+  it.only('Check backspace parameter for member_rows', () => {
+    cy.auth()
+    cy.visit('index.php/members/memberlist-backspace');
+    cy.get('div').contains("Admin").should('not.contain', 'Admin**')
+  })
+
   it('the paths are correct', () => {
 
     cy.visit('index.php/members/memberlist');

--- a/tests/cypress/support/templates/default_site/members.group/memberlist-backspace.html
+++ b/tests/cypress/support/templates/default_site/members.group/memberlist-backspace.html
@@ -1,0 +1,19 @@
+{layout="members/_layout"}
+
+<h1>Member Listing</h1>
+
+<div class="result">
+
+    {exp:member:memberlist
+        return="members/login/forgot-username"
+        inline_errors="yes"
+        email_subject="Your Username"
+        email_template="members/email-forgot-username"
+        }
+
+
+            {member_rows backspace="2"}{name}**{/member_rows}
+
+
+    {/exp:member:memberlist}
+</div>


### PR DESCRIPTION
Resolved #3489 where `member_rows` variable in `exp:member:memberlist` did not support `backspace` parameter