### PR TITLE
avoid PHP notice when getting template from group that does not exist

### DIFF
--- a/system/ee/ExpressionEngine/Model/Template/Template.php
+++ b/system/ee/ExpressionEngine/Model/Template/Template.php
@@ -120,7 +120,8 @@ class Template extends FileSyncedModel
      */
     public function getPath()
     {
-        return $this->getTemplateGroup()->group_name . '/' . $this->template_name;
+        $groupName = !is_null($this->getTemplateGroup()) ? $this->getTemplateGroup()->group_name : '';
+        return $groupName . '/' . $this->template_name;
     }
 
     /**


### PR DESCRIPTION
<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
