### PR TITLE
Fix field_required warning in CP for Pro Variables/Grid with null

### DIFF
--- a/system/ee/ExpressionEngine/Addons/grid/ft.grid.php
+++ b/system/ee/ExpressionEngine/Addons/grid/ft.grid.php
@@ -842,7 +842,7 @@ class Grid_ft extends EE_Fieldtype
         ee()->grid_lib->entry_id = ($this->content_id() == null) ? $entry_id : $this->content_id();
         ee()->grid_lib->field_id = $this->id();
         ee()->grid_lib->field_name = $this->name();
-        ee()->grid_lib->field_required = $this->settings['field_required'];
+        ee()->grid_lib->field_required = $this->settings['field_required'] ?? 'n';
         ee()->grid_lib->content_type = $this->content_type();
         ee()->grid_lib->fluid_field_data_id = (isset($this->settings['fluid_field_data_id'])) ? $this->settings['fluid_field_data_id'] : 0;
         ee()->grid_lib->in_modal_context = $this->get_setting('in_modal_context');


### PR DESCRIPTION
Porting over 7.x fix https://github.com/ExpressionEngine/ExpressionEngine/commit/8e421a589261ec8afb4d29c8238d3b5492f761e3

