### PR TITLE
Resolved issue where `:excerpt` modifier on RTE field could cause PHP notice

### DIFF
--- a/system/ee/ExpressionEngine/Addons/rte/ft.rte.php
+++ b/system/ee/ExpressionEngine/Addons/rte/ft.rte.php
@@ -457,7 +457,7 @@ class Rte_ft extends EE_Fieldtype
      */
     public function replace_has_excerpt($data)
     {
-        return (strpos($data, '<div class="readmore') !== false) ? 'y' : '';
+        return (!empty($data) && strpos($data, '<div class="readmore') !== false) ? 'y' : '';
     }
 
     /**
@@ -470,7 +470,7 @@ class Rte_ft extends EE_Fieldtype
      */
     public function replace_excerpt($data, $params)
     {
-        if (($read_more_tag_pos = strpos($data, '<div class="readmore')) !== false) {
+        if (!empty($data) && ($read_more_tag_pos = strpos($data, '<div class="readmore')) !== false) {
             $data = substr($data, 0, $read_more_tag_pos);
         }
 


### PR DESCRIPTION
https://eecms.slack.com/archives/C04CUNNR9/p1708422311824059

> Deprecated
> strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
> ee/ExpressionEngine/Addons/rte/ft.rte.php, line 473
> Severity: E_DEPRECATED
> Deprecated
> strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
> ee/ExpressionEngine/Addons/rte/ft.rte.php, line 473
> Severity: E_DEPRECATED
> Warning
> Cannot modify header information - headers already sent by (output started at ee/legacy/core/Exceptions.php:120)
> ee/ExpressionEngine/Boot/boot.common.php, line 476
> Severity: E_WARNING