### PR TITLE
Resolved #3759 when pressing Ctrl+S with Redactor editor being in full screen mode would cause the field content to be erased

### DIFF
--- a/themes/ee/asset/javascript/src/common.js
+++ b/themes/ee/asset/javascript/src/common.js
@@ -404,7 +404,7 @@ $(document).ready(function(){
 	// Ctrls+S to save
 	// -------------------------------------------------------------------
 	window.addEventListener('keydown', function (key) {
-		if (key.ctrlKey || key.metaKey){
+		if ((key.ctrlKey || key.metaKey) && !$('body').hasClass('redactor-body-fullscreen')) {
 			$('.button[data-shortcut]:visible').each(function(e) {
 				$(this).addClass('button--with-shortcut');
 				if (key.key.toLowerCase() == $(this).data('shortcut').toLowerCase()) {


### PR DESCRIPTION
Resolved #3759 when pressing Ctrl+S with Redactor editor being in full screen mode would cause the field content to be erased