### PR TITLE
Resolved #3972 where it was not possible to use 1-click Updater on servers with `disk_free_space()` disabled

### DIFF
--- a/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
@@ -828,6 +828,10 @@ class Filesystem
             return null;
         }
 
+        if (!function_exists('disk_free_space')) {
+            return false;
+        }
+
         return @disk_free_space($path);
     }
 

--- a/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
+++ b/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
@@ -176,8 +176,12 @@ class Backup
     public function startFile()
     {
         // Make sure we have enough space first
+        $freeSpace = $this->filesystem->getFreeDiskSpace(dirname($this->file_path));
+        if ($freeSpace === false) {
+            throw new \Exception("Could not determine free disk space", 1);
+        }
         $db_size = $this->getDatabaseSize();
-        if ($db_size > $this->filesystem->getFreeDiskSpace(dirname($this->file_path))) {
+        if ($db_size > $freeSpace) {
             $db_size = round($db_size / 1048576, 1);
 
             throw new \Exception("There is not enough free disk space to write your backup. {$db_size}MB needed.", 1);

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Preflight.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Preflight.php
@@ -86,8 +86,16 @@ class Preflight
      */
     public function checkDiskSpace()
     {
+        if ($this->config->get('updater_skip_disk_space_check') === 'y') {
+            $this->logger->log('Checking free disk space skipped by config setting');
+            return;
+        }
+
         $this->logger->log('Checking free disk space');
         $free_space = $this->filesystem->getFreeDiskSpace($this->path());
+        if ($free_space === false) {
+            throw new UpdaterException("Unable to determine free disk space. Please check your server configuration for <code>disk_free_space()</code> function, or set <code>\$config['updater_skip_disk_space_check'] = 'y';</code> in <code>config.php</code> to skip this check.", 11);
+        }
         $this->logger->log('Free disk space (bytes): ' . $free_space);
 
         // Try to maintain at least 50MB free disk space

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Updater/Downloader/PreflightTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Updater/Downloader/PreflightTest.php
@@ -47,6 +47,7 @@ class PreflightTest extends TestCase
             ->andReturn(1048576000)
             ->once();
 
+        $this->config->shouldReceive('get');
         $this->preflight->checkDiskSpace();
 
         $this->filesystem->shouldReceive('getFreeDiskSpace')

--- a/system/ee/installer/updater/ExpressionEngine/Updater/Library/Filesystem/Filesystem.php
+++ b/system/ee/installer/updater/ExpressionEngine/Updater/Library/Filesystem/Filesystem.php
@@ -543,6 +543,10 @@ class Filesystem
      */
     public function getFreeDiskSpace($path = '/')
     {
+        if (!function_exists('disk_free_space')) {
+            return false;
+        }
+
         return @disk_free_space($path);
     }
 


### PR DESCRIPTION
Resolved #3972 where it was not possible to use 1-click Updater on servers with `disk_free_space()` disabled

Also resolves #3549

This PR is showing appropriate error message when `disk_free_space()` is not available and also allows skipping the check in Updater by setting `$config['updater_skip_disk_space_check'] = 'y';` config file override.
