### PR TITLE
Resolved issue where error message was not using custom system message template if an extension file was missing

### DIFF
--- a/system/ee/legacy/libraries/Extensions.php
+++ b/system/ee/legacy/libraries/Extensions.php
@@ -154,6 +154,13 @@ class EE_Extensions
 
         if ($automatically_load_path) {
             if (! file_exists($extension_path)) {
+                $error = 'Unable to load the following extension file:<br /><br />' . 'ext.' . $name . '.php';
+
+                //if this is early loaded extension, and the session is not set yet
+                //we have no other solution that just show the error
+                if (!isset(ee()->session)) {
+                    return ee()->output->fatal_error($error);
+                }
 
                 $can_view_system = false;
                 if (
@@ -173,7 +180,6 @@ class EE_Extensions
                 if (REQ != 'ACTION' && $can_view_system !== true) {
                     return ee()->output->system_off_msg();
                 }
-                $error = 'Unable to load the following extension file:<br /><br />' . 'ext.' . $name . '.php';
 
                 return ee()->output->fatal_error($error);
             }


### PR DESCRIPTION
Steps to replicate:

1) Create custom system message template https://docs.expressionengine.com/latest/control-panel/template-manager.html#custom-system-messages
2) Install Pro Variables
3) Remove ext.pro_variables file
4) The error is wrong and not using the custom template

This PR is partially reverting behavior introduced in https://github.com/ExpressionEngine/ExpressionEngine/commit/1ed289ea918156def3e7141852fd5533c2ed0b91 but I think we have no other way around