### PR TITLE
Resolved #3596 where duplicate entry dates could cause inconsistent ordering in Entry Manager

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/Edit.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Edit.php
@@ -166,8 +166,11 @@ class Edit extends AbstractPublishController
             }
         }
         $sort_field = $columns[$sort_col]->getEntryManagerColumnSortField();
-        $entries->order($sort_field, $table->sort_dir)
-            ->limit($filter_values['perpage'])
+        $entries->order($sort_field, $table->sort_dir);
+        if ($sort_col != 'entry_id') {
+            $entries->order('entry_id', $table->sort_dir);
+        }
+        $entries->limit($filter_values['perpage'])
             ->offset($offset);
         $entries = $entries->all();
 


### PR DESCRIPTION
Resolved #3596 where duplicate entry dates could cause inconsistent ordering in Entry Manager

EE7 version of #3598