### PR TITLE
Resolved issue where Channel form grid has duplicated label for every single row

### DIFF
--- a/system/ee/ExpressionEngine/View/_shared/table.php
+++ b/system/ee/ExpressionEngine/View/_shared/table.php
@@ -393,8 +393,7 @@ else: ?>
                                 $column_desc = lang($columns[$key]['desc']);
                             }
 
-                            $style = (REQ == 'PAGE') ? "style='display:none'" : '';
-                            $column_label = "<div class=\"grid-field__column-label\"  role=\"rowheader\" $style>
+                            $column_label = "<div class=\"grid-field__column-label\"  role=\"rowheader\">
                                 <div class=\"grid-field__column-label__instraction\">
                                     <label>$column_name</label>";
                             if (!empty($column_desc)) {

--- a/system/ee/ExpressionEngine/View/_shared/table.php
+++ b/system/ee/ExpressionEngine/View/_shared/table.php
@@ -393,7 +393,8 @@ else: ?>
                                 $column_desc = lang($columns[$key]['desc']);
                             }
 
-                            $column_label = "<div class=\"grid-field__column-label\"  role=\"rowheader\">
+                            $style = (REQ == 'PAGE') ? "style='display:none'" : '';
+                            $column_label = "<div class=\"grid-field__column-label\"  role=\"rowheader\" $style>
                                 <div class=\"grid-field__column-label__instraction\">
                                     <label>$column_name</label>";
                             if (!empty($column_desc)) {

--- a/themes/ee/cform/css/eecms-cform.min.css
+++ b/themes/ee/cform/css/eecms-cform.min.css
@@ -16,3 +16,4 @@
 .ee-cform .redactor-in em{display: inline}
 .ee-cform .redactor-in a{font-size:revert}
 @media print{.redactor-in .readmore{padding:0}.redactor-in .readmore::after{display:none}}
+.ee-cform table .grid-field__column-label { display: none;}


### PR DESCRIPTION
EE7 version of #3693 
issue:
<img width="1440" alt="Screenshot 2023-08-09 at 16 30 41" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/23382425/047b1532-aa51-4c05-a056-32974dabdada">

Fix:
<img width="1437" alt="Screenshot 2023-08-09 at 16 31 06" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/23382425/d9faed37-b4e6-42d6-8899-d4cee36a94e7">

Fix doesn't affect CP grid view
