### PR TITLE
Resolved #3841 where some characters in entry title might cause automatic url_title generation to not work

### DIFF
--- a/system/ee/ExpressionEngine/Service/Formatter/Formats/Text.php
+++ b/system/ee/ExpressionEngine/Service/Formatter/Formats/Text.php
@@ -62,7 +62,7 @@ class Text extends Formatter
 
             if (isset($accent_map[$ord])) {
                 $this->content .= $accent_map[$ord];
-            } else {
+            } elseif (mb_ord($char) !== false) { //make sure char is valid character
                 $this->content .= $char;
             }
         }

--- a/system/ee/ExpressionEngine/Service/Formatter/Formats/Text.php
+++ b/system/ee/ExpressionEngine/Service/Formatter/Formats/Text.php
@@ -52,17 +52,19 @@ class Text extends Formatter
 
         $this->content = '';
         foreach ($chars as $index => $char) {
-            $decoded = mb_convert_encoding($char, 'ISO-8859-1', 'UTF-8');
-
-            if ($decoded != '?') {
-                $char = $decoded;
+            if ($this->multibyte) {
+                $ord = mb_ord($char);
+            } else {
+                $decoded = utf8_decode($char);
+                if ($decoded != '?') {
+                    $char = $decoded;
+                }
+                $ord = ord($char);
             }
-
-            $ord = ord($char);
 
             if (isset($accent_map[$ord])) {
                 $this->content .= $accent_map[$ord];
-            } elseif (mb_ord($char) !== false) { //make sure char is valid character
+            } elseif ($ord !== false) { //make sure char is valid character
                 $this->content .= $char;
             }
         }

--- a/system/ee/ExpressionEngine/Service/Formatter/Formats/Text.php
+++ b/system/ee/ExpressionEngine/Service/Formatter/Formats/Text.php
@@ -55,9 +55,11 @@ class Text extends Formatter
             if ($this->multibyte) {
                 $ord = mb_ord($char);
             } else {
-                $decoded = utf8_decode($char);
-                if ($decoded != '?') {
-                    $char = $decoded;
+                if (function_exists('utf8_decode')) {
+                    $decoded = utf8_decode($char);
+                    if ($decoded != '?') {
+                        $char = $decoded;
+                    }
                 }
                 $ord = ord($char);
             }

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Formatter/TextFormatterTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Formatter/TextFormatterTest.php
@@ -501,6 +501,9 @@ And if you made it to this &#x1F573;&#xFE0F; you did pretty good.']
                 ],
                 'Sample-Title-to-Turn-Into-a-Slug-including-💩-tags-quotes-and-high-ascii-ssae-and-seps____in....content'
             ],
+            // ['ExpressionEngine®', [], 'expressionengine'],
+            ['Anča', [], 'anca'],
+            ['The General’s Room', [], 'the-generals-room'],
         ];
     }
 

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Formatter/TextFormatterTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Formatter/TextFormatterTest.php
@@ -462,11 +462,7 @@ And if you made it to this &#x1F573;&#xFE0F; you did pretty good.']
      */
     public function testUrlSlug($content, $params, $expected)
     {
-        // minimal map
-        $config['foreign_chars'] = [
-            '223' => "ss", // ß
-            '230' => "ae", // æ
-        ];
+        $config['foreign_chars'] = include SYSPATH . 'ee/ExpressionEngine/Config/foreign_chars.php';
 
         $config['stopwords'] = ['a', 'and', 'into', 'to'];
 
@@ -501,8 +497,9 @@ And if you made it to this &#x1F573;&#xFE0F; you did pretty good.']
                 ],
                 'Sample-Title-to-Turn-Into-a-Slug-including-💩-tags-quotes-and-high-ascii-ssae-and-seps____in....content'
             ],
-            // ['ExpressionEngine®', [], 'expressionengine'],
-            ['Anča', [], 'anca'],
+            ['ExpressionEngine®', [], 'expressionengine®'], // ® is in our Emoji map
+            ['Anča', [], 'ancha'],
+            ['Selçuk Ören', [], 'selcuk-oeren'],
             ['The General’s Room', [], 'the-generals-room'],
         ];
     }


### PR DESCRIPTION
Resolved #3841 where some characters in entry title might cause automatic url_title generation to not work
Resolved #3870 where converting text to ASCII might have not always worked properly

When adding PHP8.2 compatibility, we replaced `utf8_decode` with `mb_convert_encoding` here, which caused mapping to foreign character not work properly.

This fix is making direct use of `mb_ord` if it's available, and falling back to deprecated `mb_convert_encoding` if multibyte is  not available (this will throw deprecation error, but people should really have multibyte support if they run PHP 8.2 in 2023)