### PR TITLE
Resolved issue where it was not possible to save loaded revision if Fluid field has some fields deleted; Resolved #3639 where is was not possible to save loaded revision with removed Grid rows; Resolved #3529 where records for Grid and Relationship fields were still left in database after removing from Fluid

### DIFF
--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -353,6 +353,32 @@ class Fluid_field_ft extends EE_Fieldtype
 
     private function removeField($fluid_field)
     {
+        // some built-in fields are more complex, we have to do more clean-up
+        // third-party fields are expected to use extensions hook
+        switch ($fluid_field->ChannelField->field_type) {
+            case 'grid':
+            case 'file_grid':
+                ee()->load->add_package_path(PATH_ADDONS . 'grid');
+                ee()->load->library('grid_lib');
+                ee()->grid_lib->field_id = $fluid_field->field_id;
+                ee()->grid_lib->content_type = $this->content_type;
+                ee()->grid_lib->entry_id = $this->content_id;
+                ee()->grid_lib->fluid_field_data_id = $fluid_field->id;
+                ee()->grid_lib->save([]);
+                ee()->load->remove_package_path(PATH_ADDONS . 'grid');
+                break;
+            case 'relationship':
+                ee('db')
+                    ->where('parent_id', $this->content_id)
+                    ->where('field_id', $fluid_field->field_id)
+                    ->where('fluid_field_data_id', $fluid_field->id)
+                    ->where('grid_field_id', 0)
+                    ->delete('relationships');
+                break;
+            default:
+                break;
+        }
+
         $query = ee('db');
         $query->where('id', $fluid_field->field_data_id);
         $query->delete($fluid_field->ChannelField->getTableName());

--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -165,7 +165,7 @@ class Fluid_field_ft extends EE_Fieldtype
                     $field = $fluid_field_data[$id]->getField();
                     $fluid_field_data_id = $fluid_field_data[$id]->getId();
                 } elseif (ee('Request')->get('version')) {
-                    $key = 'new_field_' . $total_fields + (int) $id;
+                    $key = 'new_field_' . ($total_fields + (int) $id);
                 }
             }
             // New field
@@ -223,7 +223,7 @@ class Fluid_field_ft extends EE_Fieldtype
                     $this->updateField($fluid_field_data[$id], $i, $value);
                     unset($fluid_field_data[$id]);
                 } elseif (ee('Request')->get('version')) {
-                    $key = 'new_field_' . $total_fields + (int) $id;
+                    $key = 'new_field_' . ($total_fields + (int) $id);
                 }
             }
             // New field

--- a/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
@@ -298,8 +298,16 @@ class Grid_lib
      */
     public function save($data)
     {
+        if (ee('Request')->get('version')) {
+            if (isset($data['rows'])) {
+                // only need to do this once
+                $data['rows'] = ee()->grid_model->remap_revision_rows($data['rows'], $this->field_id, $this->entry_id, $this->fluid_field_data_id, $this->content_type);
+            }
+        }
         $field_data = $this->_process_field_data('save', $data);
 
+        // save the Grid field
+        // and get back the rows that are no longer present
         $deleted_rows = ee()->grid_model->save_field_data(
             $field_data['value'],
             $this->field_id,

--- a/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
@@ -261,7 +261,7 @@ class Grid_lib
                             $keys = array_keys($data['rows']);
                             $values = array_values($data['rows']);
                             $index = array_search($key, $keys);
-                            $keys[$index] = 'new_row_' . $total_rows + (int) $row_key;
+                            $keys[$index] = 'new_row_' . ($total_rows + (int) $row_key);
                             $data['rows'] = array_combine($keys, $values);
                         } else {
                             // otherwise assume someone else removed the row, and they know what they are doing

--- a/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
@@ -250,14 +250,21 @@ class Grid_lib
         }
 
         if (isset($data['rows'])) {
+            $total_rows = count($data['rows']);
             foreach ($data['rows'] as $key => $row) {
                 if (substr($key, 0, 6) == 'row_id') {
                     $row_key = str_replace('row_id_', '', $key);
 
                     if (! in_array($row_key, $valid_rows)) {
-                        if (ee('Permission')->isSuperAdmin()) {
-                            return array('value' => '', 'error' => lang('not_authorized'));
+                        if (ee('Request')->get('version')) {
+                            //if we have loaded version, restore the fields that are missing
+                            $keys = array_keys($data['rows']);
+                            $values = array_values($data['rows']);
+                            $index = array_search($key, $keys);
+                            $keys[$index] = 'new_row_' . $total_rows + (int) $row_key;
+                            $data['rows'] = array_combine($keys, $values);
                         } else {
+                            // otherwise assume someone else removed the row, and they know what they are doing
                             unset($data['rows'][$key]);
                         }
                     }

--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -174,7 +174,7 @@ abstract class AbstractPublish extends CP_Controller
                     'toolbar_items' => array(
                         'txt-only' => array(
                             'href' => ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id, array('version' => $version->version_id)),
-                            'title' => lang('view'),
+                            'title' => lang('load_revision'),
                             'content' => lang('view')
                         ),
                     )
@@ -213,7 +213,7 @@ abstract class AbstractPublish extends CP_Controller
                         $current_id,
                         $edit_date,
                         $current_author_id,
-                        '<span class="st-open">' . lang('current') . '</span>'
+                        '<a href="' . ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id) . '"><span class="st-open">' . lang('current') . '</span></a>'
                     ))
             );
         }

--- a/system/ee/legacy/fieldtypes/EE_Fieldtype.php
+++ b/system/ee/legacy/fieldtypes/EE_Fieldtype.php
@@ -21,6 +21,9 @@ abstract class EE_Fieldtype
     public $field_id;
     public $field_name;
 
+    public $row;
+    public $var_id;
+
     // EE super object
     // @deprecated - use ee()
     protected $EE;

--- a/system/ee/legacy/models/grid_model.php
+++ b/system/ee/legacy/models/grid_model.php
@@ -950,6 +950,46 @@ class Grid_model extends CI_Model
     }
 
     /**
+     * When revision has been loaded and then trying to save it,
+     * some keys might correspond to the rows that no longer exist
+     * Here we make then submitted as new rows instead
+     *
+     * @param array $rows
+     * @param integer $field_id
+     * @param integer $entry_id
+     * @param integer $fluid_field_data_id
+     * @param string $content_type
+     * @return array
+     */
+    public function remap_revision_rows($rows, $field_id, $entry_id, $fluid_field_data_id = 0, $content_type = 'channel')
+    {
+        // get IDs of rows that already exist
+        $existingRows = ee('db')
+            ->select('row_id')
+            ->from($this->_data_table($content_type, $field_id))
+            ->where('entry_id', $entry_id)
+            ->where('fluid_field_data_id', $fluid_field_data_id)
+            ->get();
+        $existingRowKeys = array();
+        if ($existingRows->num_rows() > 0) {
+            $existingRowKeys = array_map(function ($row) {
+                return 'row_id_' . $row['row_id'];
+            }, $existingRows->result_array());
+        }
+        $total_rows = count($rows);
+        $values = array_values($rows);
+        $keys = array_keys($rows);
+        $values = array_values($rows);
+        foreach ($keys as $index => $key) {
+            if (! in_array($key, $existingRowKeys)) {
+                $keys[$index] = 'new_row_' . ($total_rows + (int) str_replace('row_id_', '', $key));
+            }
+        }
+        $rows = array_combine($keys, $values);
+        return $rows;
+    }
+
+    /**
      * Update grid field(s) search values
      *
      * @param array $field_ids Array of field_ids


### PR DESCRIPTION
Resolved issue where it was not possible to save loaded revision if Fluid field has some fields deleted
Resolved #3639 where is was not possible to save loaded revision with removed Grid rows
Resolved #3529 where records for Grid and Relationship fields were still left in database after removing from Fluid