### PR TITLE
Resolved #3639 where is was not possible to save loaded revision with removed Grid rows

### DIFF
--- a/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
@@ -250,14 +250,21 @@ class Grid_lib
         }
 
         if (isset($data['rows'])) {
+            $total_rows = count($data['rows']);
             foreach ($data['rows'] as $key => $row) {
                 if (substr($key, 0, 6) == 'row_id') {
                     $row_key = str_replace('row_id_', '', $key);
 
                     if (! in_array($row_key, $valid_rows)) {
-                        if (ee('Permission')->isSuperAdmin()) {
-                            return array('value' => '', 'error' => lang('not_authorized'));
+                        if (ee('Request')->get('version')) {
+                            //if we have loaded version, restore the fields that are missing
+                            $keys = array_keys($data['rows']);
+                            $values = array_values($data['rows']);
+                            $index = array_search($key, $keys);
+                            $keys[$index] = 'new_row_' . $total_rows + (int) $row_key;
+                            $data['rows'] = array_combine($keys, $values);
                         } else {
+                            // otherwise assume someone else removed the row, and they know what they are doing
                             unset($data['rows'][$key]);
                         }
                     }

--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -176,7 +176,7 @@ abstract class AbstractPublish extends CP_Controller
                     'toolbar_items' => array(
                         'txt-only' => array(
                             'href' => ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id, array('version' => $version->version_id)),
-                            'title' => lang('view'),
+                            'title' => lang('load_revision'),
                             'content' => lang('view')
                         ),
                     )
@@ -215,7 +215,7 @@ abstract class AbstractPublish extends CP_Controller
                         $current_id,
                         $edit_date,
                         $current_author_id,
-                        '<span class="st-open">' . lang('current') . '</span>'
+                        '<a href="' . ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id) . '"><span class="st-open">' . lang('current') . '</span></a>'
                     ))
             );
         }
@@ -467,7 +467,7 @@ abstract class AbstractPublish extends CP_Controller
             ->defer();
 
         $qs = $_GET;
-        unset($qs['S'], $qs['D'], $qs['C'], $qs['M']);
+        unset($qs['S'], $qs['D'], $qs['C'], $qs['M'], $qs['version']);
 
         // Loop through and clean GET values
         foreach ($qs as $key => $value) {


### PR DESCRIPTION
Resolved #3639 where is was not possible to save loaded revision with removed Grid rows

I think it does not quite make sense to sinlently remove Grid rows if the revision was loaded with those rows - so the goal probably was to restore those.

This PR is also making slight change to revisions UI - we previouly kept displaying "you are viewing a revision..." banner even after saving - which wasn't true; and the button to load the current version when you're on revision wasn't active. 