### PR TITLE
Change PHP variable name to avoid out-of-scope reassignment (EE 7)

### DIFF
--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -237,8 +237,8 @@ class EE_Template
         // Record the New Relic transaction. Use a constant so that separate instances of this
         // class can't accidentally restart the transaction metrics
         if (!defined('EECMS_NEW_RELIC_TRANS_NAME')) {
-            $template = $this->templates_loaded[0];
-            define('EECMS_NEW_RELIC_TRANS_NAME', "{$template['group_name']}/{$template['template_name']}");
+            $templateLoaded = $this->templates_loaded[0];
+            define('EECMS_NEW_RELIC_TRANS_NAME', "{$templateLoaded['group_name']}/{$templateLoaded['template_name']}");
             ee()->core->set_newrelic_transaction(EECMS_NEW_RELIC_TRANS_NAME);
         }
 


### PR DESCRIPTION
One of the parameters to `fetch_and_parse()` is `$template`. When defining `EECMS_NEW_RELIC_TRANS_NAME` in this function, `$template` is being reassigned, presumably unintentionally: `$template = $this->templates_loaded[0];` because the next line just uses this variable again to define the constant: `define('EECMS_NEW_RELIC_TRANS_NAME', "{$template['group_name']}/{$template['template_name']}");`.

`$template` is also used further down in the function, but it might have been overwritten by `$this->templates_loaded[0];` at this point:

```
$currentTemplateInfo = array(
    'template_name' => $template,
    'template_group' => $template_group,
);
```

This code change just renames the variable inside of the conditional to avoid potentially reassigning the `$template` variable in the scope of the function.