### PR TITLE
Improved styles for Entry Status dropdown on Publish pages

### DIFF
--- a/cp-styles/app/styles/legacy/_status-tag.scss
+++ b/cp-styles/app/styles/legacy/_status-tag.scss
@@ -154,10 +154,10 @@ body[data-theme="dark"] {
     font-weight: inherit;
     text-transform: inherit;
     letter-spacing: inherit;
-    border: inherit;
+    // border: inherit;
     background-color: inherit !important;
-    padding: inherit;
-    color: inherit !important;
+    // padding: inherit;
+    // color: inherit !important;
     background: inherit;
     display: inherit;
     border-radius: inherit;
@@ -195,4 +195,33 @@ body[data-theme="dark"] {
     }
     */
   }
+}
+
+[data-input-value="status"] {
+	.select__button {
+		.status-tag {
+			border: inherit;
+			padding: inherit;
+		}
+	}
+
+	.select__dropdown {
+		.select__dropdown-item {
+			padding: 0;
+			min-height: 0;
+			margin-bottom: 5px;
+			border-radius: 1000px;
+
+			& > span {
+				width: 100%;
+			}
+		}
+
+		.status-tag {
+			min-height: 38px;
+			padding: 7px 15px;
+			width: 100%;
+			border-radius: 1000px;
+		}
+	}
 }

--- a/cp-styles/app/styles/legacy/_status-tag.scss
+++ b/cp-styles/app/styles/legacy/_status-tag.scss
@@ -21,18 +21,6 @@
   text-transform: none;
 	border-radius: $border-radius-full;
   white-space: nowrap;
-
-	// &::before {
-	// 	content: "";
-	// 	display: inline-block;
-	// 	position: relative;
-	// 	top: -1px;
-	// 	// vertical-align: middle;
-	// 	height: 7px;
-	// 	width: 7px;
-	// 	border-radius: 50%;
-	// 	margin-right: $s-xs
-	// }
 }
 
 .status-tag--big {
@@ -70,33 +58,6 @@
 		background: #ee0707;
 	}
 }
-
-/*
-body[data-theme="dark"] {
-	.st-open,
-	.st-enable,
-	.st-status,
-	.st-unlocked,
-
-	.status-tag--open {
-		background: rgba(231, 250, 240, 0.925);
-		color: #00b533;
-	}
-
-	.st-spam,
-	.st-error,
-	.st-closed,
-	.st-banned,
-	.st-locked,
-	.st-disable,
-
-	.status-tag--closed {
-		background: rgba(254, 237, 240, 0.925);
-		color: #ee0707;
-	}
-}
-*/
-
 
 // LEGACY 6.0
 .st-spam,
@@ -138,13 +99,6 @@ body[data-theme="dark"] {
 	color: color(accent);
 }
 
-// // firefox anomalies
-// @-moz-document url-prefix(){
-// 	.status-tag{
-// 		padding: 5px 5px 3px;
-// 	}
-// }
-
 // Status tag styling in select dropdowns
 .select__dropdown,
 .select__button {
@@ -154,46 +108,10 @@ body[data-theme="dark"] {
     font-weight: inherit;
     text-transform: inherit;
     letter-spacing: inherit;
-    // border: inherit;
     background-color: inherit !important;
-    // padding: inherit;
-    // color: inherit !important;
     background: inherit;
     display: inherit;
     border-radius: inherit;
-    // padding-left: 20px;
-
-    // Add colored beacon indicator
-    /*
-    &::before {
-      content: "";
-      width: 13px;
-      height: 13px;
-      display: block;
-      position: absolute;
-      left: 20px;
-      top: calc(50% - 7px);
-      border-radius: $border-radius-full;
-    }
-
-    &.st-open::before,
-    &.st-enable::before,
-    &.st-status::before,
-    &.st-unlocked::before,
-    &.status-tag--open::before {
-    	background-color: color(success);
-    }
-
-    &.st-spam::before,
-    &.st-error::before,
-    &.st-closed::before,
-    &.st-banned::before,
-    &.st-locked::before,
-    &.st-disable::before,
-    &.status-tag--closed::before {
-      background-color: color(danger);
-    }
-    */
   }
 }
 

--- a/themes/ee/cp/css/common.min.css
+++ b/themes/ee/cp/css/common.min.css
@@ -36416,10 +36416,7 @@ body[data-theme="dark"] {
   font-weight: inherit;
   text-transform: inherit;
   letter-spacing: inherit;
-  border: inherit;
   background-color: inherit !important;
-  padding: inherit;
-  color: inherit !important;
   background: inherit;
   display: inherit;
   border-radius: inherit;
@@ -36453,6 +36450,54 @@ body[data-theme="dark"] {
     background-color: color(danger);
   }
   */
+}
+
+[data-input-value=status] .select__button .status-tag, [data-input-value=status] .select__button .st-spam,
+[data-input-value=status] .select__button .st-error,
+[data-input-value=status] .select__button .st-closed,
+[data-input-value=status] .select__button .st-banned,
+[data-input-value=status] .select__button .st-open,
+[data-input-value=status] .select__button .st-draft,
+[data-input-value=status] .select__button .st-pending,
+[data-input-value=status] .select__button .st-info,
+[data-input-value=status] .select__button .st-note,
+[data-input-value=status] .select__button .st-warning,
+[data-input-value=status] .select__button .st-locked,
+[data-input-value=status] .select__button .st-unlocked,
+[data-input-value=status] .select__button .st-enable,
+[data-input-value=status] .select__button .st-disable,
+[data-input-value=status] .select__button .st-status {
+  border: inherit;
+  padding: inherit;
+}
+[data-input-value=status] .select__dropdown .select__dropdown-item {
+  padding: 0;
+  min-height: 0;
+  margin-bottom: 5px;
+  border-radius: 1000px;
+}
+[data-input-value=status] .select__dropdown .select__dropdown-item > span {
+  width: 100%;
+}
+[data-input-value=status] .select__dropdown .status-tag, [data-input-value=status] .select__dropdown .st-spam,
+[data-input-value=status] .select__dropdown .st-error,
+[data-input-value=status] .select__dropdown .st-closed,
+[data-input-value=status] .select__dropdown .st-banned,
+[data-input-value=status] .select__dropdown .st-open,
+[data-input-value=status] .select__dropdown .st-draft,
+[data-input-value=status] .select__dropdown .st-pending,
+[data-input-value=status] .select__dropdown .st-info,
+[data-input-value=status] .select__dropdown .st-note,
+[data-input-value=status] .select__dropdown .st-warning,
+[data-input-value=status] .select__dropdown .st-locked,
+[data-input-value=status] .select__dropdown .st-unlocked,
+[data-input-value=status] .select__dropdown .st-enable,
+[data-input-value=status] .select__dropdown .st-disable,
+[data-input-value=status] .select__dropdown .st-status {
+  min-height: 38px;
+  padding: 7px 15px;
+  width: 100%;
+  border-radius: 1000px;
 }
 
 .icon--add:before {

--- a/themes/ee/cp/css/common.min.css
+++ b/themes/ee/cp/css/common.min.css
@@ -36336,31 +36336,6 @@ ul.field-reorder-drop,
   background: #ee0707;
 }
 
-/*
-body[data-theme="dark"] {
-	.st-open,
-	.st-enable,
-	.st-status,
-	.st-unlocked,
-
-	.status-tag--open {
-		background: rgba(231, 250, 240, 0.925);
-		color: #00b533;
-	}
-
-	.st-spam,
-	.st-error,
-	.st-closed,
-	.st-banned,
-	.st-locked,
-	.st-disable,
-
-	.status-tag--closed {
-		background: rgba(254, 237, 240, 0.925);
-		color: #ee0707;
-	}
-}
-*/
 .st-draft {
   background-color: var(--ee-bg-blank);
   border-color: #CCCCCC;
@@ -36420,36 +36395,6 @@ body[data-theme="dark"] {
   background: inherit;
   display: inherit;
   border-radius: inherit;
-  /*
-  &::before {
-    content: "";
-    width: 13px;
-    height: 13px;
-    display: block;
-    position: absolute;
-    left: 20px;
-    top: calc(50% - 7px);
-    border-radius: $border-radius-full;
-  }
-
-  &.st-open::before,
-  &.st-enable::before,
-  &.st-status::before,
-  &.st-unlocked::before,
-  &.status-tag--open::before {
-  	background-color: color(success);
-  }
-
-  &.st-spam::before,
-  &.st-error::before,
-  &.st-closed::before,
-  &.st-banned::before,
-  &.st-locked::before,
-  &.st-disable::before,
-  &.status-tag--closed::before {
-    background-color: color(danger);
-  }
-  */
 }
 
 [data-input-value=status] .select__button .status-tag, [data-input-value=status] .select__button .st-spam,


### PR DESCRIPTION
Improved Entry status styles; Fixes #2856 

This is implementing styles that were originally planned for 6.0 in https://packettide.atlassian.net/browse/EECORE-557

<img width="1036" alt="Screenshot 2023-11-29 at 22 05 32" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/23382425/4308baf3-1ca2-4d77-911c-87d992d48a32">
