### PR TITLE
Resolved #3910 where JavaScript to encode / decode email addresses was using deprecated function

### DIFF
--- a/system/ee/legacy/helpers/url_helper.php
+++ b/system/ee/legacy/helpers/url_helper.php
@@ -324,8 +324,8 @@ if (! function_exists('safe_mailto')) {
         foreach ($x as $val) { ?>l[<?php echo $i++; ?>]='<?php echo $val; ?>';<?php } ?>
 
 	for (var i = l.length-1; i >= 0; i=i-1){
-	if (l[i].substring(0, 1) == '|') document.write("&#"+unescape(l[i].substring(1))+";");
-	else document.write(unescape(l[i]));}
+	if (l[i].substring(0, 1) == '|') document.write("&#"+decodeURIComponent(l[i].substring(1))+";");
+	else document.write(decodeURIComponent(l[i]));}
 	//]]>
 	</script><?php
 

--- a/system/ee/legacy/libraries/Typography.php
+++ b/system/ee/legacy/libraries/Typography.php
@@ -2251,7 +2251,7 @@ var out = '',
 	j = el.length;
 
 while (--i >= 0)
-	out += unescape(l[i].replace(/^\s\s*/, '&#'));
+	out += decodeURIComponent(l[i].replace(/^\s\s*/, '&#'));
 
 while (--j >= 0)
 	if (el[j].getAttribute('<?php echo $span_marker ?>'))


### PR DESCRIPTION
Resolved #3910 where Javascript to encode/decode email addresses uses deprecated 'unescape' function
change `unescape` function -> `decodeURIComponent` function