### PR TITLE
Resolved #3680 where term Snippet was still used in error message

### DIFF
--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -388,7 +388,7 @@ class EE_Template
 
                         $replace = $this->wrapInContextAnnotations(
                             $value,
-                            'Snippet "' . $variable . '"'
+                            'Template Partial "' . $variable . '"'
                         );
 
                         $this->template = str_replace(LD . $variable . RD, $replace, $this->template);


### PR DESCRIPTION
(cherry picked from commit 20ed3f0ae50f4e4a1f66ea12364b8cab326e6b01)
