### PR TITLE
Resolved #4148 where SuperAdmins were not able to approve members into Locked roles

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Members.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Members.php
@@ -1048,7 +1048,7 @@ class Members extends CP_Controller
                 $errors[] = sprintf(lang('cannot_activate_member_role_not_exists'), $member->username, $role->name);
                 continue;
             }
-            if ($role->is_locked == 'y') {
+            if ($role->is_locked == 'y' && !ee('Permission')->isSuperAdmin()) {
                 $errors[] = sprintf(lang('cannot_activate_member_role_is_locked'), $member->username, $role->name);
                 continue;
             }

--- a/tests/cypress/cypress/integration/members/register.ee6.js
+++ b/tests/cypress/cypress/integration/members/register.ee6.js
@@ -478,7 +478,7 @@ context('Member Registration on Front-end', () => {
             cy.contains("Unable to activate");
 
             cy.authVisit('admin.php?/cp/members');
-            cy.get("a:contains('pending1')").parents('tr').find('td:nth-child(4)').should('not.contain', 'Unlocked Extra Role')
+            cy.get("a:contains('pending2')").parents('tr').find('td:nth-child(4)').should('not.contain', 'Unlocked Extra Role')
 
         })
 

--- a/tests/cypress/cypress/integration/members/register.ee6.js
+++ b/tests/cypress/cypress/integration/members/register.ee6.js
@@ -1,7 +1,9 @@
 /// <reference types="Cypress" />
 
 import EmailSettings from '../../elements/pages/settings/EmailSettings';
+import MemberCreate from '../../elements/pages/members/MemberCreate';
 
+const memberCreate = new MemberCreate
 const emailSettings = new EmailSettings
 
 const { _, $ } = Cypress
@@ -272,6 +274,19 @@ context('Member Registration on Front-end', () => {
         before(function(){
             cy.eeConfig({ item: 'req_mbr_activation', value: 'manual' })
             cy.eeConfig({ item: 'password_security_policy', value: 'none' })
+
+            //register admin member in CP
+            cy.auth()
+            memberCreate.load()
+            memberCreate.get('username').clear().type('memberadmin')
+            memberCreate.get('email').clear().type('memberadmin@expressionengine.com')
+            memberCreate.get('password').clear().type('1Password')
+            memberCreate.get('confirm_password').clear().type('1Password')
+            cy.get('[name=verify_password]').clear().type('password')
+            cy.get('.tab-bar__tab:contains("Roles")').click()
+            cy.get('[name=role_id]').check('7')
+            cy.get('body').type('{ctrl}', {release: false}).type('s')
+            cy.logout()
         })
 
         it('registers normally', function() {
@@ -451,11 +466,33 @@ context('Member Registration on Front-end', () => {
         it('unable to approve old members if default group is locked', function() {
             cy.eeConfig({ item: 'default_primary_role', value: '7' })
 
-            cy.authVisit('admin.php?/cp/members');
+            cy.auth({
+                email: 'memberadmin',
+                password: '1Password'
+            })
+
+            cy.visit('admin.php?/cp/members');
             cy.get("a:contains('pending2')").parents('tr').find('td:nth-child(4) .st-pending').should('exist')
 
             cy.get("a:contains('pending2')").parents('tr').find('td:nth-child(4) a[title=Approve]').click()
             cy.contains("Unable to activate");
+
+            cy.authVisit('admin.php?/cp/members');
+            cy.get("a:contains('pending1')").parents('tr').find('td:nth-child(4)').should('not.contain', 'Unlocked Extra Role')
+
+        })
+
+        it('superadmin can approve even if default group is locked', function() {
+
+            cy.auth()
+            cy.visit('admin.php?/cp/members');
+            cy.get("a:contains('pending2')").parents('tr').find('td:nth-child(4) .st-pending').should('exist')
+
+            cy.get("a:contains('pending2')").parents('tr').find('td:nth-child(4) a[title=Approve]').click()
+            cy.contains("Member Approved");
+
+            cy.authVisit('admin.php?/cp/members');
+            cy.get("a:contains('pending2')").parents('tr').find('td:nth-child(4)').contains('Locked Role')
 
         })
 

--- a/tests/cypress/support/sql/more-roles.sql
+++ b/tests/cypress/support/sql/more-roles.sql
@@ -5,3 +5,8 @@ INSERT INTO `exp_roles` (`role_id`, `name`, `short_name`, `description`, `is_loc
 INSERT INTO `exp_role_settings` (`role_id`, `search_flood_control`) VALUES
 	(6, 10),
 	(7, 10);
+
+INSERT INTO `exp_permissions` (`role_id`, `site_id`, `permission`) VALUES
+	(7, 1, 'can_access_cp'),
+	(7, 1, 'can_access_members'),
+	(7, 1, 'can_edit_members');


### PR DESCRIPTION
Resolved #4148 where SuperAdmins were not able to approve members into Locked roles

Note: in older versions of EE, pending members were always going into Default role. Since EE 6.something it's possible to set up registration form so that user will go into another role when approved, which can also be pending. The check for superadmin permission is something that was missed - they clearly need to be allowed to move member from pending to locked role