### PR TITLE
Added display of seconds for revisions and autosaves; #3644

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -189,7 +189,7 @@ abstract class AbstractPublish extends CP_Controller
                 'attrs' => $attrs,
                 'columns' => array(
                     $i,
-                    ee()->localize->human_time($version->version_date->format('U')),
+                    ee()->localize->human_time($version->version_date->format('U'), true, true),
                     $authors[$version->author_id],
                     $toolbar
                 )
@@ -204,7 +204,7 @@ abstract class AbstractPublish extends CP_Controller
 
             // Current
             $edit_date = ($entry->edit_date)
-                ? ee()->localize->human_time($entry->edit_date->format('U'))
+                ? ee()->localize->human_time($entry->edit_date->format('U'), true, true)
                 : null;
 
             array_unshift(
@@ -267,7 +267,7 @@ abstract class AbstractPublish extends CP_Controller
 
             // Current
             $edit_date = ($entry->edit_date)
-                ? ee()->localize->human_time($entry->edit_date->format('U'))
+                ? ee()->localize->human_time($entry->edit_date->format('U'), true, true)
                 : null;
 
             $data[] = array(
@@ -311,7 +311,7 @@ abstract class AbstractPublish extends CP_Controller
                 'attrs' => $attrs,
                 'columns' => array(
                     $i,
-                    ee()->localize->human_time($autosave->edit_date),
+                    ee()->localize->human_time($autosave->edit_date, true, true),
                     isset($authors[$autosave->author_id]) ? $authors[$autosave->author_id] : '-',
                     $toolbar
                 )
@@ -459,7 +459,7 @@ abstract class AbstractPublish extends CP_Controller
             ? ee('CP/Alert')->makeStandard()
             : ee('CP/Alert')->makeInline('entry-form');
 
-        $lang_string = sprintf(lang($action . '_entry_success_desc'), htmlentities($edit_entry_url, ENT_QUOTES, 'UTF-8'), htmlentities($entry->title, ENT_QUOTES, 'UTF-8'), ee()->localize->human_time($entry->edit_date));
+        $lang_string = sprintf(lang($action . '_entry_success_desc'), htmlentities($edit_entry_url, ENT_QUOTES, 'UTF-8'), htmlentities($entry->title, ENT_QUOTES, 'UTF-8'), ee()->localize->human_time($entry->edit_date), true, true);
 
         $alert->asSuccess()
             ->withTitle(lang($action . '_entry_success'))

--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -459,7 +459,7 @@ abstract class AbstractPublish extends CP_Controller
             ? ee('CP/Alert')->makeStandard()
             : ee('CP/Alert')->makeInline('entry-form');
 
-        $lang_string = sprintf(lang($action . '_entry_success_desc'), htmlentities($edit_entry_url, ENT_QUOTES, 'UTF-8'), htmlentities($entry->title, ENT_QUOTES, 'UTF-8'), ee()->localize->human_time($entry->edit_date), true, true);
+        $lang_string = sprintf(lang($action . '_entry_success_desc'), htmlentities($edit_entry_url, ENT_QUOTES, 'UTF-8'), htmlentities($entry->title, ENT_QUOTES, 'UTF-8'), ee()->localize->human_time($entry->edit_date, true, true));
 
         $alert->asSuccess()
             ->withTitle(lang($action . '_entry_success'))

--- a/system/ee/ExpressionEngine/View/publish/partials/revision_badge.php
+++ b/system/ee/ExpressionEngine/View/publish/partials/revision_badge.php
@@ -1,3 +1,3 @@
 <span class="app-badge ml-s button-group-xsmall">
-    <span class="txt-only button button--default"><b><?=sprintf(lang('version_no'), $number)?></b> (<?=ee()->localize->human_time($version_date->format('U'))?>)</span>
+    <span class="txt-only button button--default"><b><?=sprintf(lang('version_no'), $number)?></b> (<?=ee()->localize->human_time($version_date->format('U'), true, true)?>)</span>
 </span>


### PR DESCRIPTION
Resolves https://github.com/ExpressionEngine/ExpressionEngine/discussions/3644

Save alert:
<img width="775" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/536cfcac-7c84-4dd3-92b0-aee570c09e9e">

Revisions table:
<img width="1076" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/279d6be2-8272-4787-aa86-ea7e71526b78">

Revision badge:
<img width="612" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/7832b0ee-dc32-469e-ba7c-35750261b83d">

Autosave table:
<img width="991" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/6b9fb350-59cd-4c24-bb49-2af06e6a9629">
