### PR TITLE
Resolved #3595 where File field did not present explanation of assigned upload directory on other MSM site

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -916,6 +916,20 @@ JSC;
             )
         );
 
+        if (!array_key_exists($allowed_directories, $directory_choices)) {
+            $selectedDir = ee('Model')->get('UploadDestination', $allowed_directories)->with('Site')->first();
+            if (!is_null($selectedDir)) {
+                $settings['field_options_file']['settings'][1]['fields']['file_field_msm_warning'] = array(
+                    'type' => 'html',
+                    'content' => ee('CP/Alert')->makeInline('file_field_msm_warning')
+                        ->asImportant()
+                        ->addToBody(sprintf(lang('file_field_msm_warning'), $selectedDir->name, $selectedDir->Site->site_label))
+                        ->cannotClose()
+                        ->render()
+                );
+            }
+        }
+
         return $settings;
     }
 

--- a/system/ee/ExpressionEngine/Addons/grid/ft.file_grid.php
+++ b/system/ee/ExpressionEngine/Addons/grid/ft.file_grid.php
@@ -65,6 +65,7 @@ class file_grid_ft extends Grid_ft
 
         $vars = $this->getSettingsVars();
         $vars['group'] = $this->settings_form_field_name;
+        $allowed_directories = isset($data['allowed_directories']) ? $data['allowed_directories'] : 'all';
 
         $settings = [
             'field_options_file_grid' => [
@@ -121,7 +122,7 @@ class file_grid_ft extends Grid_ft
                             'allowed_directories' => [
                                 'type' => 'radio',
                                 'choices' => $directory_choices,
-                                'value' => isset($data['allowed_directories']) ? $data['allowed_directories'] : 'all',
+                                'value' => $allowed_directories,
                                 'no_results' => [
                                     'text' => sprintf(lang('no_found'), lang('file_ft_upload_directories')),
                                     'link_text' => 'add_new',
@@ -153,6 +154,20 @@ class file_grid_ft extends Grid_ft
                 'settings' => [$vars['grid_alert'], ee('View')->make('grid:settings')->render($vars)]
             ]
         ];
+
+        if (!array_key_exists($allowed_directories, $directory_choices)) {
+            $selectedDir = ee('Model')->get('UploadDestination', $allowed_directories)->with('Site')->first();
+            if (!is_null($selectedDir)) {
+                $settings['field_options_file_grid']['settings'][4]['fields']['file_field_msm_warning'] = array(
+                    'type' => 'html',
+                    'content' => ee('CP/Alert')->makeInline('file_field_msm_warning')
+                        ->asImportant()
+                        ->addToBody(sprintf(lang('file_field_msm_warning'), $selectedDir->name, $selectedDir->Site->site_label))
+                        ->cannotClose()
+                        ->render()
+                );
+            }
+        }
 
         $this->loadGridSettingsAssets();
 

--- a/system/ee/language/english/fieldtypes_lang.php
+++ b/system/ee/language/english/fieldtypes_lang.php
@@ -151,6 +151,8 @@ $lang = array(
 
     'file_ft_show_files_desc' => 'When enabled, a drop down with existing files will be shown to authors.',
 
+    'file_field_msm_warning' => 'This field is currently set to use the <b>%s</b> upload directory, which is only available in <b>%s</b> MSM site.',
+
     'file_ft_upload_directories' => 'Upload Directories',
 
     /* File Drag and Drop */


### PR DESCRIPTION
Resolved #3595 where File field did not present explanation of assigned upload directory on other MSM site

![image](https://github.com/ExpressionEngine/ExpressionEngine/assets/752126/fbec19d4-f2f1-4017-bdf6-f84c4522c5d0)
