### PR TITLE
Changed property visibility

### DIFF
--- a/system/ee/legacy/core/Controller.php
+++ b/system/ee/legacy/core/Controller.php
@@ -95,7 +95,7 @@ class EE_Controller extends Base_Controller
  */
 class CP_Controller extends EE_Controller
 {
-    private $base_url;
+    protected $base_url;
 
     public function __construct()
     {


### PR DESCRIPTION
I noticed that a private property was being accessed in a child class [here]( https://github.com/ExpressionEngine/ExpressionEngine/blob/fe2e00c5ddfb1d2311e67faaa07c420c82ee2121/system/ee/ExpressionEngine/Controller/Channels/AbstractChannels.php#L134) and [here]( https://github.com/ExpressionEngine/ExpressionEngine/blob/fe2e00c5ddfb1d2311e67faaa07c420c82ee2121/system/ee/ExpressionEngine/Controller/Channels/AbstractChannels.php#L128),
I have simply changed the properties visibility to protected.