### PR TITLE
Resolved #3762 where selection of checkboxes in Grid with values containing single quotes was not re-populated after saving an entry

### DIFF
--- a/system/ee/ExpressionEngine/Addons/checkboxes/ft.checkboxes.php
+++ b/system/ee/ExpressionEngine/Addons/checkboxes/ft.checkboxes.php
@@ -107,7 +107,7 @@ class Checkboxes_ft extends OptionFieldtype implements ColumnInterface
 
     public function grid_display_field($data)
     {
-        return $this->_display_field(form_prep($data), 'grid');
+        return $this->_display_field($data, 'grid');
     }
 
     /**


### PR DESCRIPTION
Resolved #3762 where selection of checkboxes in Grid with values containing single quotes was not re-populated after saving an entry

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3785