### PR TITLE
Resolved #3689 where PHP error could be shown when accessing custom fields

### DIFF
--- a/system/ee/legacy/libraries/api/Api_channel_fields.php
+++ b/system/ee/legacy/libraries/api/Api_channel_fields.php
@@ -133,7 +133,7 @@ class Api_channel_fields extends Api
             }
 
             $opts = get_class_vars($data['class']);
-            $fts[$key] = array_merge($fts[$key], isset($opts['info']) && is_array($opts['info']) ? $opts['info'] : []);
+            $fts[$key] = array_merge($fts[$key], (isset($opts['info']) && is_array($opts['info']) ? $opts['info'] : []));
         }
 
         return $fts;

--- a/system/ee/legacy/libraries/api/Api_channel_fields.php
+++ b/system/ee/legacy/libraries/api/Api_channel_fields.php
@@ -133,7 +133,7 @@ class Api_channel_fields extends Api
             }
 
             $opts = get_class_vars($data['class']);
-            $fts[$key] = array_merge($fts[$key], $opts['info']);
+            $fts[$key] = array_merge($fts[$key], $opts['info'] ?? []);
         }
 
         return $fts;

--- a/system/ee/legacy/libraries/api/Api_channel_fields.php
+++ b/system/ee/legacy/libraries/api/Api_channel_fields.php
@@ -133,7 +133,7 @@ class Api_channel_fields extends Api
             }
 
             $opts = get_class_vars($data['class']);
-            $fts[$key] = array_merge($fts[$key], $opts['info'] ?? []);
+            $fts[$key] = array_merge($fts[$key], isset($opts['info']) && is_array($opts['info']) ? $opts['info'] : []);
         }
 
         return $fts;


### PR DESCRIPTION
This change gracefully handles the situation where a fieldtype does not set it's `$info` property as an array

Resolved #3689 where PHP error could be shown when accessing custom fields