### PR TITLE
Resolved issue where only one category group was shown in Categories …

### DIFF
--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -464,7 +464,7 @@ class EntryListing
     private function createCategoryFilter($channel = null)
     {
         if (is_null($channel)) {
-            $category_groups = ee('Model')->get('CategoryGroup', null)
+            $category_groups = ee('Model')->get('CategoryGroup')
                 ->with('Categories')
                 ->filter('site_id', ee()->config->item('site_id'))
                 ->filter('exclude_group', '!=', 1)

--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -182,6 +182,7 @@ class EntryListing
         ) {
             $channel = ee('Model')->get('Channel', $this->channel_filter->value())
                 ->with('CategoryGroups')
+                ->all()
                 ->first();
         }
 
@@ -462,7 +463,15 @@ class EntryListing
      */
     private function createCategoryFilter($channel = null)
     {
-        $category_groups = ($channel)  ? $channel->CategoryGroups : [];
+        if (is_null($channel)) {
+            $category_groups = ee('Model')->get('CategoryGroup', null)
+                ->with('Categories')
+                ->filter('site_id', ee()->config->item('site_id'))
+                ->filter('exclude_group', '!=', 1)
+                ->all();
+        } else {
+            $category_groups = $channel->CategoryGroups;
+        }
 
         $category_options = array();
         foreach ($category_groups as $group) {


### PR DESCRIPTION
Resolved issue where only one category group was shown in Categories filter in Entry manager if the channel is selected

Resolved issue where Categories filter was empty if no channel is selected in Entry Manager

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
