### PR TITLE
Changed description for `is_system_on` setting on MSM sites for extra clarity; #3043

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Settings/General.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/General.php
@@ -65,7 +65,7 @@ class General extends Settings
                         )
                     )
                 ),
-                array(
+                'site_online' => array(
                     'title' => 'site_online',
                     'desc' => 'site_online_desc',
                     'fields' => array(
@@ -175,6 +175,11 @@ class General extends Settings
                 ),
             ),
         );
+
+        if (bool_config_item('multiple_sites_enabled')) {
+            $vars['sections'][0]['site_online']['title'] = 'system_online';
+            $vars['sections'][0]['site_online']['desc'] = sprintf(lang('system_online_desc'), ee('CP/URL', 'msm')->compile());
+        }
 
         $base_url = ee('CP/URL', 'settings/general');
 

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -104,6 +104,10 @@ $lang = array(
 
     'site_online_desc' => 'When disabled, only Super Admins and members with roles that have proper permissions will be able to browse this website.',
 
+    'system_online' => 'System online?',
+
+    'system_online_desc' => 'When turned off, only Super Admins and members with roles that have proper permissions will be able to browse the websites on this ExpressionEngine installation. <br>Individual <code>Website online?</code> settings for MSM sites can be managed under <a href="%s">Sites</a> section of Control Panel',
+
     'site_short_name' => 'Short name',
 
     'site_short_name_taken' => 'This short name is already taken.',

--- a/tests/cypress/cypress/integration/channel/create.ee6.js
+++ b/tests/cypress/cypress/integration/channel/create.ee6.js
@@ -56,6 +56,7 @@ context('Channel Create/Edit', () => {
 
         // Invalid channel short name
         page.get('channel_name').clear().type('test test').blur()
+        cy.wait(1000)
         page.hasError(page.get('channel_name'), this.channel_name_error)
         //page.hasErrors()
         cy.get('button[value="save"]').filter('[type=submit]').first().should('be.disabled')
@@ -64,15 +65,16 @@ context('Channel Create/Edit', () => {
         page.hasNoError(page.get('channel_title'))
         //page.hasNoErrors()
 
-
         // Duplicate channel short name
         page.get('channel_name').clear().type('news').blur()
+        cy.wait(1000)
         page.hasError(page.get('channel_name'), page.messages.validation.unique)
         //page.hasErrors()
         cy.get('button[value="save"]').filter('[type=submit]').first().should('be.disabled')
 
         // Duplicate channel title
         page.get('channel_title').clear().type('News').blur()
+        cy.wait(1000)
         page.hasError(page.get('channel_title'), page.messages.validation.unique)
         //page.hasErrors()
         cy.get('button[value="save"]').filter('[type=submit]').first().should('be.disabled')


### PR DESCRIPTION
Changed description for `is_system_on` setting on MSM sites for extra clarity; #3043

It leaves the label and description for setting as it is when there's only one site in the system and is changing it if MSM is enabled.