### PR TITLE
Resolved issue where navigating subfolders in File Manager did not retain filers and sorting

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Files/Files.php
+++ b/system/ee/ExpressionEngine/Controller/Files/Files.php
@@ -14,7 +14,6 @@ use ZipArchive;
 use ExpressionEngine\Controller\Files\AbstractFiles as AbstractFilesController;
 use ExpressionEngine\Service\Validation\Result as ValidationResult;
 use ExpressionEngine\Library\CP\Table;
-
 use ExpressionEngine\Library\Data\Collection;
 use ExpressionEngine\Model\File\UploadDestination;
 use ExpressionEngine\Service\File\ViewType;
@@ -138,7 +137,7 @@ class Files extends AbstractFilesController
             // Generate the contents of the new folder modal
             $newFolderModal = ee('View')->make('files/modals/folder')->render([
                 'name' => 'modal-new-folder',
-                'form_url'=> ee('CP/URL')->make('files/createSubdirectory')->compile(),
+                'form_url' => ee('CP/URL')->make('files/createSubdirectory')->compile(),
                 'choices' => $headerVars['uploadLocationsAndDirectoriesDropdownChoices'],
                 'selected' => $id . '.' . (int) ee('Request')->get('directory_id'),
             ]);
@@ -371,7 +370,7 @@ class Files extends AbstractFilesController
 
         if ($files->count() == 1) {
             foreach ($files as $file) {
-                $edit_url = ee('CP/URL')->make('files/file/view/' . $file->file_id.'#tab=t-usage');
+                $edit_url = ee('CP/URL')->make('files/file/view/' . $file->file_id . '#tab=t-usage');
             }
         }
 
@@ -643,7 +642,6 @@ class Files extends AbstractFilesController
         $names = array();
         $errors = array();
         foreach ($files as $file) {
-
             //are they not in target place already?
             if ($file->upload_location_id == $upload_destination_id && $file->directory_id == $subdirectory_id) {
                 $errors[$file->file_name] = lang('error_moving_already_there');
@@ -671,19 +669,19 @@ class Files extends AbstractFilesController
             $targetFilesystem = ($file->UploadDestination->id == $targetUploadLocation->id) ? null : $targetUploadLocation->getFilesystem();
             $success = $file->UploadDestination->getFilesystem()->move(
                 $file->getAbsolutePath(),
-                rtrim($targetPath,'\\/') . '/' . $file->file_name,
+                rtrim($targetPath, '\\/') . '/' . $file->file_name,
                 $targetFilesystem
             );
 
             if ($success) {
                 // Update files within a directory if it is changing upload locations
-                if($file->isDirectory() && !is_null($targetFilesystem) && $childIds = $file->getChildIds()) {
+                if ($file->isDirectory() && !is_null($targetFilesystem) && $childIds = $file->getChildIds()) {
                     ee()->db->where_in('file_id', $childIds);
                     ee()->db->update('files', ['upload_location_id' => $targetUploadLocation->id]);
                 }
 
                 // Cleanup any generated files in previous location before updating the location
-                if(!$file->isDirectory()) {
+                if (!$file->isDirectory()) {
                     $file->deleteGeneratedFiles();
                 }
 

--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Columns/Thumbnail.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Columns/Thumbnail.php
@@ -31,14 +31,14 @@ class Thumbnail extends EntryManager\Columns\Column
         ];
     }
 
-    public function renderTableCell($data, $field_id, $file, $viewtype = 'list')
+    public function renderTableCell($data, $field_id, $file, $viewtype = 'list', $pickerMode = false, $addQueryString = [])
     {
         $thumb = ee('Thumbnail')->get($file);
         $file_thumbnail = $thumb->tag;
 
         if ($viewtype == 'list') {
             if ($file->isDirectory()) {
-                $url = ee('CP/URL')->make('files/directory/' . $file->upload_location_id, ['directory_id' => $file->file_id]);
+                $url = ee('CP/URL')->make('files/directory/' . $file->upload_location_id, array_merge($addQueryString, ['directory_id' => $file->file_id]));
                 $file_thumbnail = '<a href="' . $url . '">' . $thumb->tag . '</a>';
             } elseif (ee('Permission')->can('edit_files')) {
                 $file_thumbnail = '<a href="' . ee('CP/URL')->make('files/file/view/' . $file->file_id) . ($file->isImage() ? '" class="imgpreview" data-url="' . $thumb->url : '') . '">' . $thumb->tag . '</a>'; 

--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Columns/Title.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Columns/Title.php
@@ -23,7 +23,7 @@ class Title extends EntryManager\Columns\Title
 
         if ($viewtype == 'list') {
             if ($file->isDirectory()) {
-                $url = ee('CP/URL')->make('files/directory/' . $file->upload_location_id, ['directory_id' => $file->file_id]);
+                $url = ee('CP/URL')->make('files/directory/' . $file->upload_location_id, array_merge($addQueryString, ['directory_id' => $file->file_id]));
                 $title = '<a href="' . $url . '">' . $title . '</a>';
             } elseif (ee('Permission')->can('edit_files')) {
                 $title = '<a href="' . ee('CP/URL')->make('files/file/view/' . $file->file_id) . '">' . $title . '</a>';

--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
@@ -156,7 +156,7 @@ trait FileManagerTrait
         $total_files = $files->count();
         $vars['total_files'] = $total_files;
 
-        $filters->add('Perpage', $total_files, 'show_all_files');
+        $perpageFilter = $filters->add('Perpage', $total_files, 'show_all_files');
 
         $filter_values = $filters->values();
 
@@ -171,6 +171,9 @@ trait FileManagerTrait
             },
             ARRAY_FILTER_USE_KEY
         );
+        if (! $perpageFilter->canReset()) {
+            unset($queryStringVariables['perpage']);
+        }
 
         $table = ee('CP/Table', array(
             'sort_col' => 'date_added',


### PR DESCRIPTION
Old behavior:
If you change sorting order and then go into subfolder, it would fall back to default sortering order.
If you apply a filter and go into subfolder, it would show all results, not just filtered
If you change sorting or filters while being in subfolder, and then use breadcrumbs to go into parent folder, it would reset those to defaults again.

This PR is making sure those selections are kept when navigating

