### PR TITLE
Adding target="_blank" to field info

### DIFF
--- a/system/ee/language/english/fieldtypes_lang.php
+++ b/system/ee/language/english/fieldtypes_lang.php
@@ -377,7 +377,7 @@ $lang = array(
     /* Date */
 
     'date_localization' => 'Date Localization',
-    'date_localization_desc' => 'Choose how the field data should be localized. <a href="' . DOC_URL . 'fieldtypes/date.html">More info</a>',
+    'date_localization_desc' => 'Choose how the field data should be localized. <a href="' . DOC_URL . 'fieldtypes/date.html" target="_blank">More info</a>',
     'always_localized' => 'Always localized',
     'always_fixed' => 'Always fixed',
     'ask_each_time' => 'Ask each time',


### PR DESCRIPTION
When creating a Date field, there is a small line on localization:

```
Choose how the field data should be localized. [More info](https://docs.expressionengine.com/v7/fieldtypes/date.html)
```

If you click this link, it opens in the current window, which loses all of the field group you set up, or the current field info.

This just adds `target="_blank"` so that doesn't happen.