### PR TITLE
Resolved #3689 where PHP error could be shown when accessing custom fields

### DIFF
--- a/system/ee/legacy/libraries/api/Api_channel_fields.php
+++ b/system/ee/legacy/libraries/api/Api_channel_fields.php
@@ -130,7 +130,7 @@ class Api_channel_fields extends Api
             }
 
             $opts = get_class_vars($data['class']);
-            $fts[$key] = array_merge($fts[$key], $opts['info']);
+            $fts[$key] = array_merge($fts[$key], (isset($opts['info']) && is_array($opts['info']) ? $opts['info'] : []));
         }
 
         return $fts;


### PR DESCRIPTION
Resolved #3689 where PHP error could be shown when accessing custom fields
EE 6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3688