### PR TITLE
Automatically prolong CSRF token lifetime in forms

### DIFF
--- a/system/ee/legacy/libraries/Actions.php
+++ b/system/ee/legacy/libraries/Actions.php
@@ -79,6 +79,19 @@ class EE_Actions
             $method = $query->row('method');
             $csrf_exempt = (bool) $query->row('csrf_exempt');
         } else {
+            // Just refreshing CSRF token?
+            if ($action_id == 'refresh_csrf_token') {
+                header("Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0");  //Don't cache
+                header("Expires: Sat, 26 Jul 1997 05:00:00 GMT");
+                header("Pragma: no-cache");
+                $tokenIsValid = ee()->security->have_valid_xid();
+                if ($tokenIsValid) {
+                    ee()->output->send_ajax_response(array('success'));
+                } else {
+                    ee()->output->send_ajax_response(array('error' => lang('csrf_token_expired')));
+                }
+            }
+
             // If the ID is not numeric we'll invoke the class/method manually
             if (! isset($specials[$action_id])) {
                 return false;

--- a/system/ee/legacy/libraries/Functions.php
+++ b/system/ee/legacy/libraries/Functions.php
@@ -629,6 +629,11 @@ class EE_Functions
             $form .= "</div>\n\n";
         }
 
+        // Inject JavaScript to refresh CSRF token lifetime
+        if (!bool_config_item('disable_csrf_protection') && !bool_config_item('disable_csrf_refresh')) {
+            $form .= '{!-- csrf_refresh --}';
+        }
+
         return $form;
     }
 

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3073,6 +3073,10 @@ class EE_Template
             $str = preg_replace("/\{\!--\s*(\/\/)*\s*disable\s*frontedit\s*--\}/s", '<!-- ${1}disable frontedit -->', $str);
         }
 
+        if (strpos($str, '{!-- csrf_refresh --}') !== false) {
+            ee()->output->add_token_refresh = true;
+        }
+
         return preg_replace("/\{!--.*?--\}/s", '', $str);
     }
 


### PR DESCRIPTION
This PR is adding JS code that performs a ping to EE Action URL every hour to extend the form lifetime.

For guests, it will be extending the `exp_csrf_token` cookie. For logged in members, it will be extending the session lifetime (the token lives as long as the session lives)

With the session lifetime of 2 hours, that means that if they leave the page with the form open and the computer will be active, the form will still be valid to submit if they come after 2 hours. If however the computer goes to sleep for 2 hours, the session/token will be already dead and they will need to reload page (we could also send back the token and auto-inject that into the forms though, but I'd like to get initial review first)

The potential site effect (not tested though) is that they will probably not get logged out after 2h of inactivity - because there will be activity of AJAX calls.

The code will be automatically injected into pages that contain any form, unless `disable_csrf_protection` or `disable_csrf_refresh` config override is set