### PR TITLE
Enabled logging in using email address; #2931

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -241,6 +241,10 @@ class Member_auth extends Member
     {
         $sess = ee()->auth->authenticate_username($username, $password);
 
+        if ($sess === false) {
+            $sess = ee()->auth->authenticate_email($username, $password);
+        }
+
         if (! $sess) {
             ee()->session->save_password_lockout($username);
 

--- a/system/ee/ExpressionEngine/View/account/login.php
+++ b/system/ee/ExpressionEngine/View/account/login.php
@@ -16,7 +16,7 @@
 	<?=form_open(ee('CP/URL')->make('login/authenticate'), array(), array('return_path' => $return_path, 'after' => $after))?>
 		<fieldset>
 			<div class="field-instruct">
-				<?=lang('username', 'username')?>
+				<label for="username"><?=lang('username')?> / <?=lang('email')?></label>
 			</div>
 			<?=form_input(array('dir' => 'ltr', 'name' => "username", 'id' => "username", 'value' => $username, 'maxlength' => USERNAME_MAX_LENGTH, 'tabindex' => 1))?>
 		</fieldset>

--- a/tests/cypress/cypress/integration/cp/login.ee6.js
+++ b/tests/cypress/cypress/integration/cp/login.ee6.js
@@ -172,6 +172,15 @@ context('Login Page', () => {
     })
 
     context('advanced login routines', () => {
+        it('logs in using email', function() {
+            // Log in
+            cy.login({ email: 'cypress@expressionengine.com', password: 'password' });
+
+            // User is logged in
+            cy.get('h2').contains("Members");
+
+        })
+        
         it('logs in after logout', function() {
             // Log in
             cy.login({ email: 'admin', password: 'password' });

--- a/tests/cypress/cypress/integration/members/login.ee6.js
+++ b/tests/cypress/cypress/integration/members/login.ee6.js
@@ -37,4 +37,24 @@ context('Front-end login', () => {
         cy.get('.sidebar').should('contain', 'Logged out')
     })
 
+    it('login on front-end using email', function() {
+        cy.clearCookies()
+        cy.visit('index.php/members/login');
+        cy.get('.sidebar').should('contain', 'Logged out')
+        cy.logFrontendPerformance()
+        cy.intercept("**?ACT=**").as('ajax')
+        cy.get('input[name=username]').clear().type('cypress@expressionengine.com');
+        cy.get('input[name=password]').clear().type('password');
+        cy.get('input[name=submit]').click();
+        cy.hasNoErrors();
+        cy.get('body').should('not.contain', 'errors were encountered')
+
+        cy.get('.sidebar').should('not.contain', 'Logged out')
+        cy.get('.sidebar a').contains('Logout').click()
+        cy.get('button').contains('Logout').click()
+        cy.hasNoErrors();
+        cy.get('body').should('not.contain', 'errors were encountered')
+        cy.get('.sidebar').should('contain', 'Logged out')
+    })
+
 })


### PR DESCRIPTION
Enabled logging in using email address; #2931

This adds ability to log in using email address to front-end forms. It also changes label from "username" to "username / email" on CP logi form, because logging in with email is already possible there