### PR TITLE
Add Named Navs to Structure

### DIFF
--- a/system/ee/ExpressionEngine/Addons/structure/addon.json
+++ b/system/ee/ExpressionEngine/Addons/structure/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Structure",
     "shortname": "structure",
-    "version": "6.1.1",
+    "version": "6.1.0",
     "description": "Create pages, generate navigation, manage content through a simple interface and build robust sites faster than ever.",
     "license": "ExpressionEngine",
     "namespace": "ExpressionEngine\\Structure",

--- a/system/ee/ExpressionEngine/Addons/structure/addon.json
+++ b/system/ee/ExpressionEngine/Addons/structure/addon.json
@@ -1,7 +1,7 @@
 {
     "name": "Structure",
     "shortname": "structure",
-    "version": "6.0.0",
+    "version": "6.1.1",
     "description": "Create pages, generate navigation, manage content through a simple interface and build robust sites faster than ever.",
     "license": "ExpressionEngine",
     "namespace": "ExpressionEngine\\Structure",

--- a/system/ee/ExpressionEngine/Addons/structure/mcp.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/mcp.structure.php
@@ -828,7 +828,7 @@ class Structure_mcp
             'field_name' => 'named_navs'
         ));
         $grid->loadAssets();
-        $grid->setColumns(['ID', 'Navigation Name', 'Site']);
+        $grid->setColumns([lang('nav_id'), lang('nav_name'), lang('site')]);
         $grid->setNoResultsText(lang('no_named_navs'), lang('add_new'));
         $grid->setBlankRow(array(
             array('html' =>  ''),

--- a/system/ee/ExpressionEngine/Addons/structure/mcp.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/mcp.structure.php
@@ -760,6 +760,7 @@ class Structure_mcp
         $this->set_cp_title('cp_module_settings_title');
 
         $settings = $this->sql->get_settings();
+        $named_navs = $this->sql->get_named_navs();
         $groups = $this->sql->get_member_groups();
 
         // Check if we have admin permission
@@ -779,6 +780,8 @@ class Structure_mcp
         $vars['groups'] = $groups;
         $vars['perms'] = $this->perms;
         $vars['settings'] = $settings;
+        $vars['named_navs'] = $named_navs;
+        $vars['named_nav_grid'] = $this->getNamedNavMiniGrid($named_navs);
         $vars['permissions'] = $permissions;
         $vars['extension_is_installed'] = $this->sql->extension_is_installed();
         $vars['redirect_types'] = array(
@@ -812,6 +815,47 @@ class Structure_mcp
         return ee()->general_helper->view('module_settings', $vars, true);
     }
 
+    protected function getNamedNavMiniGrid($named_navs)
+    {
+        // Get list of sites and build select options
+        $site_select_options = array();
+        $sites = ee()->db->select('site_id, site_label')->get('sites')->result_array();
+        foreach ($sites as $site) {
+            $site_select_options[$site['site_id']] = $site['site_label'];
+        }
+
+        $grid = ee('CP/MiniGridInput', array(
+            'field_name' => 'named_navs'
+        ));
+        $grid->loadAssets();
+        $grid->setColumns(['ID', 'Navigation Name', 'Site']);
+        $grid->setNoResultsText(lang('no_named_navs'), lang('add_new'));
+        $grid->setBlankRow(array(
+            array('html' =>  ''),
+            array('html' => form_input('nav_name', '')),
+            array('html' => form_dropdown('site_id', $site_select_options, set_value('site_id', ee()->config->item('site_id'))))
+        ));
+        $grid->setData(array());
+
+        if (!empty($named_navs)) {
+            $pairs = array();
+            foreach ($named_navs as $nav) {
+                $pairs[] = array(
+                    'attrs' => array('row_id' => $nav['id']),
+                    'columns' => array(
+                        array('html' => $nav['id']),
+                        array('html' => form_input('nav_name', $nav['nav_name'])),
+                        array('html' => form_dropdown('site_id', $site_select_options, set_value('site_id', $nav['site_id'])))
+                    )
+                );
+            }
+
+            $grid->setData($pairs);
+        }
+
+        return $grid;
+    }
+
     // Process form data from the module settings area
     public function module_settings_submit()
     {
@@ -823,6 +867,22 @@ class Structure_mcp
 
         // insert settings into DB
         foreach ($_POST as $key => $value) {
+            if($key == 'named_navs') {
+                // First, delete all existing named navs
+                ee()->db->where('site_id', $site_id)->delete('structure_named_navs');
+
+                $navs = $value['rows'];
+                foreach($navs as $id => $nav) {
+                    // if $id is row_id_X then it's an existing row, so we add the id so its the same
+                    if(strpos($id, 'row_id_') !== false) {
+                        $id = str_replace('row_id_', '', $id);
+                        $nav['id'] = $id;
+                    }
+
+                    ee()->db->insert('structure_named_navs', $nav);
+                }
+                continue;
+            }
             // Good heavens, this is just plain ghetto. If there is no "perm", it's a "setting"
             // if if there's no "perm" AND it's not a number, then it's a multi-option permission.
             $value = strpos($key, 'perm_') === 0 && is_numeric($value) ? 'y' : $value;

--- a/system/ee/ExpressionEngine/Addons/structure/tab.structure.php
+++ b/system/ee/ExpressionEngine/Addons/structure/tab.structure.php
@@ -132,6 +132,8 @@ class Structure_tab
             $entry_id = ee()->input->get_post('entry_id') !== false ? ee()->input->get_post('entry_id') : 0;
         }
 
+        $named_navs = $this->sql->get_named_navs($site_id);
+
         $data = $this->sql->get_data();
         $cids = isset($data['channel_ids']) ? $data['channel_ids'] : array();
         $lcids = isset($data['listing_cids']) ? $data['listing_cids'] : array();
@@ -276,6 +278,33 @@ class Structure_tab
                 'field_text_direction'  => 'ltr',
                 'field_type'            => 'select'
             );
+
+            /** -------------------------------------
+            /**  Field: Hide From Nav
+            /** -------------------------------------*/
+
+            // If the user set up named navs, show the option to hide from them
+            if(!empty($named_navs)) {
+
+                // Make array of named navs - named_nav_id -> named_nav_name
+                $named_nav_options = array_combine(array_column($named_navs, 'id'), array_column($named_navs, 'nav_name'));
+                $hidden_from_named_nav_setting = $this->sql->get_hidden_from_named_nav_state($entry_id);
+
+                $settings['hidden_from_named_nav'] = array(
+                    'field_id'              => 'hidden_from_named_nav',
+                    'field_label'           => 'Hidden From Named Navs',
+                    'field_required'        => 'n',
+                    'field_data'            => $hidden_from_named_nav_setting,
+                    'field_list_items'      => $named_nav_options,
+                    'field_fmt'             => '',
+                    'field_instructions'    => 'Hide this entry from the following named navs',
+                    'field_show_fmt'        => 'n',
+                    'field_fmt_options'     => '',
+                    'field_pre_populate'    => 'n',
+                    'field_text_direction'  => 'ltr',
+                    'field_type'            => 'checkboxes'
+                );
+            }
         }
 
         /** -------------------------------------
@@ -497,6 +526,8 @@ class Structure_tab
             }
         }
 
+        $hidden_from_named_nav = $params['hidden_from_named_nav'];
+
         // assign the hidden setting
         if (isset($params['hidden'])) {
             $hidden = $params['hidden']; // EE3
@@ -596,14 +627,15 @@ class Structure_tab
             if ($channel_type == 'page') {
                 // get form fields
                 $data = array(
-                    'site_id'       => intval($site_id),
-                    'channel_id'    => intval($channel_id),
-                    'entry_id'      => intval($entry_id),
-                    'uri'           => $uri,
-                    'template_id'   => intval($template_id),
-                    'hidden'        => $hidden,
-                    'listing_cid'   => intval($listing_channel),
-                    'structure_uri' => $structure_uri
+                    'site_id'               => intval($site_id),
+                    'channel_id'            => intval($channel_id),
+                    'entry_id'              => intval($entry_id),
+                    'uri'                   => $uri,
+                    'template_id'           => intval($template_id),
+                    'hidden'                => $hidden,
+                    'hidden_from_named_nav' => $hidden_from_named_nav,
+                    'listing_cid'           => intval($listing_channel),
+                    'structure_uri'         => $structure_uri
                 );
 
                 $data['parent_id'] = intval($parent_id);

--- a/system/ee/ExpressionEngine/Addons/structure/views/module_settings.php
+++ b/system/ee/ExpressionEngine/Addons/structure/views/module_settings.php
@@ -98,7 +98,7 @@
 
 
 <div class="container">
-    <div class="padder ee7 structure-gui">
+    <div class="padder ee7 structure-gui module_settings">
         <h2>Named Navigations</h2>
         <?= ee('View')->make('ee:_shared/form/mini_grid')->render($named_nav_grid->viewData()) ?>
     </div>

--- a/system/ee/ExpressionEngine/Addons/structure/views/module_settings.php
+++ b/system/ee/ExpressionEngine/Addons/structure/views/module_settings.php
@@ -72,7 +72,8 @@
                 </td>
             </tr>
         <?php else : ?>
-            <?php $i = 0; foreach ($perms as $perm_id => $perm) : ?>
+            <?php $i = 0;
+            foreach ($perms as $perm_id => $perm) : ?>
                 <tr class="<?php echo ($i++ % 2) ? 'even' : 'odd'; ?>">
                     <td><?=$perm?></td>
                     <?php foreach ($groups as $group) :
@@ -93,6 +94,15 @@
         <?php endif; ?>
     </tbody>
 </table>
+
+
+
+<div class="container">
+    <div class="padder ee7 structure-gui">
+        <h2>Named Navigations</h2>
+        <?= ee('View')->make('ee:_shared/form/mini_grid')->render($named_nav_grid->viewData()) ?>
+    </div>
+</div>
 
 <button type="submit" class="submit btn action">Save Module Settings</button>
 

--- a/system/ee/language/english/structure_lang.php
+++ b/system/ee/language/english/structure_lang.php
@@ -97,6 +97,9 @@ $lang = array(
     'access_edit'                   => 'Can access edit',
     'access_structure'              => 'Can access Structure',
 
+    'no_named_navs'                 => 'No named navigations have been created yet.',
+    'add_a_row'                     => 'Add a row',
+
     'settings_manage'               => 'Manage',
     'settings_reorder'              => 'Reorder',
     'settings_options'              => 'Options',

--- a/system/ee/language/english/structure_lang.php
+++ b/system/ee/language/english/structure_lang.php
@@ -99,6 +99,9 @@ $lang = array(
 
     'no_named_navs'                 => 'No named navigations have been created yet.',
     'add_a_row'                     => 'Add a row',
+    'nav_id'                        => 'Nav ID',
+    'nav_name'                      => 'Navigation Name',
+    'site'                          => 'Site',
 
     'settings_manage'               => 'Manage',
     'settings_reorder'              => 'Reorder',

--- a/themes/ee/structure/css/structure.css
+++ b/themes/ee/structure/css/structure.css
@@ -2128,6 +2128,24 @@ body[data-ee-version^="7."] #structure-ui .page-ui div.page-controls span i {
     display: none;
 }
 
+.structure-gui.module_settings h2 { margin-bottom: 30px; }
+
+.structure-gui.module_settings .field-no-results { background: var(--ee-panel-bg); }
+
+.structure-gui.module_settings .ui-sortable { background: none; }
+
+.structure-gui.module_settings .fields-keyvalue-item .field-control:first-of-type {
+  max-width: 42px;
+  display: inline-flex;
+  align-items: center;
+ }
+
+.structure-gui.module_settings select { width: 100%; }
+
+.structure-gui.module_settings .fields-keyvalue-header { margin-bottom: 10px; }
+
+.structure-gui.module_settings .fields-keyvalue-header .field-instruct:first-of-type { max-width: 42px; }
+
 @media screen and (max-width: 767px) {
     body[data-ee-version^="6."] #structure-ui .page-ui div.page-controls span a,
     body[data-ee-version^="7."] #structure-ui .page-ui div.page-controls span a {


### PR DESCRIPTION
Add the concept of "Named Navigations" to Structure. This allows you to specify a name to your navigation in your nav tags, and then hide certain entries from a single nav.

Instructions:

- Go to Module settings and scroll to "Named Navigations"
- Add new navigations. Example: Top, Side (You can add as many or as few as you need)
- Once these have been added, you can specifiy the name of a navigation in the templates, by using the "named_nav" tag parameter. This is how structure knows which tag actually is a "Side" nav or a "Top" nav. Your updated templates will look something like this:

```
{exp:structure:nav_advanced
  show_depth="1"
  start_from="/{segment_1}/"
  named_nav="Top"
}
```
- You can then hide entries from a particular navigation from the Structure tag in the Entry Create/Edit screen.