### PR TITLE
Added new Fluid hooks; #1643

### DIFF
--- a/system/ee/ExpressionEngine/Addons/fluid_field/Model/FluidField.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/Model/FluidField.php
@@ -141,15 +141,6 @@ class FluidField extends Model
             $field_data = $this->setFieldData($this->fetchFieldData());
         }
 
-        if (ee()->extensions->active_hook('fluid_field_get_all_data') === true) {
-            $field_data = ee()->extensions->call(
-                'fluid_field_get_all_data',
-                $field_data,
-                $this->fluid_field_id,
-                $this->entry_id
-            );
-        }
-
         return $field_data;
     }
 

--- a/system/ee/ExpressionEngine/Addons/fluid_field/Model/FluidField.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/Model/FluidField.php
@@ -119,7 +119,9 @@ class FluidField extends Model
             $rows = ee()->extensions->call(
                 'fluid_field_get_field_data',
                 $this->field_id,
-                $this->field_data_id
+                $this->field_data_id,
+                $this->fluid_field_id,
+                $this->entry_id
             );
         } else {
             ee()->db->where('id', $this->field_data_id);
@@ -143,7 +145,8 @@ class FluidField extends Model
             $field_data = ee()->extensions->call(
                 'fluid_field_get_all_data',
                 $field_data,
-                $this->fluid_field_id
+                $this->fluid_field_id,
+                $this->entry_id
             );
         }
 

--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -274,7 +274,7 @@ class Fluid_field_ft extends EE_Fieldtype
             'added' => [], // Only fields added
             'updated' => [], // Only fields updated
             'deleted' => [], // Only fields deleted
-            'saved' => [], // All fields, added and/or updated, when entry is saved
+            'saved' => [], // All fields, added or updated, in sequential order when entry is saved
         ];
 
         $i = 1;
@@ -346,11 +346,13 @@ class Fluid_field_ft extends EE_Fieldtype
                     $insertId = $this->addField($i, $group, $field_id, $thisFieldValue);
 
                     $rowData = [
-                        'order' => $i,
+                        'entry_id' => $this->content_id,
+                        'field_data_id' => $insertId,
+                        'field_id' => (int) $field_id,
+                        'fluid_field_id' => $this->field_id,
                         'group' => $group,
-                        'fieldId' => $field_id,
+                        'order' => $i,
                         'value' => $thisFieldValue,
-                        'dataId' => $insertId,
                     ];
 
                     $collection['added'][] = $rowData;
@@ -358,11 +360,13 @@ class Fluid_field_ft extends EE_Fieldtype
                     $this->updateField($fluid_field_data[$id], $i, $group, $value);
 
                     $rowData = [
-                        'order' => $i,
+                        'entry_id' => $this->content_id,
+                        'field_data_id' => $fluid_field_data[$id]->field_data_id,
+                        'field_id' => (int) $fluid_field_data[$id]->field_id,
+                        'fluid_field_id' => $this->field_id,
                         'group' => $group,
-                        'fieldId' => $fluid_field_data[$id]->field_id ?? 0,
+                        'order' => $i,
                         'value' => $value,
-                        'dataId' => $fluid_field_data[$id]->field_data_id ?? 0,
                     ];
 
                     $collection['updated'][] = $rowData;
@@ -380,14 +384,16 @@ class Fluid_field_ft extends EE_Fieldtype
 
         // Remove fields
         foreach ($fluid_field_data as $fluid_field) {
-            $this->removeField($fluid_field);
-
             $collection['deleted'][] = [
-                'order' => $fluid_field->order ?? 0,
+                'entry_id' => $this->content_id,
+                'field_data_id' => $fluid_field->field_data_id ?? 0,
+                'field_id' => $fluid_field->field_id ?? 0,
+                'fluid_field_id' => $this->field_id,
                 'group' => $fluid_field->group ?? null,
-                'fieldId' => $fluid_field->field_id ?? 0,
-                'dataId' => $fluid_field->field_data_id ?? 0,
+                'order' => $fluid_field->order ?? 0,
             ];
+
+            $this->removeField($fluid_field);
         }
 
         if (ee()->extensions->active_hook('fluid_field_after_save') === true) {
@@ -533,7 +539,7 @@ class Fluid_field_ft extends EE_Fieldtype
             );
         }
 
-        return $id ?? 0;
+        return $id ? (int) $id : 0;
     }
 
     private function removeField($fluid_field)

--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -405,15 +405,17 @@ class Fluid_field_ft extends EE_Fieldtype
             );
         }
 
-        $fluid_field->field_group_id = array_key_exists('id', $group) ? $group['id'] : null;
-        $fluid_field->group = array_key_exists('order', $group) ? $group['order'] : null;
-        $fluid_field->order = $order;
-        $fluid_field->save();
+//        if (!empty($values)) {
+            $fluid_field->field_group_id = array_key_exists('id', $group) ? $group['id'] : null;
+            $fluid_field->group = array_key_exists('order', $group) ? $group['order'] : null;
+            $fluid_field->order = $order;
+            $fluid_field->save();
 
-        $query = ee('db');
-        $query->set($values);
-        $query->where('id', $fluid_field->field_data_id);
-        $query->update($fluid_field->ChannelField->getTableName());
+            $query = ee('db');
+            $query->set($values);
+            $query->where('id', $fluid_field->field_data_id);
+            $query->update($fluid_field->ChannelField->getTableName());
+//        }
 
         if (ee()->extensions->active_hook('fluid_field_after_update_field') === true) {
             ee()->extensions->call(
@@ -454,13 +456,15 @@ class Fluid_field_ft extends EE_Fieldtype
 
         $field = ee('Model')->get('ChannelField', $field_id)->first();
 
-        $query = ee('db');
-        $query->set($values);
-        $query->insert($field->getTableName());
-        $id = $query->insert_id();
+//        if (!empty($values)) {
+            $query = ee('db');
+            $query->set($values);
+            $query->insert($field->getTableName());
+            $id = $query->insert_id();
 
-        $fluid_field->field_data_id = $id;
-        $fluid_field->save();
+            $fluid_field->field_data_id = $id;
+            $fluid_field->save();
+//        }
 
         if (ee()->extensions->active_hook('fluid_field_after_add_field') === true) {
             ee()->extensions->call(
@@ -468,7 +472,7 @@ class Fluid_field_ft extends EE_Fieldtype
                 $fluid_field,
                 $fluid_field->ChannelField->getTableName(),
                 $values,
-                $id
+                $id ?? 0
             );
         }
     }

--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -1063,6 +1063,15 @@ class Fluid_field_ft extends EE_Fieldtype
             ee()->session->set_cache("FluidField", $cache_key, $fluid_field_data);
         }
 
+        if (ee()->extensions->active_hook('fluid_field_get_all_data') === true) {
+            $fluid_field_data = ee()->extensions->call(
+                'fluid_field_get_all_data',
+                $fluid_field_data,
+                $fluid_field_id,
+                $entry_id
+            );
+        }
+
         return $fluid_field_data;
     }
 

--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -624,17 +624,17 @@ class Fluid_field_ft extends EE_Fieldtype
                         $fields .= ee('View')->make($view)->render($viewData);
                     } else {
                         foreach ($field_data as $field_datum) {
-                           $field = $field_datum->getField();
+                            $field = $field_datum->getField();
 
-                           $field->setName($this->name() . '[fields][field_' . $field_datum->getId() . '][field_group_id_0][field_id_' . $field->getId() . ']');
+                            $field->setName($this->name() . '[fields][field_' . $field_datum->getId() . '][field_group_id_0][field_id_' . $field->getId() . ']');
 
-                           $viewData = array_merge($viewData, [
+                            $viewData = array_merge($viewData, [
                                'field' => $field,
                                'field_name' => $field_datum->ChannelField->field_name,
-                           ]);
+                            ]);
 
-                           $fields .= ee('View')->make($view)->render($viewData);
-                       }
+                            $fields .= ee('View')->make($view)->render($viewData);
+                        }
                     }
                 }
             }
@@ -934,7 +934,7 @@ class Fluid_field_ft extends EE_Fieldtype
             // Sometimes a fluid field with no fields attached to it gets saved as an empty string
             //   rather than an empty array. In this case, we need to convert it to an array to
             //   perform array operations on it
-            if(is_string($all['field_channel_fields']) && empty($all['field_channel_fields'])){
+            if (is_string($all['field_channel_fields']) && empty($all['field_channel_fields'])) {
                 $all['field_channel_fields'] = [];
             }
 

--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -682,22 +682,15 @@ class Fluid_field_ft extends EE_Fieldtype
                             }, $field_data),
                             'field_name' => $field_group->short_name,
                         ]);
-
-                        $fields .= ee('View')->make($view)->render($viewData);
                     } else {
-                        foreach ($field_data as $field_datum) {
-                            $field = $field_datum->getField();
-
-                            $field->setName($this->name() . '[fields][field_' . $field_datum->getId() . '][field_group_id_0][field_id_' . $field->getId() . ']');
-
-                            $viewData = array_merge($viewData, [
-                               'field' => $field,
-                               'field_name' => $field_datum->ChannelField->field_name,
-                            ]);
-
-                            $fields .= ee('View')->make($view)->render($viewData);
-                        }
+                        $field = $field_data[0]->getField();
+                        $field->setName($this->name() . '[fields][field_' . $field_data[0]->getId() . '][field_group_id_0][field_id_' . $field->getId() . ']');
+                        $viewData = array_merge($viewData, [
+                            'field' => $field,
+                            'field_name' => $field_data[0]->ChannelField->field_name,
+                        ]);
                     }
+                    $fields .= ee('View')->make($view)->render($viewData);
                 }
             }
         // This happens when we have a validation issue and data was not saved

--- a/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
+++ b/system/ee/ExpressionEngine/Addons/fluid_field/ft.fluid_field.php
@@ -405,17 +405,17 @@ class Fluid_field_ft extends EE_Fieldtype
             );
         }
 
-//        if (!empty($values)) {
-            $fluid_field->field_group_id = array_key_exists('id', $group) ? $group['id'] : null;
-            $fluid_field->group = array_key_exists('order', $group) ? $group['order'] : null;
-            $fluid_field->order = $order;
-            $fluid_field->save();
+        $fluid_field->field_group_id = array_key_exists('id', $group) ? $group['id'] : null;
+        $fluid_field->group = array_key_exists('order', $group) ? $group['order'] : null;
+        $fluid_field->order = $order;
+        $fluid_field->save();
 
+        if (!empty($values)) {
             $query = ee('db');
             $query->set($values);
             $query->where('id', $fluid_field->field_data_id);
             $query->update($fluid_field->ChannelField->getTableName());
-//        }
+        }
 
         if (ee()->extensions->active_hook('fluid_field_after_update_field') === true) {
             ee()->extensions->call(
@@ -446,17 +446,20 @@ class Fluid_field_ft extends EE_Fieldtype
         ));
 
         if (ee()->extensions->active_hook('fluid_field_add_field') === true) {
+            // The parameter order is different from fluid_field_update_field because
+            // $fluid_field was added as a 3rd parameter after this was released, and
+            // we want to ensure backwards compatibility with anyone using this hook.
             $values = ee()->extensions->call(
                 'fluid_field_add_field',
-                $fluid_field,
                 $fluid_field->ChannelField->getTableName(),
-                $values
+                $values,
+                $fluid_field,
             );
         }
 
         $field = ee('Model')->get('ChannelField', $field_id)->first();
 
-//        if (!empty($values)) {
+        if (!empty($values)) {
             $query = ee('db');
             $query->set($values);
             $query->insert($field->getTableName());
@@ -464,7 +467,7 @@ class Fluid_field_ft extends EE_Fieldtype
 
             $fluid_field->field_data_id = $id;
             $fluid_field->save();
-//        }
+        }
 
         if (ee()->extensions->active_hook('fluid_field_after_add_field') === true) {
             ee()->extensions->call(


### PR DESCRIPTION
resolves #1643

  - Added fluid_field_after_update_field hook
  - Added fluid_field_after_add_field hook
  - Added additional parameters to fluid_field_get_field_data and fluid_field_add_field hooks
  - Move fluid_field_get_all_data hook, it was in the wrong place
  - Only attempt to save Fluid data if savable data exists

These are changes and additions made to hopefully allow Publisher to support Fluid field.

The addition of the conditionals checking if $values is empty or not lets the first hook return no data. In Publisher if saving a non-default language, we don't want the native Fluid field to be updated with non-default data.

The change in the foreach loop when displaying fields is hard to explain at this point because it's been so long since I originally tested it, but it seems like a logical change, even outside the context of these hook changes. I tested it with and without Publisher installed and it still saves and displays Fluid field data just fine.

I'm pretty certain that the fluid_field_get_all_data hook was just in the wrong file. There are two getFieldData methods in different files and I think it was some confusion when the hook was originally added.

With these changes I'm able to successfully save basic text fields in Fluid with drafts and translations. Default Fluid functionality remains unchanged. Grid and Relationship fields inside of Fluid are a different beast that I need to figure out, but I'm pretty certain those need to be managed outside the context of any hooks added to the Fluid field.