### PR TITLE
Resolved issue where JavaScript error could be shown when accessing add-on settings

### DIFF
--- a/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.es6
+++ b/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.es6
@@ -557,7 +557,7 @@ class DragAndDropUpload extends React.Component {
 
     var selectedDirectoryNotInList = false;
     if (this.state.directory != 'all') {
-      dir = this.state.directory;
+      var dir = this.state.directory;
       if (EE.dragAndDrop.uploadDesinations.length != 0) {
         selectedDirectoryNotInList = true;
         Object.values(EE.dragAndDrop.uploadDesinations).forEach(function (uploadDesination) {

--- a/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.js
+++ b/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.js
@@ -644,7 +644,7 @@ var DragAndDropUpload = /*#__PURE__*/function (_React$Component) {
       var selectedDirectoryNotInList = false;
 
       if (this.state.directory != 'all') {
-        dir = this.state.directory;
+        var dir = this.state.directory;
 
         if (EE.dragAndDrop.uploadDesinations.length != 0) {
           selectedDirectoryNotInList = true;


### PR DESCRIPTION
original issue:
![image](https://github.com/ExpressionEngine/ExpressionEngine/assets/23382425/06faba5e-47d1-439c-9b49-0ac9a0805e24)
Fix:
Added `var` before `dir` variable 