### PR TITLE
Localize returning empty string

### DIFF
--- a/system/ee/legacy/libraries/Localize.php
+++ b/system/ee/legacy/libraries/Localize.php
@@ -61,7 +61,7 @@ class Localize
     public function string_to_timestamp($human_string, $localized = true, $date_format = null)
     {
         if (trim($human_string) == '') {
-            return '';
+            return false;
         }
 
         $dt = $this->_datetime($human_string, $localized, $date_format);


### PR DESCRIPTION
Localize::string_to_timestamp() was returning an empty string rather than false when passed an empty string argument.

When passing empty strings to Table::compareData() https://github.com/ExpressionEngine/ExpressionEngine/blob/ccbbf02bf9059a17cea5d994ac688022c94ced48/system/ee/ExpressionEngine/Library/CP/Table.php#L528C40-L528C40 they are treated as dates and compared as such on line https://github.com/ExpressionEngine/ExpressionEngine/blob/ccbbf02bf9059a17cea5d994ac688022c94ced48/system/ee/ExpressionEngine/Library/CP/Table.php#L557

Both $date_a and $date_b are empty strings at this point.

![image](https://github.com/ExpressionEngine/ExpressionEngine/assets/14264007/75884b0b-c410-45f9-b0b2-201f8c40304b)


As the doc-block in Localize Localize::string_to_timestamp() specifies that either an integer or false should be returned then this seemed the logical place to fix.

![image](https://github.com/ExpressionEngine/ExpressionEngine/assets/14264007/b0616dda-25c3-4ef2-b5eb-0ccb0a6de1db)
