### PR TITLE
Resolved issue where saving entry with Fluid field using groups could throw PHP error if field was removed from group

### DIFF
--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -107,7 +107,15 @@ class Fluid_field_ft extends EE_Fieldtype
                         continue;
                     }
 
-                    $field = clone $field_templates[$field_id];
+                    // the field might be present, but not in the settings currently
+                    if (isset($field_templates[$field_id])) {
+                        $field = clone $field_templates[$field_id];
+                    } else {
+                        $field = ee('Model')->get('ChannelField', $field_id)->first();
+                        if (empty($field)) {
+                            continue;
+                        }
+                    }
 
                     $f = $field->getField();
                     $ft_instance = $f->getNativeField();


### PR DESCRIPTION
The original issue:
- have a fluid using field group "news" with 2 fields
- create and entry with Fluid field, add "news" block
- remove second field from the group
- try to save entry
- get the error