### PR TITLE
Resolved #3634 where having MSM-shared upload directory would cause Pages to be saved to wrong site

### DIFF
--- a/system/ee/legacy/models/file_upload_preferences_model.php
+++ b/system/ee/legacy/models/file_upload_preferences_model.php
@@ -114,7 +114,7 @@ class File_upload_preferences_model extends CI_Model
         $site_id = $upload_destination['site_id'];
         $overrides = array();
 
-        if ($site_id != ee()->config->item('site_id')) {
+        if ($site_id != 0 && $site_id != ee()->config->item('site_id')) {
             $overrides = ee()->config->get_cached_site_prefs($site_id);
         }
 


### PR DESCRIPTION
Resolved #3634 where having MSM-shared upload directory would cause Pages to be saved to wrong site