### PR TITLE
Enable passing through MySQL PDO configuration from config file; #2989; #3427; Only set MySQL collation explicitely if it's different than default

### DIFF
--- a/system/ee/ExpressionEngine/Service/Database/DBConfig.php
+++ b/system/ee/ExpressionEngine/Service/Database/DBConfig.php
@@ -72,6 +72,11 @@ class DBConfig extends ConfigWithDefaults
         );
 
         if (is_array($result)) {
+            if (!isset($result['dbcollat'])) {
+                $result['dbcollat_default'] = true;
+            } elseif ($result['dbcollat'] == 'utf8mb4_unicode_ci' && $result['char_set'] == 'utf8mb4') {
+                $result['dbcollat_default'] = true;
+            }
             return array_merge($default, $result);
         }
 

--- a/system/ee/legacy/database/DB_driver.php
+++ b/system/ee/legacy/database/DB_driver.php
@@ -46,6 +46,7 @@ class CI_DB_driver
     public $cachedir = '';
     public $cache_autodel = false;
     public $CACHE; // The cache class object
+    public $dbcollat_default; // true if the collation is not in the config or is default
 
     // Private variables
     public $_protect_identifiers = true;

--- a/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php
+++ b/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php
@@ -74,6 +74,12 @@ class CI_DB_mysqli_connection
             PDO::ATTR_STRINGIFY_FETCHES => ! $this->mysqlnd
         );
 
+        // only set names and collation if they are set in config
+        // and are different from what's default in EE
+        if (isset($this->config['dbcollat_default']) && $this->config['dbcollat_default'] === true) {
+            $options[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET NAMES '$char_set' COLLATE '$dbcollat'";
+        }
+
         // There is a limited set of PDO options that we can pass though
         // from config.php file
         $mysqlAttr = [
@@ -108,8 +114,6 @@ class CI_DB_mysqli_connection
             $password,
             $options
         );
-
-        $this->query("SET NAMES '$char_set' COLLATE '$dbcollat'");
     }
 
     /**

--- a/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php
+++ b/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php
@@ -74,6 +74,34 @@ class CI_DB_mysqli_connection
             PDO::ATTR_STRINGIFY_FETCHES => ! $this->mysqlnd
         );
 
+        // There is a limited set of PDO options that we can pass though
+        // from config.php file
+        $mysqlAttr = [
+            'MYSQL_ATTR_LOCAL_INFILE',
+            'MYSQL_ATTR_LOCAL_INFILE_DIRECTORY',
+
+            'MYSQL_ATTR_READ_DEFAULT_FILE',
+            'MYSQL_ATTR_READ_DEFAULT_GROUP',
+
+            'MYSQL_ATTR_MAX_BUFFER_SIZE',
+
+            'MYSQL_ATTR_INIT_COMMAND',
+
+            'MYSQL_ATTR_COMPRESS',
+
+            'MYSQL_ATTR_SSL_CA',
+            'MYSQL_ATTR_SSL_CAPATH',
+            'MYSQL_ATTR_SSL_CERT',
+            'MYSQL_ATTR_SSL_CIPHER',
+            'MYSQL_ATTR_SSL_KEY',
+            'MYSQL_ATTR_SSL_VERIFY_SERVER_CERT'
+        ];
+        foreach ($mysqlAttr as $attr) {
+            if (isset($this->config[$attr])) {
+                $options[constant("PDO::$attr")] = $this->config[$attr];
+            }
+        }
+
         $this->connection = @new PDO(
             $dsn,
             $username,


### PR DESCRIPTION
This PR consists of 2 parts (commits). The first is straighforward and allows setting some PDO attributes from config.php file:

https://github.com/ExpressionEngine/ExpressionEngine/discussions/2989 (Config option for MYSQL_ATTR_LOCAL_INFILE in database settings)

https://github.com/ExpressionEngine/ExpressionEngine/discussions/3427 (SSL/TLS for Database Connections)

The other one is more complex and this is where I have some doubt.

Back in the year 2004 running `SET NAMES... COLLATE...` before querying the database was important because of all the variety of character sets that could be used. Using EE could be problematic with Cyryllic characters when MySQL default is Latin-1 and your tables are Windows-1251 - and this was the common case (to be fair, not just with EE by almost any CMS)

Today, the situation is different because most of the times UTF-8 is used (in different flavors though)

It seems that SET NAMES is currently not necessary because we already set character set when initializing PDO connection - which did not have effect before PHP 5.4 and that's why we still need to had run SET NAMES, but with PHP v 7 and greater supported we don't need to take that into consideration

Setting collation might be necessary for getting the right sorting order when sorting by title, for example. But I think that is only necessary for edge cases, when your database is using collation different that the default. E.g. if you're using utf-8 charset but want to use specific Polish collation to get "Ł" after "L" and not before. Therefore the suggested change is to only set collation if it's set in config and if it's different from what's currently set by EE as default.

While this is small query, avoiding it from being run on EVERY request would be good optimization