### PR TITLE
Resolved issue where PHP warning could have been shown when using Grid with Pro Variables

### DIFF
--- a/system/ee/ExpressionEngine/Addons/grid/ft.grid.php
+++ b/system/ee/ExpressionEngine/Addons/grid/ft.grid.php
@@ -844,7 +844,7 @@ class Grid_ft extends EE_Fieldtype
         ee()->grid_lib->entry_id = ($this->content_id() == null) ? $entry_id : $this->content_id();
         ee()->grid_lib->field_id = $this->id();
         ee()->grid_lib->field_name = $this->name();
-        ee()->grid_lib->field_required = $this->settings['field_required'];
+        ee()->grid_lib->field_required = $this->settings['field_required'] ?? 'n';
         ee()->grid_lib->content_type = $this->content_type();
         ee()->grid_lib->fluid_field_data_id = (isset($this->settings['fluid_field_data_id'])) ? $this->settings['fluid_field_data_id'] : 0;
         ee()->grid_lib->in_modal_context = $this->get_setting('in_modal_context');


### PR DESCRIPTION
…l coalescing

Addresses an undefined array key warning for 'field_required' within the control panel, when Pro Variables implements the Grid field without providing a default, 'n.'

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
