### PR TITLE
Resolved issue where the user was redirected to different page after saving Front-End Editing Settings

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro/Controller/Settings/Frontedit.php
+++ b/system/ee/ExpressionEngine/Addons/pro/Controller/Settings/Frontedit.php
@@ -53,7 +53,7 @@ class Frontedit extends Settings\Pro
                     ->defer();
             }
 
-            ee()->functions->redirect(ee('CP/URL')->make('settings/pro/general'));
+            ee()->functions->redirect($this->base_url);
         }
 
         $settings = [];


### PR DESCRIPTION
<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->

## Overview

The `CP/URL` used for redirection after submitting the **Front-End Editing Settings** is incorrect.

The settings form is visible via the URI: `/cp/settings/pro/frontedit`. 

The redirect URL after submitting the form is currently [`/cp/settings/pro/general`](https://github.com/ExpressionEngine/ExpressionEngine/blob/0949dd1aa989e7ba97321d02c72dfecc0cb83dd8/system/ee/ExpressionEngine/Addons/pro/Controller/Settings/Frontedit.php#L56).

### Suggested changes

Instead of defining the redirect URL, I have proposed code that utilizes that class property [`$base_url`](https://github.com/ExpressionEngine/ExpressionEngine/blob/0949dd1aa989e7ba97321d02c72dfecc0cb83dd8/system/ee/ExpressionEngine/Addons/pro/Controller/Settings/Frontedit.php#L20).