### PR TITLE
Resolved #3989 where Role permissions could have been saved during validation request

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Roles/Roles.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Roles/Roles.php
@@ -567,21 +567,27 @@ class Roles extends AbstractRolesController
                 }
             }
         } else {
-            // Clear the slate and remove all the permissions this form has set
-            ee('Model')->get('Permission')
+            $existingRolePermissions = ee('Model')->get('Permission')
                 ->filter('permission', 'IN', $this->getPermissionKeys())
                 ->filter('site_id', $site_id)
                 ->filter('role_id', $role->getId())
-                ->delete();
-
+                ->all();
+            $existingRolePermissionNames = $existingRolePermissions->pluck('permission');
+            // remove the permissions that are no longer allowed
+            foreach ($existingRolePermissions as $permission) {
+                $permIndex = array_search($permission->permission, $allowed_perms);
+                if ($permIndex === false || empty($allowed_perms[$permIndex])) {
+                    $role->Permissions->getAssociation()->remove($permission);
+                }
+            }
             // Add back in all the allowances
             foreach ($allowed_perms as $perm) {
-                if (!empty($perm)) {
-                    ee('Model')->make('Permission', [
-                        'role_id' => $role->getId(),
+                if (!empty($perm) && !in_array($perm, $existingRolePermissionNames)) {
+                    $p = ee('Model')->make('Permission', [
                         'site_id' => $site_id,
                         'permission' => $perm
-                    ])->save();
+                    ]);
+                    $role->Permissions->getAssociation()->add($p);
                 }
             }
         }

--- a/system/ee/legacy/core/Output.php
+++ b/system/ee/legacy/core/Output.php
@@ -571,7 +571,7 @@ class EE_Output
             ->filter('site_id', ee()->config->item('site_id'))
             ->filter('group_name', 'system_messages')->first();
 
-        if (! empty($template_group)) {
+        if (isset(ee()->session) && ! empty($template_group)) {
             $template = ee('Model')->get('Template')
                 ->filter('site_id', ee()->config->item('site_id'))
                 ->filter('group_id', $template_group->group_id)

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -126,7 +126,7 @@ class EE_Core
         ee('App')->setupAddons(PATH_THIRD);
 
         //is this pro version?
-        if (isset(ee()->session) && ee('Addon')->get('pro') && ee('Addon')->get('pro')->isInstalled()) {
+        if (ee('Addon')->get('pro') && ee('Addon')->get('pro')->isInstalled()) {
             define('IS_PRO', true);
         } else {
             define('IS_PRO', false);

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -126,7 +126,7 @@ class EE_Core
         ee('App')->setupAddons(PATH_THIRD);
 
         //is this pro version?
-        if (ee('Addon')->get('pro') && ee('Addon')->get('pro')->isInstalled()) {
+        if (isset(ee()->session) && ee('Addon')->get('pro') && ee('Addon')->get('pro')->isInstalled()) {
             define('IS_PRO', true);
         } else {
             define('IS_PRO', false);

--- a/tests/cypress/cypress/integration/member_roles/member_roles_members.ee6.js
+++ b/tests/cypress/cypress/integration/member_roles/member_roles_members.ee6.js
@@ -97,6 +97,51 @@ context('Test Member roles Members ', () => {
 	   cy.contains('You are not authorized')
 	})
 
+	it('Cannot access member roles before permissions saved', () => {
+		cy.auth();
+
+		cy.visit('admin.php?/cp/members/roles')
+
+		cy.get('div[class="list-item__title"]').contains('MemberManager').parent().find('.list-item__secondary').click()
+
+		cy.get('button').contains('CP Access').click()
+
+		cy.get('#fieldset-can_admin_roles .toggle-btn').click();
+		cy.get('#fieldset-role_actions .checkbox-label:nth-child(1) > input').click();
+		cy.get('#fieldset-role_actions .checkbox-label:nth-child(2) > input').click();
+		cy.get('#fieldset-role_actions .checkbox-label:nth-child(3) > input').click();
+
+		cy.logout()
+		
+		cy.auth({
+			email: 'MemberManager1',
+			password: 'password'
+		})
+
+	   cy.visit('admin.php?/cp/members/roles',{failOnStatusCode:false})
+
+	   cy.on('uncaught:exception', (err, runnable) => {
+			    expect(err.message).to.include('something about the error')
+			    done()
+			    return false
+		}) //got this block off of cypress docs
+	   cy.contains('You are not authorized')
+
+	   cy.logout()
+	   cy.auth();
+
+		cy.visit('admin.php?/cp/members/roles')
+
+		cy.get('div[class="list-item__title"]').contains('MemberManager').parent().find('.list-item__secondary').click()
+
+		cy.get('button').contains('CP Access').click()
+
+		cy.get('#fieldset-can_admin_roles .toggle-btn').click();
+		cy.get('#fieldset-role_actions .checkbox-label:nth-child(1) > input').should('not.be.checked');
+		cy.get('#fieldset-role_actions .checkbox-label:nth-child(2) > input').should('not.be.checked');
+		cy.get('#fieldset-role_actions .checkbox-label:nth-child(3) > input').should('not.be.checked');
+	})
+
 	it('Can accecss member roles after it is assigned',() =>{
 		cy.auth();
 
@@ -112,6 +157,7 @@ context('Test Member roles Members ', () => {
 		cy.get('#fieldset-role_actions .checkbox-label:nth-child(1) > input').click();
 		cy.get('#fieldset-role_actions .checkbox-label:nth-child(2) > input').click();
 		cy.get('#fieldset-role_actions .checkbox-label:nth-child(3) > input').click();
+		cy.get('body').type('{ctrl}', {release: false}).type('s')
 
 		cy.logout()
 
@@ -199,4 +245,3 @@ function logout(){
   cy.get('.main-nav__account-icon > img').click()
   cy.get('[href="admin.php?/cp/login/logout"]').click()
 }
-

--- a/tests/cypress/cypress/integration/member_roles/member_roles_utilities.ee6.js
+++ b/tests/cypress/cypress/integration/member_roles/member_roles_utilities.ee6.js
@@ -79,6 +79,7 @@ context('Test Member roles Utilities ', () => {
 
 
 		cy.get('.field-inputs:nth-child(1) > .nestable-item:nth-child(1) > .checkbox-label > input').last().click(); //turn off access to communicate
+		cy.get('body').type('{ctrl}', {release: false}).type('s')
 		cy.logout()
 
 		cy.auth({
@@ -127,6 +128,7 @@ context('Test Member roles Utilities ', () => {
 
 
 		cy.get('.field-inputs:nth-child(1) > .nestable-item:nth-child(2) input').last().click(); //turn off access to Translations
+		cy.get('body').type('{ctrl}', {release: false}).type('s')
 		cy.logout()
 
 		cy.auth({
@@ -175,6 +177,7 @@ context('Test Member roles Utilities ', () => {
 
 		cy.get('.field-inputs:nth-child(1) > .nestable-item:nth-child(3) input').click();
  				//turn off access to Imports
+		cy.get('body').type('{ctrl}', {release: false}).type('s')
 		cy.logout()
 
 		cy.auth({
@@ -229,6 +232,7 @@ context('Test Member roles Utilities ', () => {
 			cy.get('.field-inputs:nth-child(1) > .nestable-item:nth-child(4) input').click();
 
  				//turn off access to SQL
+		cy.get('body').type('{ctrl}', {release: false}).type('s')
 		cy.logout()
 
 		cy.auth({


### PR DESCRIPTION
Resolved #3989 where Role permissions could have been saved during validation request


EE6 version of #3991

This PR also includes check whether session is set when checking for Pro. This helps to avoid "session is not defined" message when custom system messages are enabled and extension file is missing (note that the fix is different from what is in https://github.com/ExpressionEngine/ExpressionEngine/pull/3994 )

