### PR TITLE
Make channel layout JS more specific and only operate on layout tabs

### DIFF
--- a/system/ee/ExpressionEngine/View/channels/layout/form.php
+++ b/system/ee/ExpressionEngine/View/channels/layout/form.php
@@ -2,7 +2,7 @@
 
 <div class="panel">
 <div class="form-standard has-tabs publish" data-publish>
-	<?=form_open($form_url, 'class="ajax-validate"')?>
+	<?=form_open($form_url, 'class="ajax-validate" id="layout-form"')?>
   <div class="panel-heading">
     <div class="form-btns form-btns-top">
 		<div class="title-bar title-bar--large">

--- a/themes/ee/asset/javascript/src/cp/channel/layout.js
+++ b/themes/ee/asset/javascript/src/cp/channel/layout.js
@@ -8,16 +8,12 @@
  */
 
 $(document).ready(function () {
-	// remove debug - it has tabs and we don't want fields to end up in them
-	// we'll add it back in after all the events are bound
-	var debug = $('.ee-debugger').remove();
-
 	// Cache the elements - these selectors shouldn't grab debug even if it's
 	// somehow still there.  Doppelt gemoppelt hält besser.
 	// This will also speed up the code - we don't want to keep asking the dom
 	// for elements
-	var tabs = $('form .tab-wrap .tab-bar__tabs');
-	var sheets = $('form .tab-wrap div.tab');
+	var tabs = $('form#layout-form .tab-wrap .tab-bar__tabs');
+	var sheets = $('form#layout-form .tab-wrap div.tab');
 
 	function getTabIndex()
 	{
@@ -254,7 +250,7 @@ $(document).ready(function () {
 				};
 				EE.publish_layout.push(tab);
 
-				var index = $('form .tab-wrap .tab-bar .tab-bar__tab').length;
+				var index = $('form#layout-form .tab-wrap .tab-bar .tab-bar__tab').length;
 
 				tabs.find('.tab-bar__tab').droppable("destroy");
 
@@ -264,7 +260,7 @@ $(document).ready(function () {
 				makeTabsDroppable();
 
 				// Update tabs
-				sheets = $('form .tab-wrap div.tab');
+				sheets = $('form#layout-form .tab-wrap div.tab');
 				sheets.eq(-1).sortable(sortable_options_for_sheets);
 
 				$('.modal-add-new-tab .js-modal-close').trigger('click');
@@ -290,7 +286,7 @@ $(document).ready(function () {
 	tabs.on('click', '.tab-remove', function(e) {
 		e.preventDefault();
 		var tab = $(this).parents('.tab-bar__tab').eq(0);
-		var index = $('.tab-bar .tab-bar__tab').index(tab);
+		var index = tabs.find('.tab-bar__tab').index(tab);
 		var tabContents = sheets.filter('.' + $(tab).attr('rel'));
 
 		if (tabContents.find('.layout-item-wrapper').html().trim()) {
@@ -346,7 +342,7 @@ $(document).ready(function () {
 				input.after($('<em></em>').append(input.data('duplicate')));
 				input.parents('fieldset').addClass('invalid');
 			} else {
-				var button = $('.tab-bar__tab')[index];
+				var button = tabs.find('.tab-bar__tab')[index];
 				$(button).find('span.tab-name').replaceWith('<span class="tab-name">'+tab_name+'</span>');
 
 				EE.publish_layout[index]['id'] = tab_id;
@@ -378,7 +374,7 @@ $(document).ready(function () {
 
 		EE.publish_layout[tab].fields[field].width = this.value;
 	});
-	
+
 	// Saving the collapsed state
 	$('[data-publish] form').on('click', '.field-option-collapse input', function(e) {
 		var tab = getTabIndex();
@@ -390,11 +386,4 @@ $(document).ready(function () {
 	$('[data-publish] form').on('submit', function(e) {
 		$('input[name="field_layout"]').val(JSON.stringify(EE.publish_layout));
 	});
-
-	// put debug back
-	if ($('body .ee-main').length) {
-		$('body .ee-main').append(debug);
-	} else {
-		$('body').append(debug);
-	}
 });


### PR DESCRIPTION
We utilize the `cp_js_end` hook to add an SSO button to the `#idle-modal` in new tabs:

<img width="431" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/e2af6d7d-a50d-44c6-9447-b40ca779ca23">

But because of those new tabs in the modal, we're experiencing a bug on the Channel Layout page when adding new Tabs. The JS for this page currently operates on the entire DOM, so when it tries to determine the index for a new tab, it increments it not by one, but by 3 because it sees the 2 tabs that we added to the `#idle-modal` too. See how the new `rel` attribute is `t-9` when the previous tab's `rel` is `t-6` - I'd expect the new `rel` to be `t-7`.

<img width="600" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/939c07ac-8db3-463d-8ebf-c7f909088bae">

The issue that this causes is that when we create a new tab, we are unable to immediately drag fields to that tab, because the relevant section isn't created:

<img width="600" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/0931c146-b364-4383-9807-8f0249499be0">

---

This PR adds an ID to the Form:

<img width="600" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/cc7672dd-3d3e-46aa-af1f-9dba38ce83cb">

And then adjusts the JavaScript to only see the tabs in this form, rather than any tabs in the DOM, so the new tab ID is correct:

<img width="600" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/966b5277-68f6-43cb-8147-e957efe7326d">

And the new tab immediately has a section to drag/drop into:

<img width="600" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/39a7ece2-d0ce-458a-b189-640beaea0acd">


