### PR TITLE
Added {exp:member:role_groups} template tag

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member.php
@@ -2620,6 +2620,42 @@ class Member
     }
 
     /**
+     * Member Role Groups list
+     */
+    public function role_groups()
+    {
+        $member_id = (!ee()->TMPL->fetch_param('member_id')) ? ee()->session->userdata('member_id') : ee()->TMPL->fetch_param('member_id');
+
+        $member = ee('Model')
+            ->get('Member', $member_id)
+            ->with('RoleGroups')
+            ->all()
+            ->first();
+
+        if (!$member) {
+            return ee()->TMPL->no_results();
+        }
+
+        $vars = [];
+        foreach($member->RoleGroups->asArray() as $roleGroup) {
+            if ($roleGroup->group_id === 0 && $roleGroup->name === null) {
+                continue;
+            }
+
+            $vars[] = [
+                'role_group_id' => $roleGroup->group_id,
+                'role_group_name' => $roleGroup->name,
+            ];
+        };
+
+        if (!$vars) {
+            return ee()->TMPL->no_results();
+        }
+
+        return ee()->TMPL->parse_variables(ee()->TMPL->tagdata, $vars);
+    }
+
+    /**
      * Member roles list
      */
     public function roles()

--- a/system/ee/ExpressionEngine/Addons/member/mod.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member.php
@@ -2637,7 +2637,7 @@ class Member
         }
 
         $vars = [];
-        foreach($member->RoleGroups->asArray() as $roleGroup) {
+        foreach ($member->RoleGroups as $roleGroup) {
             if ($roleGroup->group_id === 0 && $roleGroup->name === null) {
                 continue;
             }
@@ -2648,7 +2648,7 @@ class Member
             ];
         };
 
-        if (!$vars) {
+        if (!empty($vars)) {
             return ee()->TMPL->no_results();
         }
 


### PR DESCRIPTION
Add `{exp:member:role_groups}` template tag to get info about which Role Groups a member is assigned to.

Documentation will still be needed if this is accepted, which I am happy to update too. I didn't want to do all of the work if this will be declined by the mods though.

Demo template:
```
{!-- existing functionality --}
<h1>Roles</h1>
{exp:member:roles}
	<p>role ID: {role_id}</p>
	<p>role name: {name}</p>
{/exp:member:roles}

{!-- new functionality --}
<h1>Role Groups</h1>
{exp:member:role_groups}
	<p>role group id: {role_group_id}</p>
	<p>role group name: {role_group_name}</p>
{/exp:member:role_groups}
```

Output for member not assigned to any Role Groups:
<img width="192" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/6a5b9bba-fb94-4091-b89d-b78caebb6d51">

Output for member in a Role Group:
<img width="223" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/155cb696-4610-4e91-bfb9-91c778a18d9b">
