### PR TITLE
Fix issue #4037 where uploading a file could remove EXIF data

### DIFF
--- a/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
+++ b/system/ee/ExpressionEngine/Library/Filesystem/Filesystem.php
@@ -1131,13 +1131,33 @@ class Filesystem
     }
 
     /**
+     * Get the adapter for the filesystem
+     *
+     * @return Flysystem\AdapterInterface
+     */
+    public function getAdapter()
+    {
+        return $this->flysystem->getAdapter();
+    }
+
+    /**
+     * Determine whether or not the Filesystem is using a CachedAdapter
+     *
+     * @return boolean
+     */
+    public function hasCachedAdapter()
+    {
+        return ($this->getAdapter() instanceof Flysystem\Cached\CachedAdapter);
+    }
+
+    /**
      * Get the base adapter for the filesystem
      *
-     * @return void
+     * @return Flysystem\AdapterInterface
      */
     public function getBaseAdapter()
     {
-        $adapter = $this->flysystem->getAdapter();
+        $adapter = $this->getAdapter();
 
         return ($adapter instanceof Flysystem\Cached\CachedAdapter) ? $adapter->getAdapter() : $adapter;
     }

--- a/system/ee/legacy/libraries/Upload.php
+++ b/system/ee/legacy/libraries/Upload.php
@@ -370,7 +370,7 @@ class EE_Upload
         // Since we use native functions to copy/move uploads in the local filesystem
         // we need to explicitly update the existence in the adapter's cache
         if ($filesystem && $filesystem->isLocal() && $filesystem->hasCachedAdapter()) {
-            $filesystem->getAdapter()->getCache()->updateObject($this->file_name, [
+            $filesystem->getAdapter()->getCache()->updateObject($filesystem->relative($destination), [
                 'type' => 'file',
                 'contents' => false,
                 'path' => $destination

--- a/system/ee/legacy/libraries/Upload.php
+++ b/system/ee/legacy/libraries/Upload.php
@@ -369,7 +369,7 @@ class EE_Upload
 
         // Since we use native functions to copy/move uploads in the local filesystem
         // we need to explicitly update the existence in the adapter's cache
-        if ($filesystem->isLocal() && $filesystem->hasCachedAdapter()) {
+        if ($filesystem && $filesystem->isLocal() && $filesystem->hasCachedAdapter()) {
             $filesystem->getAdapter()->getCache()->updateObject($this->file_name, [
                 'type' => 'file',
                 'contents' => false,

--- a/system/ee/legacy/libraries/Upload.php
+++ b/system/ee/legacy/libraries/Upload.php
@@ -367,8 +367,18 @@ class EE_Upload
             }
         }
 
+        // Since we use native functions to copy/move uploads in the local filesystem
+        // we need to explicitly update the existence in the adapter's cache
+        if ($filesystem->isLocal() && $filesystem->hasCachedAdapter()) {
+            $filesystem->getAdapter()->getCache()->updateObject($this->file_name, [
+                'type' => 'file',
+                'contents' => false,
+                'path' => $destination
+            ], true);
+        }
+
         if (!$filesystem || $filesystem->isLocal()) {
-            @chmod($this->upload_path . $this->file_name, FILE_WRITE_MODE);
+            @chmod($destination, FILE_WRITE_MODE);
         }
 
         return $result;


### PR DESCRIPTION
When an image is uploaded to an Upload Destination using a local filesystem adapter we will move the file in a way that preserves any EXIF data present.  Note that if any transformations are performed upon upload the EXIF data may be removed if the image processing library does not support EXIF.