### PR TITLE
Added fallback for PHP `tmpfile()` function when it's not enabled

### DIFF
--- a/system/ee/ExpressionEngine/Boot/boot.common.php
+++ b/system/ee/ExpressionEngine/Boot/boot.common.php
@@ -660,6 +660,7 @@ if (!function_exists('array_key_first')) {
         foreach ($arr as $key => $unused) {
             return $key;
         }
+
         return null;
     }
 }
@@ -674,7 +675,6 @@ if (!function_exists('tmpfile')) {
         return \ExpressionEngine\Library\Filesystem\TempFileFactory::fallback();
     }
 }
-
 
 /**
  * Show pre-formatted debug trace of required depth (default: 5)

--- a/system/ee/ExpressionEngine/Boot/boot.common.php
+++ b/system/ee/ExpressionEngine/Boot/boot.common.php
@@ -664,6 +664,17 @@ if (!function_exists('array_key_first')) {
     }
 }
 
+/**
+ * Polyfill for missing tmpfile()
+ * https://www.php.net/manual/en/function.tmpfile.php
+ */
+if (!function_exists('tmpfile')) {
+    function tmpfile()
+    {
+        return \ExpressionEngine\Library\Filesystem\TempFileFactory::fallback();
+    }
+}
+
 
 /**
  * Show pre-formatted debug trace of required depth (default: 5)

--- a/system/ee/ExpressionEngine/Library/Filesystem/TempFileFactory.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/TempFileFactory.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Library\Filesystem;
+
+class TempFileFactory
+{
+    public static $fallbackRegistered = false;
+
+    public static function make()
+    {
+        return function_exists('tmpfile') ? tmpfile() : static::fallback();
+    }
+
+    /**
+     *
+     * Polyfill for missing tmpfile()
+     * https://www.php.net/manual/en/function.tmpfile.php
+     *
+     * tmpfile() description from php.net:
+     * Creates a temporary file with a unique name in read-write-binary (w+b) mode and returns a file handle.
+     * The file is automatically removed when closed (for example, by calling fclose(), or when there
+     * are no remaining references to the file handle returned by tmpfile()), or when the script ends.
+     *
+     * @return resource|false
+     */
+    public static function fallback()
+    {
+        if(!static::$fallbackRegistered) {
+            ee()->logger->developer(
+                "Your system has disabled support for PHP's tmpfile(). " .
+                "For best results please enable tmpfile in your php.ini settings",
+                true,
+                7 * 24 * 60 * 60 // only show this message once per week
+            );
+        }
+
+        if (!defined('PATH_CACHE')) {
+            return false;
+        }
+
+        $tmpFolder = PATH_CACHE . 'tmp';
+
+        // make sure PATH_CACHE/tmp exists
+        if (!file_exists($tmpFolder)) {
+            $created = mkdir($tmpFolder);
+            if(!$created) {
+                return false;
+            }
+        }
+
+        // Create a temp file with prefix of 'ee' and get a file handler
+        // with the same permissions as tmpfile()
+        $path = tempnam($tmpFolder, 'ee');
+        $tmpfile = ($path !== false) ? fopen($path, "w+b") : false;
+
+        // Register a single shutdown function to remove any temporary files created during the request
+        if (!static::$fallbackRegistered) {
+            register_shutdown_function(function () use ($tmpFolder) {
+                $files = glob("$tmpFolder/ee*") ?: [];
+                foreach ($files as $file) {
+                    if (is_file($file)) {
+                        unlink($file);
+                    }
+                }
+            });
+            static::$fallbackRegistered = true;
+        }
+
+        return $tmpfile;
+    }
+
+}

--- a/system/ee/ExpressionEngine/Library/Filesystem/TempFileFactory.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/TempFileFactory.php
@@ -33,7 +33,7 @@ class TempFileFactory
      */
     public static function fallback()
     {
-        if(!static::$fallbackRegistered) {
+        if (!static::$fallbackRegistered) {
             ee()->logger->developer(
                 "Your system has disabled support for PHP's tmpfile(). " .
                 "For best results please enable tmpfile in your php.ini settings",
@@ -51,7 +51,7 @@ class TempFileFactory
         // make sure PATH_CACHE/tmp exists
         if (!file_exists($tmpFolder)) {
             $created = mkdir($tmpFolder);
-            if(!$created) {
+            if (!$created) {
                 return false;
             }
         }
@@ -76,5 +76,4 @@ class TempFileFactory
 
         return $tmpfile;
     }
-
 }


### PR DESCRIPTION
This PR aims to improve the user experience when ExpressionEngine is running in an environment where `tmpfile()` has been disabled.  We provide a polyfill that gives a similar experience to the native tmpfile() while also adding an entry to the developer log to indicate the fallback is being used.  It is still preferable to use PHP's native tmpfile function when possible.

You can test this behavior by updating your `disable_functions` line in `php.ini` to include `tmpfile` like this

```

disable_functions = 'tmpfile'

```