### PR TITLE
Resolved #2666 where using Dynamic query caching caused pagination on Structure listing being inaccurate

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -117,7 +117,7 @@ class Channel
 
         $tag .= $this->fetch_dynamic_params();
 
-        return ee()->cache->get('/' . $this->_sql_cache_prefix . '/' . md5($tag . $this->uri));
+        return ee()->cache->get('/' . $this->_sql_cache_prefix . '/' . md5($tag . ee()->uri->uri_string()));
     }
 
     /**
@@ -128,7 +128,7 @@ class Channel
         $tag = ($identifier == '') ? ee()->TMPL->tagproper : ee()->TMPL->tagproper . $identifier;
 
         return ee()->cache->save(
-            '/' . $this->_sql_cache_prefix . '/' . md5($tag . $this->uri),
+            '/' . $this->_sql_cache_prefix . '/' . md5($tag . ee()->uri->uri_string()),
             $sql,
             0   // No TTL, cache lives on till cleared
         );

--- a/system/ee/ExpressionEngine/Addons/structure/ext.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/ext.structure.php
@@ -583,6 +583,7 @@ class Structure_ext
 
             if ($entry_id) {
                 $template_id = $this->site_pages['templates'][$entry_id];
+                ee()->uri->page_query_string = $entry_id;
 
                 // TODO:: I think we only need to select the template name and the group name.
                 // This could be a large speed increase -- Matt


### PR DESCRIPTION
The previous solution on this was to remove setting `ee()->uri->page_query_string` - however that did not work because when you both page and listing tags on same page, one would still not show proper results.

The solution here is more generic, use full page_uri as cache key instead of just query string, which would not include pagination