### PR TITLE
Resolved issue where using undefined layout variables in tag parameters would cause unexpected results

### DIFF
--- a/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
@@ -408,7 +408,7 @@ class LegacyParser
         if (preg_match_all('/' . LD . 'layout:(?!\bcontents\b|\bset\b)([^!]+?)' . RD . '/', $str, $matches)) {
             foreach ($matches[1] as $match) {
                 // ensure that the match string has a modifier character in it
-                if (($modifier_pos = strrpos($match, ':')) !== false) {
+                if (($modifier_pos = strpos($match, ':')) !== false) {
                     $key = substr($match, 0, $modifier_pos);
 
                     // ignore if layout:variable is already defined

--- a/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
@@ -403,25 +403,6 @@ class LegacyParser
     {
         $conditionals = [];
 
-        // get all the left over layout variables in the string (excluding layout:contents and layout:set)
-        // the ones left here (after Template parseLayoutVariables) should only be layout variables with modifiers
-        if (preg_match_all('/' . LD . 'layout:(?!\bcontents\b|\bset\b)([^!]+?)' . RD . '/', $str, $matches)) {
-            foreach ($matches[1] as $match) {
-                // ensure that the match string has a modifier character in it
-                if (($modifier_pos = strpos($match, ':')) !== false) {
-                    $key = substr($match, 0, $modifier_pos);
-
-                    // ignore if layout:variable is already defined
-                    if (isset($vars['layout:' . $key])) {
-                        continue;
-                    }
-
-                    // set the undeclared (but referenced) variable to an empty string
-                    $vars['layout:' . $key] = '';
-                }
-            }
-        }
-
         foreach ($vars as $name => $value) {
             if (strpos($str, $name . ':') !== false) {
                 $prefix = '';

--- a/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
@@ -403,6 +403,25 @@ class LegacyParser
     {
         $conditionals = [];
 
+        // get all the left over layout variables in the string (excluding layout:contents and layout:set)
+        // the ones left here (after Template parseLayoutVariables) should only be layout variables with modifiers
+        if (preg_match_all('/' . LD . 'layout:(?!\bcontents\b|\bset\b)([^!]+?)' . RD . '/', $str, $matches)) {
+            foreach ($matches[1] as $match) {
+                // ensure that the match string has a modifier character in it
+                if (($modifier_pos = strrpos($match, ':')) !== false) {
+                    $key = substr($match, 0, $modifier_pos);
+
+                    // ignore if layout:variable is already defined
+                    if (isset($vars['layout:' . $key])) {
+                        continue;
+                    }
+
+                    // set the undeclared (but referenced) variable to an empty string
+                    $vars['layout:' . $key] = '';
+                }
+            }
+        }
+
         foreach ($vars as $name => $value) {
             if (strpos($str, $name . ':') !== false) {
                 $prefix = '';

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -558,7 +558,7 @@ class EE_Template
             $this->log_item("Conditionals Parsed, Processing Sub Templates");
             $this->template = $this->process_layout_template($this->template, $layout);
             $this->template = $this->process_sub_templates($this->template);
-            $this->final_template = $this->_cleanup_layout_tags($this->template);
+            $this->final_template = $this->template;
 
             return;
         }
@@ -669,7 +669,7 @@ class EE_Template
             $this->template = $this->process_layout_template($this->template, $layout);
             $this->template = $this->process_sub_templates($this->template);
 
-            $this->final_template = $this->_cleanup_layout_tags($this->template);
+            $this->final_template = $this->template;
         }
     }
 
@@ -755,6 +755,11 @@ class EE_Template
         }
 
         $this->layout_conditionals = $layout_conditionals;
+
+        // cleanup of leftover/undeclared layout variables (excluding layout:contents)
+        if (strpos($str, LD . 'layout:') !== false) {
+            $str = preg_replace('/' . LD . 'layout:(?!\bcontents\b)([^!]+?)' . RD . '/', '', $str);
+        }
 
         return $str;
     }
@@ -871,25 +876,6 @@ class EE_Template
         }
 
         return $layout;
-    }
-
-    /**
-     * Cleanup any leftover layout tags
-     *
-     * We need to do this at various steps of post parsing as doing it too early
-     * can result in accidental cleanup of the {layout:contents} variable.
-     *
-     * @param   string  $template  Template string
-     * @return  string  Template string with cleaned up layout tags
-     */
-    protected function _cleanup_layout_tags($template)
-    {
-        // cleanup of leftover/undeclared layout variables
-        if (strpos($template, LD . 'layout:') !== false) {
-            $template = preg_replace('/' . LD . 'layout:([^!]+?)' . RD . '/', '', $template);
-        }
-
-        return $template;
     }
 
     /**
@@ -1279,8 +1265,6 @@ class EE_Template
 
                 $args = trim((preg_match("/\s+.*/", $tag, $matches))) ? $matches[0] : '';
                 $tag = trim(str_replace($args, '', $tag));
-
-                $args = $this->_cleanup_layout_tags($args);
 
                 $cur_tag_close = LD . '/' . $tag . RD;
 

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -559,6 +559,7 @@ class EE_Template
             $this->template = $this->process_layout_template($this->template, $layout);
             $this->template = $this->process_sub_templates($this->template);
             $this->final_template = $this->template;
+            $this->_cleanup_layout_tags();
 
             return;
         }
@@ -670,6 +671,7 @@ class EE_Template
             $this->template = $this->process_sub_templates($this->template);
 
             $this->final_template = $this->template;
+            $this->_cleanup_layout_tags();
         }
     }
 
@@ -756,9 +758,9 @@ class EE_Template
 
         $this->layout_conditionals = $layout_conditionals;
 
-        // cleanup of leftover/undeclared layout variables (excluding layout:contents)
+        // cleanup of leftover/undeclared layout variables (excluding layout:contents and variables with chained modifiers)
         if (strpos($str, LD . 'layout:') !== false) {
-            $str = preg_replace('/' . LD . 'layout:(?!\bcontents\b)([^!]+?)' . RD . '/', '', $str);
+            $str = preg_replace('/' . LD . 'layout:(?!\bcontents\b)([^!:]+?)' . RD . '/', '', $str);
         }
 
         return $str;
@@ -876,6 +878,22 @@ class EE_Template
         }
 
         return $layout;
+    }
+
+    /**
+     * Cleanup any leftover layout tags
+     *
+     * We need to do this at various steps of post parsing as doing it too early
+     * can result in accidental cleanup of the {layout:contents} variable.
+     *
+     * @return  void
+     */
+    protected function _cleanup_layout_tags()
+    {
+        // cleanup of leftover/undeclared layout variables
+        if (strpos($this->final_template, LD . 'layout:') !== false) {
+            $this->final_template = preg_replace('/' . LD . 'layout:([^!]+?)' . RD . '/', '', $this->final_template);
+        }
     }
 
     /**

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -687,11 +687,13 @@ class EE_Template
      */
     private function parseLayoutVariables($str, $layout_vars)
     {
-        $this->log_item("layout Variables:", $layout_vars);
+        $this->log_item("Layout Variables:", $layout_vars);
         $this->layout_conditionals = [];
 
         // get all the declared layout variables (excluding layout:contents)
         if (preg_match_all('/' . LD . 'layout:(?!\bcontents\b)([^!]+?)' . RD . '/', $str, $matches)) {
+            $undefined_layout_vars = [];
+
             foreach ($matches[1] as $match) {
                 // get the key to the layout_vars array, if the string contains any modifier characters
                 // we will remove the trailing part of the string. (e.g. {layout:var:modifier} -> {layout:var})
@@ -712,6 +714,11 @@ class EE_Template
 
                 // set the undefined (but declared) variable to an empty string
                 $layout_vars[$key] = '';
+                $undefined_layout_vars[] = $key;
+            }
+
+            if (count($undefined_layout_vars) > 0) {
+                $this->log_item(" -> Undefined Variables:", $undefined_layout_vars);
             }
         }
 

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -558,8 +558,7 @@ class EE_Template
             $this->log_item("Conditionals Parsed, Processing Sub Templates");
             $this->template = $this->process_layout_template($this->template, $layout);
             $this->template = $this->process_sub_templates($this->template);
-            $this->final_template = $this->template;
-            $this->_cleanup_layout_tags();
+            $this->final_template = $this->_cleanup_layout_tags($this->template);
 
             return;
         }
@@ -670,8 +669,7 @@ class EE_Template
             $this->template = $this->process_layout_template($this->template, $layout);
             $this->template = $this->process_sub_templates($this->template);
 
-            $this->final_template = $this->template;
-            $this->_cleanup_layout_tags();
+            $this->final_template = $this->_cleanup_layout_tags($this->template);
         }
     }
 
@@ -881,14 +879,17 @@ class EE_Template
      * We need to do this at various steps of post parsing as doing it too early
      * can result in accidental cleanup of the {layout:contents} variable.
      *
-     * @return  void
+     * @param   string  $template  Template string
+     * @return  string  Template string with cleaned up layout tags
      */
-    protected function _cleanup_layout_tags()
+    protected function _cleanup_layout_tags($template)
     {
         // cleanup of leftover/undeclared layout variables
-        if (strpos($this->final_template, LD . 'layout:') !== false) {
-            $this->final_template = preg_replace('/' . LD . 'layout:([^!]+?)' . RD . '/', '', $this->final_template);
+        if (strpos($template, LD . 'layout:') !== false) {
+            $template = preg_replace('/' . LD . 'layout:([^!]+?)' . RD . '/', '', $template);
         }
+
+        return $template;
     }
 
     /**
@@ -1278,6 +1279,8 @@ class EE_Template
 
                 $args = trim((preg_match("/\s+.*/", $tag, $matches))) ? $matches[0] : '';
                 $tag = trim(str_replace($args, '', $tag));
+
+                $args = $this->_cleanup_layout_tags($args);
 
                 $cur_tag_close = LD . '/' . $tag . RD;
 

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -690,6 +690,26 @@ class EE_Template
         $this->log_item("layout Variables:", $layout_vars);
         $this->layout_conditionals = [];
 
+        // get all the declared layout variables (excluding layout:contents)
+        if (preg_match_all('/' . LD . 'layout:(?!\bcontents\b)([^!]+?)' . RD . '/', $str, $matches)) {
+            foreach ($matches[1] as $match) {
+                // get the key to the layout_vars array, if the string contains any modifier characters
+                // we will remove the trailing part of the string.
+                $key = $match;
+                if (($modifier_pos = strpos($key, ':')) !== false) {
+                    $key = substr($key, 0, $modifier_pos);
+                }
+
+                // ignore if the variable is already defined
+                if (isset($layout_vars[$key])) {
+                    continue;
+                }
+
+                // set the undefined (but declared) variable to an empty string
+                $layout_vars[$key] = '';
+            }
+        }
+
         foreach ($layout_vars as $key => $val) {
             if (is_array($val)) {
                 $layout_conditionals['layout:' . $key] = true;
@@ -757,11 +777,6 @@ class EE_Template
         }
 
         $this->layout_conditionals = $layout_conditionals;
-
-        // cleanup of leftover/undeclared layout variables (excluding layout:contents and variables with chained modifiers)
-        if (strpos($str, LD . 'layout:') !== false) {
-            $str = preg_replace('/' . LD . 'layout:(?!\bcontents\b)([^!:]+?)' . RD . '/', '', $str);
-        }
 
         return $str;
     }

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -691,22 +691,10 @@ class EE_Template
         $this->layout_conditionals = [];
 
         // get all the declared layout variables (excluding layout:contents)
-        if (preg_match_all('/' . LD . 'layout:(?!\bcontents\b)([^!]+?)' . RD . '/', $str, $matches)) {
+        if (preg_match_all('/' . LD . 'layout:(?!\bcontents\b)([^!]+?)(' . RD . '|\s|:)/', $str, $matches)) {
             $undefined_layout_vars = [];
 
-            foreach ($matches[1] as $match) {
-                // get the key to the layout_vars array, if the string contains any modifier characters
-                // we will remove the trailing part of the string. (e.g. {layout:var:modifier} -> {layout:var})
-                $key = $match;
-                if (($modifier_pos = strpos($key, ':')) !== false) {
-                    $key = substr($key, 0, $modifier_pos);
-                }
-
-                // remove any arguments after the remaining variable name (e.g. {layout:var index='1'} -> {layout:var})
-                if (($args_pos = strpos($key, ' ')) !== false) {
-                    $key = substr($key, 0, $args_pos);
-                }
-
+            foreach ($matches[1] as $key) {
                 // ignore if the variable is already defined
                 if (isset($layout_vars[$key])) {
                     continue;

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -694,10 +694,15 @@ class EE_Template
         if (preg_match_all('/' . LD . 'layout:(?!\bcontents\b)([^!]+?)' . RD . '/', $str, $matches)) {
             foreach ($matches[1] as $match) {
                 // get the key to the layout_vars array, if the string contains any modifier characters
-                // we will remove the trailing part of the string.
+                // we will remove the trailing part of the string. (e.g. {layout:var:modifier} -> {layout:var})
                 $key = $match;
                 if (($modifier_pos = strpos($key, ':')) !== false) {
                     $key = substr($key, 0, $modifier_pos);
+                }
+
+                // remove any arguments after the remaining variable name (e.g. {layout:var index='1'} -> {layout:var})
+                if (($args_pos = strpos($key, ' ')) !== false) {
+                    $key = substr($key, 0, $args_pos);
                 }
 
                 // ignore if the variable is already defined


### PR DESCRIPTION
This PR fixes an issue where passing undefined layout variables in to template tag arguments would result in `ee()->TMPL->fetch_param` giving back unclean layout variables, this is because `_cleanup_layout_tags` is called after the function which parses template tags.

Example:
```php
// inside our layout template.html
{exp:addon:tag arg="{layout:some_variable_which_doesnt_exist}"}

// then inside our addon Tag.php
dump(ee()->TMPL->fetch_param('arg'));
```

The above would result in an unclean layout variable being output (`string(41) "{layout:some_variable_which_doesnt_exist}"`) instead of an empty string - which forces me to manually check and replace any input passed to my tag which comes from potentially undefined layout variables.

Example 2:
```php
// inside layout template.html
{exp:addon:tag arg="{if '{layout:some_variable_which_doesnt_exist}'}true{if:else}false{/if}"}
```

The above would result in strange behaviour - `truefalse"}` being output if we just return the `fetch_param` back from the tag.

Example 3:
```php
// inside layout template.html
{exp:addon:tag arg="{layout:some_variable_which_doesnt_exist:trim:url_slug}"}
{exp:addon:tag arg="{if '{layout:some_variable_which_doesnt_exist:trim:url_slug}'}true{if:else}false{/if}"}
```
This again would have the same effect as above as, but because these are parsed in a slightly different way, we must have a valid key for `some_variable_which_doesnt_exist` in the `layout_conditionals` array, or the conditionals won't be run.

---

To fix these issues, I'm giving all referenced layout variables (which are undefined) a default value of an empty string. This is done by matching all the layout variables (excluding `layout:contents`), finding out which of the referenced variables are undefined in the `$layout_vars` array, then adding in the variable name with an empty value.