### PR TITLE
Added ability to send http status code with ajax response, #4108

### DIFF
--- a/system/ee/legacy/core/Output.php
+++ b/system/ee/legacy/core/Output.php
@@ -688,15 +688,19 @@ class EE_Output
      *
      * @access  public
      * @param   string
-     * @param   bool    whether or not the response is an error
+     * @param   bool|int    HTTP status code. If boolean, status code to send.
      * @return  void
      */
-    public function send_ajax_response($msg, $error = false)
+    public function send_ajax_response($msg, $statusCode = false)
     {
         $this->enable_profiler(false);
 
-        if ($error === true) {
+        if ($statusCode === true) {
             $this->set_status_header(500);
+        } else if ($statusCode === false || (!is_int($statusCode) && !is_bool($statusCode))) {
+            $this->set_status_header(200);
+        } else {
+            $this->set_status_header($statusCode);
         }
 
         if (ee()->config->item('send_headers') == 'y') {


### PR DESCRIPTION
Addresses #4108 

Adds ability to send status code, instead of a boolean value, for `send_ajax_response()` function.

Example:

`ee()->output->send_ajax_response(['success' => false, 'message' => 'not allowed'], 401)`

This will return the ajax response with a 401 ( Unauthorized) status code.

This is backwards compatible, so:

`ee()->output->send_ajax_response(['success' => false, 'message' => 'not allowed'])` will still return 200.

`ee()->output->send_ajax_response(['success' => false, 'message' => 'not allowed'], true)` will return 500

Let me know what other info is needed