### PR TITLE
Resolved bug where post flight could not use site_id

### DIFF
--- a/system/ee/ExpressionEngine/Library/Advisor/Advisor.php
+++ b/system/ee/ExpressionEngine/Library/Advisor/Advisor.php
@@ -17,9 +17,10 @@ class Advisor
     {
         // if we call this from updater, site_short_name might be not set
         // grab the first site and set it
-        if (empty(ee()->config->item('site_short_name'))) {
-            $siteQuery = ee('db')->select('site_name')->from('sites')->order_by('site_id', 'asc')->limit(1)->get();
+        if (empty(ee()->config->item('site_short_name')) || empty(ee()->config->item('site_id'))) {
+            $siteQuery = ee('db')->select('site_id, site_name')->from('sites')->order_by('site_id', 'asc')->limit(1)->get();
             ee()->config->set_item('site_short_name', $siteQuery->row('site_name'));
+            ee()->config->set_item('site_id', $siteQuery->row('site_id'));
         }
 
         $messages = [];

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -4320,7 +4320,7 @@ class EE_Template
         }
 
         // if we don't know site short name, we can't proceed
-        if (empty(ee()->config->item('site_short_name'))) {
+        if (empty(ee()->config->item('site_short_name')) || empty(ee()->config->item('site_id'))) {
             return false;
         }
 


### PR DESCRIPTION
This bug could also result in duplicate template groups when post flight check happened on a manual update