### PR TITLE
Resolved issue where it was not possible to save loaded revision if Fluid field has some fields deleted; Resolved #3639 where is was not possible to save loaded revision with removed Grid rows; Resolved #3529 where records for Grid and Relationship fields were still left in database after removing from Fluid

### DIFF
--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -604,6 +604,11 @@ class Fluid_field_ft extends EE_Fieldtype
                     $fluid_field_data_id = (int) str_replace('field_', '', $key);
                 }
 
+                // if we loaded older revision, it might be structured differently
+                if (ee('Request')->get('version') && strpos(array_key_first($field_data), 'field_group_id_') !== 0) {
+                    $field_data = ['field_group_id_0' => $field_data];
+                }
+
                 foreach ($field_data as $id => $datum) {
                     if (strpos($id, 'field_group_id_') === 0) {
                         $field_group_id = (int) str_replace('field_group_id_', '', $id);

--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -193,7 +193,7 @@ class Fluid_field_ft extends EE_Fieldtype
             if (strpos($key, 'field_') === 0) {
                 $fluid_field_id = (int) str_replace('field_', '', $key);
                 if (! isset($fluid_field_data[$fluid_field_id]) && ee('Request')->get('version')) {
-                    $key = 'new_field_' . $total_fields + $fluid_field_id;
+                    $key = 'new_field_' . ($total_fields + $fluid_field_id);
                 }
             }
             // New field - field_id_3[fields][new_field_1][field_group_1][field_id_2] = value
@@ -284,7 +284,7 @@ class Fluid_field_ft extends EE_Fieldtype
                     if (isset($fluid_field_data[$id])) {
                         $group_key = 'group_' . $fluid_field_data[$id]->group;
                     } elseif (ee('Request')->get('version')) {
-                        $key = 'new_field_' . $total_fields + (int) $id;
+                        $key = 'new_field_' . ($total_fields + (int) $id);
                     }
                 }
                 // New field

--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -175,6 +175,7 @@ class Fluid_field_ft extends EE_Fieldtype
 
         $compiled_data_for_search = [];
 
+        $total_fields = count($data['fields']);
         foreach ($data['fields'] as $key => $value) {
             if ($key == 'new_field_0') {
                 continue;
@@ -191,8 +192,12 @@ class Fluid_field_ft extends EE_Fieldtype
             // Existing field - field_id_3[fields][field_3][field_group_0][field_id_2] = value
             if (strpos($key, 'field_') === 0) {
                 $fluid_field_id = (int) str_replace('field_', '', $key);
+                if (! isset($fluid_field_data[$fluid_field_id]) && ee('Request')->get('version')) {
+                    $key = 'new_field_' . $total_fields + $fluid_field_id;
+                }
+            }
             // New field - field_id_3[fields][new_field_1][field_group_1][field_id_2] = value
-            } elseif (strpos($key, 'new_field_') === 0) {
+            if (strpos($key, 'new_field_') === 0) {
                 $create = true;
             }
 
@@ -250,6 +255,7 @@ class Fluid_field_ft extends EE_Fieldtype
 
         $i = 1;
         $g = 0;
+        $total_fields = count($data['fields']);
         // [field_3][field_group_0][field_id_2]
         // [new_field_1][field_group_1][field_id_2]
         foreach ($data['fields'] as $key => $value) {
@@ -275,9 +281,14 @@ class Fluid_field_ft extends EE_Fieldtype
                 // Existing field
                 if (strpos($key, 'field_') === 0 && (!defined('CLONING_MODE') || CLONING_MODE !== true)) {
                     $id = str_replace('field_', '', $key);
-                    $group_key = 'group_' . $fluid_field_data[$id]->group;
+                    if (isset($fluid_field_data[$id])) {
+                        $group_key = 'group_' . $fluid_field_data[$id]->group;
+                    } elseif (ee('Request')->get('version')) {
+                        $key = 'new_field_' . $total_fields + (int) $id;
+                    }
+                }
                 // New field
-                } elseif (strpos($key, 'new_field_') === 0 || (defined('CLONING_MODE') && CLONING_MODE === true)) {
+                if (strpos($key, 'new_field_') === 0 || (defined('CLONING_MODE') && CLONING_MODE === true)) {
                     $field_id = str_replace('field_id_', '', $fieldKey);
                 }
 

--- a/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
@@ -298,8 +298,16 @@ class Grid_lib
      */
     public function save($data)
     {
+        if (ee('Request')->get('version')) {
+            if (isset($data['rows'])) {
+                // only need to do this once
+                $data['rows'] = ee()->grid_model->remap_revision_rows($data['rows'], $this->field_id, $this->entry_id, $this->fluid_field_data_id, $this->content_type);
+            }
+        }
         $field_data = $this->_process_field_data('save', $data);
 
+        // save the Grid field
+        // and get back the rows that are no longer present
         $deleted_rows = ee()->grid_model->save_field_data(
             $field_data['value'],
             $this->field_id,

--- a/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
@@ -261,7 +261,7 @@ class Grid_lib
                             $keys = array_keys($data['rows']);
                             $values = array_values($data['rows']);
                             $index = array_search($key, $keys);
-                            $keys[$index] = 'new_row_' . $total_rows + (int) $row_key;
+                            $keys[$index] = 'new_row_' . ($total_rows + (int) $row_key);
                             $data['rows'] = array_combine($keys, $values);
                         } else {
                             // otherwise assume someone else removed the row, and they know what they are doing

--- a/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
@@ -250,14 +250,21 @@ class Grid_lib
         }
 
         if (isset($data['rows'])) {
+            $total_rows = count($data['rows']);
             foreach ($data['rows'] as $key => $row) {
                 if (substr($key, 0, 6) == 'row_id') {
                     $row_key = str_replace('row_id_', '', $key);
 
                     if (! in_array($row_key, $valid_rows)) {
-                        if (ee('Permission')->isSuperAdmin()) {
-                            return array('value' => '', 'error' => lang('not_authorized'));
+                        if (ee('Request')->get('version')) {
+                            //if we have loaded version, restore the fields that are missing
+                            $keys = array_keys($data['rows']);
+                            $values = array_values($data['rows']);
+                            $index = array_search($key, $keys);
+                            $keys[$index] = 'new_row_' . $total_rows + (int) $row_key;
+                            $data['rows'] = array_combine($keys, $values);
                         } else {
+                            // otherwise assume someone else removed the row, and they know what they are doing
                             unset($data['rows'][$key]);
                         }
                     }

--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -176,7 +176,7 @@ abstract class AbstractPublish extends CP_Controller
                     'toolbar_items' => array(
                         'txt-only' => array(
                             'href' => ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id, array('version' => $version->version_id)),
-                            'title' => lang('view'),
+                            'title' => lang('load_revision'),
                             'content' => lang('view')
                         ),
                     )
@@ -215,7 +215,7 @@ abstract class AbstractPublish extends CP_Controller
                         $current_id,
                         $edit_date,
                         $current_author_id,
-                        '<span class="st-open">' . lang('current') . '</span>'
+                        '<a href="' . ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id) . '"><span class="st-open">' . lang('current') . '</span></a>'
                     ))
             );
         }
@@ -467,7 +467,7 @@ abstract class AbstractPublish extends CP_Controller
             ->defer();
 
         $qs = $_GET;
-        unset($qs['S'], $qs['D'], $qs['C'], $qs['M']);
+        unset($qs['S'], $qs['D'], $qs['C'], $qs['M'], $qs['version']);
 
         // Loop through and clean GET values
         foreach ($qs as $key => $value) {

--- a/system/ee/legacy/models/grid_model.php
+++ b/system/ee/legacy/models/grid_model.php
@@ -950,6 +950,46 @@ class Grid_model extends CI_Model
     }
 
     /**
+     * When revision has been loaded and then trying to save it,
+     * some keys might correspond to the rows that no longer exist
+     * Here we make then submitted as new rows instead
+     *
+     * @param array $rows
+     * @param integer $field_id
+     * @param integer $entry_id
+     * @param integer $fluid_field_data_id
+     * @param string $content_type
+     * @return array
+     */
+    public function remap_revision_rows($rows, $field_id, $entry_id, $fluid_field_data_id = 0, $content_type = 'channel')
+    {
+        // get IDs of rows that already exist
+        $existingRows = ee('db')
+            ->select('row_id')
+            ->from($this->_data_table($content_type, $field_id))
+            ->where('entry_id', $entry_id)
+            ->where('fluid_field_data_id', $fluid_field_data_id)
+            ->get();
+        $existingRowKeys = array();
+        if ($existingRows->num_rows() > 0) {
+            $existingRowKeys = array_map(function ($row) {
+                return 'row_id_' . $row['row_id'];
+            }, $existingRows->result_array());
+        }
+        $total_rows = count($rows);
+        $values = array_values($rows);
+        $keys = array_keys($rows);
+        $values = array_values($rows);
+        foreach ($keys as $index => $key) {
+            if (! in_array($key, $existingRowKeys)) {
+                $keys[$index] = 'new_row_' . ($total_rows + (int) str_replace('row_id_', '', $key));
+            }
+        }
+        $rows = array_combine($keys, $values);
+        return $rows;
+    }
+
+    /**
      * Update grid field(s) search values
      *
      * @param array $field_ids Array of field_ids


### PR DESCRIPTION
Resolved issue where it was not possible to save loaded revision if Fluid field has some fields deleted;
Resolved #3639 where is was not possible to save loaded revision with removed Grid rows;
Resolved #3529 where records for Grid and Relationship fields were still left in database after removing from Fluid