### PR TITLE
PHP version issue in ban check.

### DIFF
--- a/system/ee/legacy/libraries/Session.php
+++ b/system/ee/legacy/libraries/Session.php
@@ -293,6 +293,7 @@ class EE_Session
             return false;
         }
 
+        $match = (string) $match;
         foreach (explode('|', $ban) as $val) {
             if ($val == '*') {
                 continue;


### PR DESCRIPTION
Deprecated
substr(): Passing null to parameter #1 ($string) of type string is deprecated ee/legacy/libraries/Session.php, line 310

Severity: E_DEPRECATED

