### PR TITLE
Added Utility and post-update check for duplicate Template Groups

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Design/AbstractDesign.php
+++ b/system/ee/ExpressionEngine/Controller/Design/AbstractDesign.php
@@ -104,7 +104,13 @@ abstract class AbstractDesign extends CP_Controller
             }
         }
 
+        $groupNamesListed = [];
+
         foreach ($template_groups->all() as $group) {
+            if (in_array($group->group_name, $groupNamesListed)) {
+                // duplicates found, show alert but do not add to sidebar
+                continue;
+            }
             $item = $template_group_list->addItem($group->group_name, ee('CP/URL')->make('design/manager/' . $group->group_name));
 
             $item->withEditUrl(ee('CP/URL')->make('design/group/edit/' . $group->group_name));
@@ -127,6 +133,8 @@ abstract class AbstractDesign extends CP_Controller
             if ($group->is_site_default) {
                 $item->asDefaultItem();
             }
+
+            $groupNamesListed[] = $group->group_name;
         }
 
         // System Templates

--- a/system/ee/ExpressionEngine/Controller/Design/AbstractDesign.php
+++ b/system/ee/ExpressionEngine/Controller/Design/AbstractDesign.php
@@ -19,6 +19,7 @@ use ExpressionEngine\Service\CP\Filter\Filter;
 use ExpressionEngine\Service\Filter\FilterFactory;
 use ExpressionEngine\Service\CP\Filter\FilterRunner;
 use ExpressionEngine\Service\Model\Query\Builder as QueryBuilder;
+use ExpressionEngine\Library\Advisor;
 
 /**
  * Abstract Design Controller
@@ -109,6 +110,19 @@ abstract class AbstractDesign extends CP_Controller
         foreach ($template_groups->all() as $group) {
             if (in_array($group->group_name, $groupNamesListed)) {
                 // duplicates found, show alert but do not add to sidebar
+                if (!isset($duplicateAlert)) {
+                    ee()->lang->load('utilities');
+                    $templateAdvisor = new Advisor\TemplateAdvisor();
+                    $message = sprintf(lang('duplicate_template_groups_found'), $templateAdvisor->getDuplicateTemplateGroupsCount()) . '<br><a href="' . ee('CP/URL')->make('utilities/debug-tools/duplicate-template-groups') . '">' . lang('review_duplicate_template_groups') . '</a>';
+                    $duplicateAlert = ee('CP/Alert')
+                        ->makeInline()
+                        ->addToBody($message)
+                        ->asImportant();
+                    if (ee('Permission')->isSuperAdmin()) {
+                        $duplicateAlert->now();
+                    }
+                    ee()->logger->developer($message, true, 60 * 60 * 24 * 30);
+                }
                 continue;
             }
             $item = $template_group_list->addItem($group->group_name, ee('CP/URL')->make('design/manager/' . $group->group_name));

--- a/system/ee/ExpressionEngine/Controller/Design/Design.php
+++ b/system/ee/ExpressionEngine/Controller/Design/Design.php
@@ -135,7 +135,8 @@ class Design extends AbstractDesignController
         $group = ee('Model')->get('TemplateGroup')
             ->fields('group_id', 'group_name')
             ->filter('site_id', ee()->config->item('site_id'))
-            ->order('group_name', 'asc');
+            ->order('group_name', 'asc')
+            ->order('group_id', 'asc'); //get the older group
 
         if ($group_name) {
             $group->filter('group_name', $group_name);

--- a/system/ee/ExpressionEngine/Controller/Design/Template.php
+++ b/system/ee/ExpressionEngine/Controller/Design/Template.php
@@ -39,6 +39,7 @@ class Template extends AbstractDesignController
         $group = ee('Model')->get('TemplateGroup')
             ->filter('group_name', $group_name)
             ->filter('site_id', ee()->config->item('site_id'))
+            ->order('group_id', 'asc')
             ->first();
 
         if (! $group) {

--- a/system/ee/ExpressionEngine/Controller/Utilities/DebugTools.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/DebugTools.php
@@ -12,6 +12,7 @@
 namespace ExpressionEngine\Controller\Utilities;
 
 use ExpressionEngine\Library\Advisor;
+use ExpressionEngine\Library\CP\Table;
 
 /**
  * Debug Tools
@@ -44,6 +45,7 @@ class DebugTools extends Utilities
 
         $templateAdvisor = new Advisor\TemplateAdvisor();
         $vars['bad_tags_count'] = $templateAdvisor->getBadTagCount();
+        $vars['duplicate_template_groups_count'] = $templateAdvisor->getDuplicateTemplateGroupsCount();
 
         $ftAdvisor = new Advisor\FieldtypeAdvisor();
         $vars['missing_fieldtype_count'] = $ftAdvisor->getMissingFieldtypeCount();
@@ -141,6 +143,91 @@ class DebugTools extends Utilities
         );
 
         return ee()->cp->render('utilities/debug-tools/missing_fieldtypes', $vars);
+    }
+
+    public function duplicateTemplateGroups()
+    {
+        ee()->view->cp_page_title = lang('debug_tools_debug_duplicate_template_groups');
+
+        $templateAdvisor = new Advisor\TemplateAdvisor();
+
+        $vars = [];
+        $table = ee('CP/Table', array('autosort' => false));
+
+        $table->setColumns(
+            array(
+                'group_id',
+                'group_name',
+                'manage' => array(
+                    'type' => Table::COL_TOOLBAR
+                )
+            )
+        );
+
+        $data = [];
+        $duplicates = $templateAdvisor->getDuplicateTemplateGroups();
+        if (count($duplicates) > 0) {
+            foreach ($duplicates as $row) {
+                $toolbar = array(
+                    'edit' => array(
+                        'href' => ee('CP/URL')->make('design/group/edit/' . $row['group_name'] . '/' . $row['group_id']),
+                        'title' => lang('edit')
+                    ),
+                    'remove' => array(
+                        'href' => '#',
+                        'class' => 'm-link',
+                        'data-confirm' => lang('template_group') . ': <b>' . $row['group_name'] . '</b>, ID: <b>' . $row['group_id'] . '</b>',
+                        'data-group_id' => $row['group_id'],
+                        'title' => lang('remove'),
+                        'rel' => 'modal-confirm-delete-template-group'
+                    )
+                );
+                $column = [
+                    $row['group_id'],
+                    $row['group_name'],
+                    ['toolbar_items' => $toolbar]
+                ];
+                $data[] = [
+                    'attrs' => [],
+                    'columns' => $column
+                ];
+            }
+        }
+
+        $table->setData($data);
+
+        $vars['form_url'] = ee('CP/URL')->make('design/group/remove');
+
+        $base_url = ee('CP/URL', 'utilities/debug-tools/duplicate-template-groups');
+        $vars['table'] = $table->viewData($base_url);
+
+        ee()->cp->add_js_script(array(
+            'file' => array(
+                'cp/confirm_remove',
+                'cp/design/manager'
+            ),
+        ));
+
+        ee()->javascript->output("
+        $(document).ready(function () {
+            $('[rel=modal-confirm-delete-template-group]').click(function (e) {
+                var modalIs = '.' + $(this).attr('rel');
+        
+                $(modalIs + ' .checklist').html(''); // Reset it
+                $(modalIs + ' .checklist').append('<li>' + $(this).data('confirm') + '</li>');
+                $(modalIs + ' input[name=group_id]').val($(this).data('group_id'));
+        
+                e.preventDefault();
+            })
+        });
+        ");
+
+        ee()->view->cp_breadcrumbs = array(
+            ee('CP/URL')->make('utilities/debug-tools')->compile() => lang('debug_tools'),
+            '' => lang('debug_tools_debug_duplicate_template_groups')
+        );
+
+        return ee()->cp->render('utilities/debug-tools/duplicate_template_groups', $vars);
     }
 }
 // END CLASS

--- a/system/ee/ExpressionEngine/Controller/Utilities/DebugTools.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/DebugTools.php
@@ -196,6 +196,14 @@ class DebugTools extends Utilities
 
         $table->setData($data);
 
+        if (!empty($data)) {
+            ee('CP/Alert')
+                ->makeInline()
+                ->addToBody(lang('back_up_db_and_templates'))
+                ->asImportant()
+                ->now();
+        }
+
         $vars['form_url'] = ee('CP/URL')->make('design/group/remove');
 
         $base_url = ee('CP/URL', 'utilities/debug-tools/duplicate-template-groups');

--- a/system/ee/ExpressionEngine/Controller/Utilities/Utilities.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/Utilities.php
@@ -87,6 +87,7 @@ class Utilities extends CP_Controller
             $debug_tools = $sidebar->addHeader(lang('debug_tools'))
                 ->addBasicList();
             $debug_tools->addItem(lang('debug_tools_overview'), ee('CP/URL')->make('utilities/debug-tools'));
+            $debug_tools->addItem(lang('debug_tools_debug_duplicate_template_groups'), ee('CP/URL')->make('utilities/debug-tools/duplicate-template-groups'));
             $debug_tools->addItem(lang('debug_tools_debug_tags'), ee('CP/URL')->make('utilities/debug-tools/debug-tags'));
             $debug_tools->addItem(lang('debug_tools_fieldtypes'), ee('CP/URL')->make('utilities/debug-tools/debug-fieldtypes'));
         }

--- a/system/ee/ExpressionEngine/Library/Advisor/Advisor.php
+++ b/system/ee/ExpressionEngine/Library/Advisor/Advisor.php
@@ -32,6 +32,10 @@ class Advisor
         if ($bad_tags_count > 0) {
             $messages[] = sprintf(lang('debug_tools_broken_tags_found'), $bad_tags_count);
         }
+        $duplicate_template_groups_count = $templateAdvisor->getDuplicateTemplateGroupsCount();
+        if ($duplicate_template_groups_count > 0) {
+            $messages[] = sprintf(lang('duplicate_template_groups_found'), $duplicate_template_groups_count);
+        }
 
         $ftAdvisor = new \ExpressionEngine\Library\Advisor\FieldtypeAdvisor();
         $missing_fieldtype_count = $ftAdvisor->getMissingFieldtypeCount();

--- a/system/ee/ExpressionEngine/Library/Advisor/TemplateAdvisor.php
+++ b/system/ee/ExpressionEngine/Library/Advisor/TemplateAdvisor.php
@@ -100,6 +100,45 @@ class TemplateAdvisor
 
         return $tags;
     }
+
+    public function getDuplicateTemplateGroupsCount()
+    {
+        $duplicatesCheckQuery = ee()->db
+            ->select('group_name')
+            ->from('template_groups')
+            ->where('site_id', ee()->config->item('site_id'))
+            ->group_by('group_name, site_id')
+            ->having('COUNT(group_name) > 1')
+            ->get();
+        return $duplicatesCheckQuery->num_rows();
+    }
+
+    public function getDuplicateTemplateGroups()
+    {
+        $duplicatesCheckQuery = ee()->db
+            ->select('group_name')
+            ->from('template_groups')
+            ->where('site_id', ee()->config->item('site_id'))
+            ->group_by('group_name, site_id')
+            ->having('COUNT(group_name) > 1')
+            ->get();
+        if ($duplicatesCheckQuery->num_rows() > 0) {
+            $duplicateGroupNames = array_map(function ($row) {
+                return $row['group_name'];
+            }, $duplicatesCheckQuery->result_array());
+            // get the duplicate groups
+            $duplicatesQuery = ee()->db
+                ->select('group_name, group_id')
+                ->from('template_groups')
+                ->where('site_id', ee()->config->item('site_id'))
+                ->where_in('group_name', $duplicateGroupNames)
+                ->order_by('group_name', 'asc')
+                ->order_by('group_id', 'asc')
+                ->get();
+            return $duplicatesQuery->result_array();
+        }
+        return array();
+    }
 }
 
 // EOF

--- a/system/ee/ExpressionEngine/Service/JumpMenu/JumpMenu.php
+++ b/system/ee/ExpressionEngine/Service/JumpMenu/JumpMenu.php
@@ -1811,6 +1811,14 @@ class JumpMenu extends AbstractJumpMenu
                 'target' => 'utilities/debug-tools/debug-fieldtypes',
                 'permission' => 'is_super_admin'
             ),
+            'systemUtilitiesDebugDuplicateTemplateGroups' => array(
+                'icon' => 'fa-hammer',
+                'command' => 'system_utilities debug_tools_debug_duplicate_template_groups',
+                'dynamic' => false,
+                'addon' => false,
+                'target' => 'utilities/debug-tools/duplicate-template-groups',
+                'permission' => 'is_super_admin'
+            ),
             'systemUtilitiesFileConverter' => array(
                 'icon' => 'fa-hammer',
                 'command' => 'system_utilities member_tools import_converter',

--- a/system/ee/ExpressionEngine/View/utilities/debug-tools/duplicate_template_groups.php
+++ b/system/ee/ExpressionEngine/View/utilities/debug-tools/duplicate_template_groups.php
@@ -9,6 +9,7 @@
     </div>
 
     <div class="panel-body">
+        <div class="app-notice-wrap"><?=ee('CP/Alert')->getAllInlines()?></div>
         <?php $this->embed('_shared/table', $table); ?>
     </div>
 

--- a/system/ee/ExpressionEngine/View/utilities/debug-tools/duplicate_template_groups.php
+++ b/system/ee/ExpressionEngine/View/utilities/debug-tools/duplicate_template_groups.php
@@ -10,7 +10,6 @@
 
     <div class="panel-body">
         <?php $this->embed('_shared/table', $table); ?>
-        <?=$pagination?>
     </div>
 
 </div>

--- a/system/ee/ExpressionEngine/View/utilities/debug-tools/duplicate_template_groups.php
+++ b/system/ee/ExpressionEngine/View/utilities/debug-tools/duplicate_template_groups.php
@@ -1,0 +1,32 @@
+<?php $this->extend('_templates/default-nav', array(), 'outer_box'); ?>
+
+<div class="panel">
+
+    <div class="panel-heading">
+        <div class="title-bar">
+            <h3 class="title-bar__title"><?php echo isset($cp_heading) ? $cp_heading : $cp_page_title?></h3>
+        </div>
+    </div>
+
+    <div class="panel-body">
+        <?php $this->embed('_shared/table', $table); ?>
+        <?=$pagination?>
+    </div>
+
+</div>
+
+
+<?php
+$modal_vars = array(
+    'name' => 'modal-confirm-delete-template-group',
+    'form_url' => $form_url,
+    'hidden' => array(
+        'bulk_action' => 'remove',
+        'return' => 'utilities/debug-tools/duplicate-template-groups',
+        'group_id' => ''
+    )
+);
+
+$modal = $this->make('ee:_shared/modal_confirm_delete')->render($modal_vars);
+ee('CP/Modal')->addModal('delete-template-group', $modal);
+?>

--- a/system/ee/ExpressionEngine/View/utilities/debug-tools/index.php
+++ b/system/ee/ExpressionEngine/View/utilities/debug-tools/index.php
@@ -12,25 +12,40 @@
 
     <?php
         $alerts = [];
-        $alerts[0] = ee('CP/Alert')
+
+        $alert = ee('CP/Alert')
+            ->makeInline()
+            ->withTitle(lang('debug_tools_debug_duplicate_template_groups'));
+        if ($duplicate_template_groups_count > 0) {
+            $alert->addToBody(sprintf(lang('duplicate_template_groups_found'), $duplicate_template_groups_count) . '<br><a href="' . ee('CP/URL')->make('utilities/debug-tools/duplicate-template-groups') . '">' . lang('review_duplicate_template_groups') . '</a>');
+            $alert->asImportant();
+        } else {
+            $alert->addToBody(lang('no_duplicate_template_groups_found'));
+            $alert->asSuccess();
+        }
+        $alerts[] = $alert;
+
+        $alert = ee('CP/Alert')
             ->makeInline()
             ->withTitle(lang('debug_tools_debug_tags'))
             ->addToBody(sprintf(lang('debug_tools_broken_tags_found'), $bad_tags_count) . '<br><a href="' . ee('CP/URL')->make('utilities/debug-tools/debug-tags') . '">' . lang('debug_tools_debug_tags') . '</a>');
         if ($bad_tags_count == 0) {
-            $alerts[0]->asSuccess();
+            $alert->asSuccess();
         } else {
-            $alerts[0]->asImportant();
+            $alert->asImportant();
         }
+        $alerts[] = $alert;
 
-        $alerts[1] = ee('CP/Alert')
+        $alert = ee('CP/Alert')
             ->makeInline()
             ->withTitle(lang('debug_tools_fieldtypes'))
             ->addToBody(sprintf(lang('debug_tools_found_missing_fieldtypes'), $missing_fieldtype_count) . '<br><a href="' . ee('CP/URL')->make('utilities/debug-tools/debug-fieldtypes') . '">' . lang('debug_tools_show_missing_fieldtypes') . '</a>');
         if ($missing_fieldtype_count == 0) {
-            $alerts[1]->asSuccess();
+            $alert->asSuccess();
         } else {
-            $alerts[1]->asImportant();
+            $alert->asImportant();
         }
+        $alerts[] = $alert;
 
         foreach ($alerts as $alert) {
             $alert->cannotClose();

--- a/system/ee/installer/updates/ud_7_03_08.php
+++ b/system/ee/installer/updates/ud_7_03_08.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Updater\Version_7_3_8;
+
+/**
+ * Update
+ */
+class Updater
+{
+    public $version_suffix = '';
+
+    /**
+     * Do Update
+     *
+     * @return TRUE
+     */
+    public function do_update()
+    {
+        return true;
+    }
+}
+
+// EOF

--- a/system/ee/language/english/utilities_lang.php
+++ b/system/ee/language/english/utilities_lang.php
@@ -640,6 +640,8 @@ Once you are ready to experience the new File Manager features, please run the <
 
     'review_duplicate_template_groups' => 'Review duplicate template groups',
 
+    'back_up_db_and_templates' => 'Make sure you have back up of your database and templates before making any changes',
+
 );
 
 // EOF

--- a/system/ee/language/english/utilities_lang.php
+++ b/system/ee/language/english/utilities_lang.php
@@ -632,6 +632,14 @@ Once you are ready to experience the new File Manager features, please run the <
 
     'debug_tools_members' => 'Debug Members',
 
+    'debug_tools_debug_duplicate_template_groups' => 'Duplicate Template Groups',
+
+    'duplicate_template_groups_found' => 'We found %s duplicate template groups.',
+
+    'no_duplicate_template_groups_found' => 'No duplicate template groups found.',
+
+    'review_duplicate_template_groups' => 'Review duplicate template groups',
+
 );
 
 // EOF

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -4329,6 +4329,7 @@ class EE_Template
             $groups = ee('Model')->get('TemplateGroup')
                 ->with('Templates')
                 ->filter('site_id', ee()->config->item('site_id'))
+                ->order('group_id', 'desc') // sort reverse, so that older group IDs would be used
                 ->all();
         } catch (\Exception $e) {
             //if we got SQL error, silently exit


### PR DESCRIPTION
User guide: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/718

This PR is adding post-update check for duplicate template groups, as well as stand-alone utility to check and fix.

If duplicates are found, message is shown post-update, same as with other checks.

The Utility lists all duplicates and offers renaming and removing any of those - they can pick the earlier one or the later one.

I had to add support for group_id to some functions in template manager (edit and remove) so that we could address exactly the groups selected.

The template manager is listing only the earlier template groups (the ones that are used on front-end) - but also display banner if duplicates exist letting them know they need to use utility. It also adds record to developer log

Upon deleting, they are brought back to the list of duplicates; upon editing they are brought to template manager (this is not easy to change so I'd like to keep even if that's not ideal)

Partailly based on work in https://github.com/ExpressionEngine/ExpressionEngine/pull/3593