### PR TITLE
Make on-the-fly image manipulations available inside file field tag pair; #3753

### DIFF
--- a/tests/cypress/cypress/integration/content/file_field.ee6.js
+++ b/tests/cypress/cypress/integration/content/file_field.ee6.js
@@ -1,0 +1,107 @@
+/// <reference types="Cypress" />
+
+import ChannelFieldForm from '../../elements/pages/channel/ChannelFieldForm';
+import FileModal from '../../elements/pages/publish/FileModal';
+
+let file_modal = new FileModal;
+
+context('File field tags', () => {
+
+    before(function () {
+        cy.task('db:seed')
+        cy.eeConfig({ item: 'save_tmpl_files', value: 'y' })
+
+        //copy templates
+        cy.task('filesystem:copy', { from: 'support/templates/*', to: '../../system/user/templates/' }).then(() => {
+            cy.authVisit('admin.php?/cp/design')
+        })
+    })
+
+    it('{url} variable inside File field tag pair', () => {
+        cy.visit('/index.php/entries/picture')
+
+        cy.hasNoErrors()
+
+        cy.get('.file img.url')
+            .should('be.visible')
+            .and(($img) => {
+            expect($img[0].naturalWidth).to.be.greaterThan(0)
+        })
+
+        cy.get('.file img.resized')
+            .should('be.visible')
+            .and(($img) => {
+            expect($img[0].naturalWidth).to.be.eq(50)
+        })
+
+        cy.get('.file img.cropped')
+            .should('be.visible')
+            .and(($img) => {
+            expect($img[0].naturalWidth).to.be.eq(75)
+            expect($img[0].naturalHeight).to.be.eq(75)
+        })
+
+        cy.get('.file img.webp')
+            .should('be.visible')
+            .and(($img) => {
+            expect($img[0].naturalWidth).to.be.eq(75)
+            expect($img[0].naturalHeight).to.be.eq(75)
+        })
+        cy.get('.file img.webp').invoke('attr', 'src').should('match', /\.webp$/)
+    })
+
+    it('{url} variable inside File Grid field tag pair', () => {
+        cy.auth()
+        const channel_field_form = new ChannelFieldForm
+        channel_field_form.createField({
+            group_id: 1,
+            type: 'File Grid',
+            label: 'File Grid Field',
+            fields: { field_content_type: 'all' }
+        })
+
+        cy.visit('admin.php?/cp/publish/edit/entry/1')
+        // add another row
+        let link = cy.get('.js-file-grid').find("button:contains('Choose Existing'):visible");
+        link.click()
+        link.next('.dropdown').find("a:contains('About')").click()
+        file_modal.get('files').should('be.visible')
+        file_modal.get('files').first().click()
+        file_modal.get('files').should('not.be.visible')
+        cy.wait(5000); //give JS some extra time
+        cy.get('body').type('{ctrl}', {release: false}).type('s')
+
+        cy.visit('/index.php/entries/picture')
+
+        cy.hasNoErrors()
+
+        cy.get('.file_grid img.url')
+            .should('be.visible')
+            .and(($img) => {
+            expect($img[0].naturalWidth).to.be.greaterThan(0)
+        })
+
+        cy.get('.file_grid img.resized')
+            .should('be.visible')
+            .and(($img) => {
+            expect($img[0].naturalWidth).to.be.eq(40)
+        })
+
+        cy.get('.file_grid img.cropped')
+            .should('be.visible')
+            .and(($img) => {
+            expect($img[0].naturalWidth).to.be.eq(65)
+            expect($img[0].naturalHeight).to.be.eq(65)
+        })
+
+        cy.get('.file_grid img.webp')
+            .should('be.visible')
+            .and(($img) => {
+            expect($img[0].naturalWidth).to.be.eq(65)
+            expect($img[0].naturalHeight).to.be.eq(65)
+        })
+        cy.get('.file_grid img.webp').invoke('attr', 'src').should('match', /\.webp$/)
+
+    })
+
+})

--- a/tests/cypress/support/templates/default_site/entries.group/picture.html
+++ b/tests/cypress/support/templates/default_site/entries.group/picture.html
@@ -1,0 +1,38 @@
+{layout="cypress/layout"}
+{exp:channel:entries entry_id="1"}
+<h1>{title}</h1>
+
+<div class="file">
+{news_image}
+
+    <img src="{url}" class="url">
+
+    <img src="{url:resize width="50"}" class="resized">
+
+    <img src="{url:crop width="75" height="75" maintain_ratio="n"}" class="cropped">
+
+    <img src="{url:crop:webp width="75" height="75" maintain_ratio="n"}" class="webp">
+
+{/news_image}
+</div>
+
+<div class="file_grid">
+    {file_grid_field}
+
+        {file_grid_field:file}
+
+        <img src="{url}" class="url">
+    
+        <img src="{url:resize width="40"}" class="resized">
+    
+        <img src="{url:crop width="65" height="65" maintain_ratio="n"}" class="cropped">
+    
+        <img src="{url:crop:webp width="65" height="65" maintain_ratio="n"}" class="webp">
+
+        {/file_grid_field:file}
+    
+    {/file_grid_field}
+    </div>
+
+
+{/exp:channel:entries}


### PR DESCRIPTION
Make on-the-fly image manipulations available inside file field tag pair; #3753

User Guide: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/743