### PR TITLE
Resolved issue where duplicate template group would show 404

### DIFF
--- a/build-tools/build.json
+++ b/build-tools/build.json
@@ -1,5 +1,5 @@
 {
-    "tag": "7.3.7",
+    "tag": "7.3.8",
 
     "repositories": {
         "app": "git@github.com:ExpressionEngine/ExpressionEngine",

--- a/system/ee/ExpressionEngine/Tests/bootstrap.php
+++ b/system/ee/ExpressionEngine/Tests/bootstrap.php
@@ -11,7 +11,7 @@ define('SYSPATH', $project_base);
 define('BASEPATH', SYSPATH . 'ee/legacy/');
 define('PATH_CACHE', SYSPATH . 'user/cache/');
 define('APPPATH', BASEPATH);
-define('APP_VER', '7.3.7');
+define('APP_VER', '7.3.8');
 define('PATH_THEMES', realpath(SYSPATH . '/../themes') . '/');
 define('DOC_URL', 'http://our.doc.url/');
 define('PATH_THIRD', SYSPATH . 'user/addons/');

--- a/system/ee/installer/controllers/wizard.php
+++ b/system/ee/installer/controllers/wizard.php
@@ -13,7 +13,7 @@
  */
 class Wizard extends CI_Controller
 {
-    public $version = '7.3.7'; // The version being installed
+    public $version = '7.3.8'; // The version being installed
     public $installed_version = '';  // The version the user is currently running (assuming they are running EE)
     public $schema = null; // This will contain the schema object with our queries
     public $languages = array(); // Available languages the installer supports (set dynamically based on what is in the "languages" folder)

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -74,8 +74,8 @@ class EE_Core
 
         // application constants
         define('APP_NAME', 'ExpressionEngine');
-        define('APP_BUILD', '20230711');
-        define('APP_VER', '7.3.7');
+        define('APP_BUILD', '20230720');
+        define('APP_VER', '7.3.8');
         define('APP_VER_ID', '');
         define('SLASH', '&#47;');
         define('LD', '{');

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -2230,10 +2230,17 @@ class EE_Template
         ee()->db->select('group_id');
         ee()->db->where('group_name', ee()->uri->segment(1));
         ee()->db->where('site_id', ee()->config->item('site_id'));
+        ee()->db->order_by('group_id', 'asc');
         $query = ee()->db->get('template_groups');
 
+        $row = $query->first_row();
+
+        if($query->num_rows() > 1) {
+            $this->log_item("Duplicate Template Group Name: " . ee()->uri->segment(1) . ". Using Template Group ID: " . $row->group_id);
+        }
+
         // Template group found!
-        if ($query->num_rows() == 1) {
+        if ($row) {
             // Set the name of our template group
             $template_group = ee()->uri->segment(1);
 
@@ -2278,18 +2285,12 @@ class EE_Template
             }
         } else {
             // The first segment in the URL does NOT correlate to a valid template group.  Oh my!
-            if ($query->num_rows() > 1) {
-                $duplicate = true;
-                $this->log_item("Duplicate Template Group: " . ee()->uri->segment(1));
-            } else {
-                $duplicate = false;
-                $this->log_item("Template group and template not found, showing 404 page");
-            }
+            $this->log_item("Template group and template not found, showing 404 page");
 
             // If we are enforcing strict URLs we need to show a 404
-            if ($duplicate == true or $this->strict_urls == true) {
+            if ($this->strict_urls == true) {
                 // is there a file we can automatically create this template from?
-                if ($duplicate == false && ee()->config->item('save_tmpl_files') == 'y') {
+                if (ee()->config->item('save_tmpl_files') == 'y') {
                     if ($this->_create_from_file(ee()->uri->segment(1), ee()->uri->segment(2))) {
                         return $this->fetch_template(ee()->uri->segment(1), ee()->uri->segment(2), false);
                     }

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -2233,14 +2233,12 @@ class EE_Template
         ee()->db->order_by('group_id', 'asc');
         $query = ee()->db->get('template_groups');
 
-        $row = $query->first_row();
-
-        if($query->num_rows() > 1) {
-            $this->log_item("Duplicate Template Group Name: " . ee()->uri->segment(1) . ". Using Template Group ID: " . $row->group_id);
+        if ($query->num_rows() > 1) {
+            $this->log_item("Duplicate Template Group Name: " . ee()->uri->segment(1) . ". Using Template Group ID: " . $query->row('group_id'));
         }
 
         // Template group found!
-        if ($row) {
+        if ($query->num_rows() > 0) {
             // Set the name of our template group
             $template_group = ee()->uri->segment(1);
 

--- a/tests/cypress/support/config/config.php
+++ b/tests/cypress/support/config/config.php
@@ -13,7 +13,7 @@ $config['legacy_member_templates'] = 'y';
 
 $config['log_date_format'] = 'Y-m-d H:i:s';
 $config['log_threshold'] = '1';
-$config['app_version'] = '7.3.7';
+$config['app_version'] = '7.3.8';
 $config['encryption_key'] = '4b9e521eb02751d8466a3e9b764524aff14b91ad';
 $config['session_crypt_key'] = '1f307a8afe66e692c2689508a5d9f783606379a8';
 $config['base_path'] = $_SERVER['DOCUMENT_ROOT'];


### PR DESCRIPTION
Improve visitor experience by displaying the template from the oldest/original template group instead of a 404 page.