### PR TITLE
Modified the addon update process to stay on Updates tab if more updates are available; #2860

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/ExpressionEngine/Controller/Addons/Addons.php
@@ -506,6 +506,8 @@ class Addons extends CP_Controller
             $return = ee('CP/URL')->decodeUrl(ee()->input->get('return'));
         }
 
+        $return .= '#tab=t-update';
+
         ee()->functions->redirect($return);
     }
 

--- a/system/ee/ExpressionEngine/View/addons/index.php
+++ b/system/ee/ExpressionEngine/View/addons/index.php
@@ -3,45 +3,49 @@
   <div class="panel-body">
 
 <div class="tab-wrap">
-	<div class="app-notice-wrap"><?=ee('CP/Alert')->getAllInlines()?></div>
+    <div class="app-notice-wrap"><?=ee('CP/Alert')->getAllInlines()?></div>
 
 <div class="tab-bar">
-	<div class="tab-bar__tabs">
-		<button type="button" class="tab-bar__tab active js-tab-button" rel="t-0"><?=lang('installed')?> <span class="tab-bar__tab-notification tab-notification-generic"><?=count($installed)?></span></button>
-		<button type="button" class="tab-bar__tab js-tab-button" rel="t-2">
-			<?=lang('updates')?>
-			<span class="tab-bar__tab-notification<?php if (empty($updates)) : ?> tab-notification-generic<?php endif; ?>"><?=count($updates)?></span>
-		</button>
-	</div>
+    <div class="tab-bar__tabs">
+        <button type="button" class="tab-bar__tab active js-tab-button" rel="t-all"><?=lang('installed')?> <span class="tab-bar__tab-notification tab-notification-generic"><?=count($installed)?></span></button>
+        <?php if (!empty($updates)) : ?>
+        <button type="button" class="tab-bar__tab js-tab-button" rel="t-updates">
+            <?=lang('updates')?>
+            <span class="tab-bar__tab-notification"><?=count($updates)?></span>
+        </button>
+        <?php endif; ?>
+    </div>
 </div>
 
-<div class="tab t-0 tab-open">
+<div class="tab t-all tab-open">
 
-	<div class="add-on-card-list">
-		<?php $addons = $installed; foreach ($addons as $addon): ?>
-			<?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => false]); ?>
-		<?php endforeach; ?>
-	</div>
+    <div class="add-on-card-list">
+        <?php $addons = $installed; foreach ($addons as $addon): ?>
+            <?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => false]); ?>
+        <?php endforeach; ?>
+    </div>
 
-	<?php if (count($uninstalled)): ?>
-		<h4 class="line-heading"><?=lang('uninstalled')?></h4>
-		<hr>
+    <?php if (count($uninstalled)): ?>
+        <h4 class="line-heading"><?=lang('uninstalled')?></h4>
+        <hr>
 
-		<div class="add-on-card-list">
-			<?php foreach ($uninstalled as $addon): ?>
-				<?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => false]); ?>
-			<?php endforeach; ?>
-		</div>
-	<?php endif; ?>
+        <div class="add-on-card-list">
+            <?php foreach ($uninstalled as $addon): ?>
+                <?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => false]); ?>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
 </div>
 
-<div class="tab t-2">
-	<div class="add-on-card-list">
-		<?php foreach ($updates as $addon): ?>
-			<?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => true]); ?>
-		<?php endforeach; ?>
-	</div>
-</div>
+<?php if (!empty($updates)) : ?>
+    <div class="tab t-updates">
+        <div class="add-on-card-list">
+            <?php foreach ($updates as $addon): ?>
+                <?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => true]); ?>
+            <?php endforeach; ?>
+        </div>
+    </div>
+<?php endif; ?>
 
 </div>
 


### PR DESCRIPTION
This PR is implementing the feature request: https://github.com/ExpressionEngine/ExpressionEngine/discussions/2860

In addition, it's making the Updates tab to appear only of there are actual updates