### PR TITLE
Resolved #2178 where pagination in Entry Manager was not correct for people who only can edit their own entries

### DIFF
--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -307,7 +307,15 @@ class EntryListing
             $entries->filter('status', $this->status_filter->value());
         }
 
-        if (! empty($this->author_filter) && $this->author_filter->value()) {
+        // if the user has no 'other entries' permissions at all
+        // or if they are viewing a channel where they have "own" permissions only
+        // then restrict to their own entries
+        if (
+            (!empty($channel_id) && !ee('Permission')->has('can_edit_other_entries_channel_id_' . $channel_id)) ||
+            !ee('Permission')->hasAny('can_edit_other_entries')
+        ) {
+            $entries->filter('author_id', ee()->session->userdata('member_id'));
+        } elseif (! empty($this->author_filter) && $this->author_filter->value()) {
             $entries->filter('author_id', $this->author_filter->value());
         }
 


### PR DESCRIPTION
This is reverse of https://github.com/ExpressionEngine/ExpressionEngine/pull/3196 because that presented issue where people could see the entries for channels where they has no access.

We still need to find a solution that would allow some editors to see existing entried, but not edit them