### PR TITLE
Added 2 Structure settings to customize Pages UI

### DIFF
--- a/system/ee/ExpressionEngine/Addons/structure/addon.json
+++ b/system/ee/ExpressionEngine/Addons/structure/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Structure",
     "shortname": "structure",
-    "version": "6.0.0",
+    "version": "6.1.0",
     "description": "Create pages, generate navigation, manage content through a simple interface and build robust sites faster than ever.",
     "license": "ExpressionEngine",
     "namespace": "ExpressionEngine\\Structure",

--- a/system/ee/ExpressionEngine/Addons/structure/mcp.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/mcp.structure.php
@@ -78,7 +78,7 @@ class Structure_mcp
 
         ee()->load->library('general_helper');
 
-        ee()->cp->add_to_head("<link rel='stylesheet' href='" . $this->sql->theme_url() . "css/structure.css'>");
+        ee()->cp->add_to_head("<link rel='stylesheet' href='" . $this->sql->theme_url() . "css/structure.css?v=".STRUCTURE_VERSION."'>");
     }
 
     /**

--- a/system/ee/ExpressionEngine/Addons/structure/mcp.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/mcp.structure.php
@@ -752,6 +752,8 @@ class Structure_mcp
             'redirect_on_login'     => 'n',
             'redirect_on_publish'   => 'n',
             'hide_hidden_templates' => 'n',
+            'show_nav_status'       => 'y',
+            'show_entry_status'     => 'n',
             'add_trailing_slash' => 'y'
         );
 

--- a/system/ee/ExpressionEngine/Addons/structure/mcp.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/mcp.structure.php
@@ -150,6 +150,14 @@ class Structure_mcp
         $data['homepage'] = array_search('/', $site_pages['uris']);
         $data['selected_tab'] = 0;
         $data['channel_rules'] = $rules;
+        $data['status_tags'] = [];
+
+        // generate all status tags for UI to reference
+        if (isset($settings['show_entry_status']) && $settings['show_entry_status'] == 'y') {
+            foreach(ee('Model')->get('Status')->all()->getIterator() as $status) {
+                $data['status_tags'][$status->status] = $status->renderTag();
+            }
+        }
 
         // Gut check to make sure they ran the update method!
         if (!ee()->db->field_exists('updated', 'structure')) {

--- a/system/ee/ExpressionEngine/Addons/structure/views/index.php
+++ b/system/ee/ExpressionEngine/Addons/structure/views/index.php
@@ -145,8 +145,17 @@ if ($cp_asset_data or count($tabs) > 1) {
                     }
                 }
 
-                if ($page['hidden'] == 'y') {
+                if (isset($settings['show_entry_status']) && $settings['show_entry_status'] == 'y') {
+                    $status = ee('Model')->get('Status')->filter('status', '==', $page['status'])->first();
+                    echo $status->renderTag();
+                }
+
+                if (isset($settings['show_nav_status']) && $settings['show_nav_status'] == 'y' && $page['hidden'] == 'y') {
                     echo ' <span class="hidden-page">(hidden)</span>';
+                }
+
+                if (isset($page['extra_html']) && $page['extra_html']) {
+                    echo ' <span class="extra-html">'.$page['extra_html'].'</span>';
                 }
 
                 echo '</span>', "\n";

--- a/system/ee/ExpressionEngine/Addons/structure/views/index.php
+++ b/system/ee/ExpressionEngine/Addons/structure/views/index.php
@@ -146,8 +146,7 @@ if ($cp_asset_data or count($tabs) > 1) {
                 }
 
                 if (isset($settings['show_entry_status']) && $settings['show_entry_status'] == 'y') {
-                    $status = ee('Model')->get('Status')->filter('status', '==', $page['status'])->first();
-                    echo $status->renderTag();
+                    echo isset($status_tags[$page['status']]) ? $status_tags[$page['status']] : '<span class="status-tag st-'.str_replace(" ", "-", strtolower($page['status'])).'" style="">'.$page['status'].'</span>';
                 }
 
                 if ((!isset($settings['show_nav_status']) || $settings['show_nav_status'] == 'y') && $page['hidden'] == 'y') {

--- a/system/ee/ExpressionEngine/Addons/structure/views/index.php
+++ b/system/ee/ExpressionEngine/Addons/structure/views/index.php
@@ -146,7 +146,7 @@ if ($cp_asset_data or count($tabs) > 1) {
                 }
 
                 if (isset($settings['show_entry_status']) && $settings['show_entry_status'] == 'y') {
-                    echo isset($status_tags[$page['status']]) ? $status_tags[$page['status']] : '<span class="status-tag st-'.str_replace(" ", "-", strtolower($page['status'])).'" style="">'.$page['status'].'</span>';
+                    echo isset($status_tags[$page['status']]) ? $status_tags[$page['status']] : '<span class="status-tag missing-status" style="">'.$page['status'].'</span>';
                 }
 
                 if ((!isset($settings['show_nav_status']) || $settings['show_nav_status'] == 'y') && $page['hidden'] == 'y') {

--- a/system/ee/ExpressionEngine/Addons/structure/views/index.php
+++ b/system/ee/ExpressionEngine/Addons/structure/views/index.php
@@ -150,7 +150,7 @@ if ($cp_asset_data or count($tabs) > 1) {
                     echo $status->renderTag();
                 }
 
-                if (isset($settings['show_nav_status']) && $settings['show_nav_status'] == 'y' && $page['hidden'] == 'y') {
+                if ((!isset($settings['show_nav_status']) || $settings['show_nav_status'] == 'y') && $page['hidden'] == 'y') {
                     echo ' <span class="hidden-page">(hidden)</span>';
                 }
 

--- a/system/ee/ExpressionEngine/Addons/structure/views/index.php
+++ b/system/ee/ExpressionEngine/Addons/structure/views/index.php
@@ -146,7 +146,7 @@ if ($cp_asset_data or count($tabs) > 1) {
                 }
 
                 if (isset($settings['show_entry_status']) && $settings['show_entry_status'] == 'y') {
-                    echo isset($status_tags[$page['status']]) ? $status_tags[$page['status']] : '<span class="status-tag missing-status" style="">'.$page['status'].'</span>';
+                    echo isset($status_tags[$page['status']]) ? $status_tags[$page['status']] : '<span class="status-tag missing-status">'.$page['status'].'</span>';
                 }
 
                 if ((!isset($settings['show_nav_status']) || $settings['show_nav_status'] == 'y') && $page['hidden'] == 'y') {

--- a/system/ee/ExpressionEngine/Addons/structure/views/module_settings.php
+++ b/system/ee/ExpressionEngine/Addons/structure/views/module_settings.php
@@ -49,6 +49,24 @@
                 </select>
             </td>
         </tr>
+        <tr class="odd">
+            <td><?=lang('show_nav_status')?></td>
+            <td>
+                <select name="show_nav_status">
+                    <option value="y"<?=set_select('yes', 'Yes', ($settings['show_nav_status'] == '' || $settings['show_nav_status'] == 'y' ? 'y' : ''));?>><?=lang('yes')?></option>
+                    <option value="n"<?=set_select('no', 'No', ($settings['show_nav_status'] == '' || $settings['show_nav_status'] == 'n' ? 'y' : ''));?>><?=lang('no')?></option>
+                </select>
+            </td>
+        </tr>
+        <tr class="event">
+            <td><?=lang('show_entry_status')?></td>
+            <td>
+                <select name="show_entry_status">
+                    <option value="y"<?=set_select('yes', 'Yes', ($settings['show_entry_status'] == '' || $settings['show_entry_status'] == 'y' ? 'y' : ''));?>><?=lang('yes')?></option>
+                    <option value="n"<?=set_select('no', 'No', ($settings['show_entry_status'] == '' || $settings['show_entry_status'] == 'n' ? 'y' : ''));?>><?=lang('no')?></option>
+                </select>
+            </td>
+        </tr>
     </tbody>
 </table>
 <?php endif;?>

--- a/system/ee/ExpressionEngine/Model/Status/Status.php
+++ b/system/ee/ExpressionEngine/Model/Status/Status.php
@@ -141,6 +141,8 @@ class Status extends Model
 
     public function renderTag()
     {
+        ee()->lang->loadfile('admin_content');
+
         $status_name = ($this->status == 'closed' or $this->status == 'open') ? lang($this->status) : $this->status;
 
         $status_class = str_replace(' ', '_', strtolower((string) $this->status));

--- a/system/ee/language/english/structure_lang.php
+++ b/system/ee/language/english/structure_lang.php
@@ -74,6 +74,8 @@ $lang = array(
     'setting_redirect_publish'  => 'Redirect to Structure on entry publish/save',
     'split_assets'              => 'Make each entry a single asset (no Add/Edit)',
     'hide_hidden_templates'     => 'Hide hidden templates on publish/edit tab',
+    'show_nav_status'           => 'Show nav status (e.g. "(hidden)") in Pages view',
+    'show_entry_status'         => 'Show entry status (e.g. "Open") in Pages view',
 
     'setting'                       => 'Setting',
     'structure_settings'            => 'Settings',

--- a/themes/ee/structure/css/structure.css
+++ b/themes/ee/structure/css/structure.css
@@ -533,6 +533,12 @@ ul.state-sorting {
     font-weight: normal;
 }
 
+#structure-ui span.status-tag.missing-status {
+    border-color: black;
+    background-color: white;
+    color: black;
+}
+
 /* assets */
 
 #structure-ui ul#assets {

--- a/themes/ee/structure/css/structure.css
+++ b/themes/ee/structure/css/structure.css
@@ -4,7 +4,7 @@
 
 /* RESET! */
 
-#structure-ui div, #structure-ui span,
+#structure-ui div, #structure-ui > span:not(.status-tag),
 #structure-ui h1, #structure-ui h2, #structure-ui h3,
 #structure-ui h4, #structure-ui h5, #structure-ui h6, #structure-ui p,
 #structure-ui a, #structure-ui img, #structure-ui strong,
@@ -510,6 +510,11 @@ ul.state-sorting {
     color: #666;
     }
 
+#structure-ui .page-ui .page-title > span {
+    margin-left: 8px;
+    font-weight: normal;
+}
+
 /* listings */
 
 #structure-ui .page-ui .page-listing {
@@ -522,6 +527,11 @@ ul.state-sorting {
 #structure-ui .page-ui .page-listing a:link, #structure-ui .page-ui .page-listing a:visited {
     color: #666;
     }
+
+#structure-ui span.status-tag {
+    line-height: 1.6;
+    font-weight: normal;
+}
 
 /* assets */
 


### PR DESCRIPTION
Added 2 new settings (at the bottom) to toggle elements on the Pages UI:

<img width="1268" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/c6a4b8ad-8233-4f48-9b6a-4ea2853d245d">

Default view:

<img width="269" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/5644ce4d-e326-4fc2-9bfa-815d92f284e0">

Status displayed, "Hide from nav" hidden:

<img width="241" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/d3b4be4e-7225-4940-90bf-6c5cface28e3">
