### PR TITLE
Added display of seconds for revisions and autosaves; #3644

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -187,7 +187,7 @@ abstract class AbstractPublish extends CP_Controller
                 'attrs' => $attrs,
                 'columns' => array(
                     $i,
-                    ee()->localize->human_time($version->version_date->format('U')),
+                    ee()->localize->human_time($version->version_date->format('U'), true, true),
                     $authors[$version->author_id],
                     $toolbar
                 )
@@ -202,7 +202,7 @@ abstract class AbstractPublish extends CP_Controller
 
             // Current
             $edit_date = ($entry->edit_date)
-                ? ee()->localize->human_time($entry->edit_date->format('U'))
+                ? ee()->localize->human_time($entry->edit_date->format('U'), true, true)
                 : null;
 
             array_unshift(
@@ -265,7 +265,7 @@ abstract class AbstractPublish extends CP_Controller
 
             // Current
             $edit_date = ($entry->edit_date)
-                ? ee()->localize->human_time($entry->edit_date->format('U'))
+                ? ee()->localize->human_time($entry->edit_date->format('U'), true, true)
                 : null;
 
             $data[] = array(
@@ -309,7 +309,7 @@ abstract class AbstractPublish extends CP_Controller
                 'attrs' => $attrs,
                 'columns' => array(
                     $i,
-                    ee()->localize->human_time($autosave->edit_date),
+                    ee()->localize->human_time($autosave->edit_date, true, true),
                     isset($authors[$autosave->author_id]) ? $authors[$autosave->author_id] : '-',
                     $toolbar
                 )

--- a/system/ee/ExpressionEngine/View/publish/partials/revision_badge.php
+++ b/system/ee/ExpressionEngine/View/publish/partials/revision_badge.php
@@ -1,3 +1,3 @@
 <span class="app-badge ml-s button-group-xsmall">
-    <span class="txt-only button button--default"><b><?=sprintf(lang('version_no'), $number)?></b> (<?=ee()->localize->human_time($version_date->format('U'))?>)</span>
+    <span class="txt-only button button--default"><b><?=sprintf(lang('version_no'), $number)?></b> (<?=ee()->localize->human_time($version_date->format('U'), true, true)?>)</span>
 </span>


### PR DESCRIPTION
Resolves https://github.com/ExpressionEngine/ExpressionEngine/discussions/3644

Revisions table:
<img width="1076" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/279d6be2-8272-4787-aa86-ea7e71526b78">

Revision badge:
<img width="612" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/7832b0ee-dc32-469e-ba7c-35750261b83d">

Autosave table:
<img width="991" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/6b9fb350-59cd-4c24-bb49-2af06e6a9629">
