### PR TITLE
Changed default limit in Members field settings

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/ft.member.php
+++ b/system/ee/ExpressionEngine/Addons/member/ft.member.php
@@ -31,7 +31,7 @@ class Member_ft extends Relationship_ft implements ColumnInterface
 
     public $default_settings = [
         'roles' => '--',
-        'limit' => '',
+        'limit' => 100,
         'order_field' => 'screen_name',
         'order_dir' => 'asc',
         'allow_multiple' => 'y',


### PR DESCRIPTION
Previous default setting was not limit, which caused slowdowns on large websites;

changed it to 100 which is same default values that Relationship ft is using