### PR TITLE
Improve performance in conditional field sync utility

### DIFF
--- a/system/ee/ExpressionEngine/Cli/Commands/CommandSyncConditionalFieldLogic.php
+++ b/system/ee/ExpressionEngine/Cli/Commands/CommandSyncConditionalFieldLogic.php
@@ -111,7 +111,7 @@ class CommandSyncConditionalFieldLogic extends Cli
 
                 // Evaluate the conditions and save
                 $entry->evaluateConditionalFields();
-                $entry->save();
+                $entry->HiddenFields->save();
 
                 unset($entry);
 
@@ -128,6 +128,14 @@ class CommandSyncConditionalFieldLogic extends Cli
 
             unset($entries);
         }
+
+        // clear caches
+        if (ee()->config->item('new_posts_clear_caches') == 'y') {
+            ee()->functions->clear_caching('all');
+        } else {
+            ee()->functions->clear_caching('sql');
+        }
+
 
         // End timer
         $endtime = microtime(true);

--- a/system/ee/ExpressionEngine/Controller/Utilities/SyncConditionalFields.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/SyncConditionalFields.php
@@ -229,8 +229,15 @@ class SyncConditionalFields extends Utilities
             if ($entry->conditionalFieldsOutdated()) {
                 // Conditional fields are outdated, so we evaluate the conditions and save
                 $entry->evaluateConditionalFields();
-                $entry->save();
+                $entry->HiddenFields->save();
             }
+        }
+
+        // clear caches
+        if (ee()->config->item('new_posts_clear_caches') == 'y') {
+            ee()->functions->clear_caching('all');
+        } else {
+            ee()->functions->clear_caching('sql');
         }
 
         return json_encode([


### PR DESCRIPTION
Only save the HiddenFields relation after the logic is evaluated.  This reduces unnecessary side effects from saving the entire ChannelEntry model.
