### PR TITLE
Stopped thecodingmachine namespace conflict with coilpack

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro/Service/Mfa/Mfa.php
+++ b/system/ee/ExpressionEngine/Addons/pro/Service/Mfa/Mfa.php
@@ -29,21 +29,27 @@ class Mfa
      */
     private function _init()
     {
-        \ExpressionEngine\Core\Autoloader::getInstance()
+        $autoloader = \ExpressionEngine\Core\Autoloader::getInstance()
             ->addPrefix('OTPHP', SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib/spomky-labs/otphp')
             ->addPrefix('ParagonIE\ConstantTime', SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib/paragonie/constant_time_encoding')
             ->addPrefix('BaconQrCode', SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib/bacon/bacon-qr-code')
             ->addPrefix('DASPRiD\Enum', SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib/dasprid/enum')
-            ->addPrefix('Assert', SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib/beberlei/assert/lib/Assert')
-            ->addPrefix('Safe', SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib/thecodingmachine/safe/generated')
-            ->addPrefix('Safe', SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib/thecodingmachine/safe/lib')
-            ->register();
+            ->addPrefix('Assert', SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib/beberlei/assert/lib/Assert');
 
-        $extraFiles = [
-            '/thecodingmachine/safe/generated/strings.php',
-            '/thecodingmachine/safe/generated/array.php',
-            '/thecodingmachine/safe/generated/url.php',
-        ];
+        $extraFiles = [];
+        if (!class_exists('Expressionengine\Coilpack\Coilpack')) {
+            $autoloader
+                ->addPrefix('Safe', SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib/thecodingmachine/safe/generated')
+                ->addPrefix('Safe', SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib/thecodingmachine/safe/lib');
+
+            $extraFiles = [
+                '/thecodingmachine/safe/generated/strings.php',
+                '/thecodingmachine/safe/generated/array.php',
+                '/thecodingmachine/safe/generated/url.php',
+            ];
+        }
+        $autoloader->register();
+
         foreach ($extraFiles as $file) {
             include_once(SYSPATH . 'ee/ExpressionEngine/Addons/pro/lib' . $file);
         }


### PR DESCRIPTION
Whilst working on EE under Laravel coilpack I found a namespace conflict when using EE multi factor authentication. The error occurs with the endpoint rendering the QR code, **/admin.php?/cp/members/profile/pro/mfa/qrCode&code=[code string]**.

![image](https://github.com/ExpressionEngine/ExpressionEngine/assets/14264007/935e028b-10d5-4505-965e-2ffab309f7dc)
When accessing the QR code URL directly.
![image](https://github.com/ExpressionEngine/ExpressionEngine/assets/14264007/c7c95600-9116-4899-8318-2a9a06ce4ff2)

As **[thecodingmachine/safe](https://github.com/thecodingmachine/safe)** is installed as an indirect dependency of Coilpack, EE Mfa.php attempts to include these files causing the conflict.
[https://github.com/ExpressionEngine/Coilpack/blob/4c497643372a8d38db746dc89113ef23431b4fcf/composer.lock#L591C37-L591C37](https://github.com/ExpressionEngine/Coilpack/blob/4c497643372a8d38db746dc89113ef23431b4fcf/composer.lock#L591C37-L591C37)
[https://github.com/ExpressionEngine/Coilpack/blob/4c497643372a8d38db746dc89113ef23431b4fcf/composer.lock#L591C37-L591C37](https://github.com/ExpressionEngine/Coilpack/blob/4c497643372a8d38db746dc89113ef23431b4fcf/composer.lock#L2090C27-L2090C27)

I have added a simple check to EE MFA to see if Coilpack is installed, if so do not include the **thecodingmachine** files in the [pro add-on lib folder](https://github.com/ExpressionEngine/ExpressionEngine/tree/7.dev/system/ee/ExpressionEngine/Addons/pro/lib).

Laravel version 9.52.13
Coilpack version 1.1.2
EE 7.3.8

As I am new to both EE and Coilpack, please let me know if there is another official way to stop this namespace conflict.