### PR TITLE
Add ability to forward URL parameters with template redirect tag

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Settings/DebugOutput.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/DebugOutput.php
@@ -93,6 +93,13 @@ class DebugOutput extends Settings
                     )
                 ),
                 array(
+                    'title' => 'redirect_forward_url_parameters',
+                    'desc' => 'redirect_forward_url_parameters_desc',
+                    'fields' => array(
+                        'redirect_forward_url_parameters' => array('type' => 'yes_no')
+                    )
+                ),
+                array(
                     'title' => 'caching_driver',
                     'desc' => 'caching_driver_desc',
                     'fields' => array(

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -297,6 +297,10 @@ $lang = array(
 
     'redirect_method_opt_refresh' => 'Refresh (Windows only)',
 
+    'redirect_forward_url_parameters' => 'Forward URL parameters in template redirect tags?',
+
+    'redirect_forward_url_parameters_desc' => 'When enabled, <code>{redirect=\'\'}</code> tags in templates will forward all URL parameters to the destination URL.',
+
     'send_headers' => 'Use <abbr title="Hypertext Transfer Protocol">HTTP</abbr> page headers?',
 
     'send_headers_desc' => 'When enabled, your website will generate <abbr title="Hypertext Transfer Protocol">HTTP</abbr> headers for all pages.',

--- a/system/ee/legacy/libraries/Functions.php
+++ b/system/ee/legacy/libraries/Functions.php
@@ -415,7 +415,7 @@ class EE_Functions
      * @param string
      * @return void
      */
-    public function redirect($location, $method = false, $status_code = null)
+    public function redirect($location, $method = false, $status_code = null, $forward_url_parameters = false)
     {
         // Remove hard line breaks and carriage returns
         $location = str_replace(array("\n", "\r"), '', $location);
@@ -427,6 +427,14 @@ class EE_Functions
 
         $location = $this->insert_action_ids($location);
         $location = ee()->uri->reformat($location);
+
+        if ($forward_url_parameters) {
+            $query = ee()->input->server('QUERY_STRING');
+
+            if ($query !== '') {
+                $location .= '?' . $query;
+            }
+        }
 
         if (isset(ee()->session) && count(ee()->session->flashdata)) {
             // Ajax requests don't redirect - serve the flashdata

--- a/system/ee/legacy/libraries/Functions.php
+++ b/system/ee/legacy/libraries/Functions.php
@@ -432,7 +432,14 @@ class EE_Functions
             $query = ee()->input->server('QUERY_STRING');
 
             if ($query !== '') {
-                $location .= '?' . $query;
+                // Parse query strings as arrays. Then merge them to recreate the param string.
+                parse_str($query, $query_params);
+                parse_str(parse_url($location, PHP_URL_QUERY) ?? '', $location_query);
+                $query = http_build_query(array_merge($query_params, $location_query));
+
+                // Rebuild the redirect URL with the updated parameters
+                $path = explode('?', $location)[0];
+                $location = $path . '?' . $query;
             }
         }
 

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3148,7 +3148,8 @@ class EE_Template
                     ee()->functions->redirect(
                         ee()->functions->create_url(ee()->functions->extract_path("=" . $match['2'])),
                         false,
-                        $status_code
+                        $status_code,
+                        ee()->config->item('redirect_forward_url_parameters') === 'y'
                     );
                 }
             }

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3006,7 +3006,12 @@ class EE_Template
                     return $this->no_results;
                 }
             } else {
-                ee()->functions->redirect(ee()->functions->create_url(ee()->functions->extract_path("=" . $match[2])));
+                ee()->functions->redirect(
+                    ee()->functions->create_url(ee()->functions->extract_path("=" . $match[2])),
+                    false,
+                    null,
+                    ee()->config->item('redirect_forward_url_parameters') === 'y'
+                );
             }
         }
     }
@@ -3134,6 +3139,7 @@ class EE_Template
                     // If the status code isn't a 3xx redirect code, it will be ignored
                     // by redirect().
                     $status_code = null;
+                    $forward_url_parameters = ee()->config->item('redirect_forward_url_parameters') === 'y';
 
                     if (isset($match[5])) {
                         $status_code = $match[5];
@@ -3141,7 +3147,12 @@ class EE_Template
 
                     // handle full URLs, don't need to prepend site details
                     if (filter_var($match[2], FILTER_VALIDATE_URL)) {
-                        ee()->functions->redirect($match[2], false, $status_code);
+                        ee()->functions->redirect(
+                            $match[2],
+                            false,
+                            $status_code,
+                            $forward_url_parameters
+                        );
                     }
 
                     // Functions::redirect() exits on its own
@@ -3149,7 +3160,7 @@ class EE_Template
                         ee()->functions->create_url(ee()->functions->extract_path("=" . $match['2'])),
                         false,
                         $status_code,
-                        ee()->config->item('redirect_forward_url_parameters') === 'y'
+                        $forward_url_parameters
                     );
                 }
             }


### PR DESCRIPTION
This will add a setting and functionality to optionally forward URL parameters when the `{redirect=''}` tag is called in a template.

New setting in `Settings` > `Debugging & Output`:

<img width="592" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/35d5890b-13e2-4453-bd40-0e6c1d7ade86">

Additionally, `$config['redirect_forward_url_parameters'] = 'y';` (or `'n'`) can be added to `config.php` to control this behavior instead of toggling it in the CP.

To test this, create a new template like `redirect.group/index.html` with only `{redirect='/'}` (or add a redirect tag to an existing template if that's easier).

With the new setting turned off, go to `/redirect?utm_test=thing` in the browser, and you should land on the homepage without the URL parameters. Note the `GET` URL and the `Location` URL:

<img width="1552" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/f8d155c0-b93c-4814-bcc6-98dbe3141e4f">

With the new setting turned on, go to `/redirect?utm_test=thing` again, and you should land on the homepage with `?utm_test=thing` appended. Note the `GET` URL and the `Location` URL:

<img width="1552" alt="image" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/2423727/96bb23b7-70b5-496a-abc5-bffdeec9a28a">
