### PR TITLE
Resolved #3749 where TLS 1.3 was showing up as option in email settings for PHP versions that don't support it

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Settings/Email.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Email.php
@@ -34,9 +34,11 @@ class Email extends Settings
         $tls_options = array(
             STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT => '1.0',
             STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT => '1.1',
-            STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT => '1.2',
-            STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT => '1.3'
+            STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT => '1.2'
         );
+        if (version_compare(PHP_VERSION, 7.4, '>=')) {
+            $tls_options[STREAM_CRYPTO_METHOD_TLSv1_3_CLIENT] = '1.3';
+        }
         if (ee()->config->item('tls_crypto_method') !== false && ! array_key_exists(ee()->config->item('tls_crypto_method'), $tls_options)) {
             $tls_options[ee()->config->item('tls_crypto_method')] = ee()->config->item('tls_crypto_method'); //support custom value
         }


### PR DESCRIPTION
Resolved #3749 where TLS 1.3 was showing up as option in email settings for PHP versions that don't support it

EE6 version of https://github.com/ExpressionEngine/ExpressionEngine/pull/3877