### PR TITLE
Resolved #3772 where ExpressionEngine News dashboard widgets was not using date fomatting preference

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro/widgets/eecms_news.php
+++ b/system/ee/ExpressionEngine/Addons/pro/widgets/eecms_news.php
@@ -41,7 +41,7 @@ class Eecms_news extends Dashboard\AbstractDashboardWidget implements Dashboard\
                     $news[] = array(
                         'title'   => strip_tags($item->get_title()),
                         'date'    => ee()->localize->format_date(
-                            "%j%S %M, %Y",
+                            ee()->session->userdata('date_format', ee()->config->item('date_format')),
                             $item->get_date('U')
                         ),
                         'content' => ee('Security/XSS')->clean(


### PR DESCRIPTION
Resolved #3772 where ExpressionEngine News dashboard widgets was not using date fomatting preference