### PR TITLE
Resolved #4187 where Pro Variables tag was causing a warning

### DIFF
--- a/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
@@ -309,7 +309,7 @@ class LegacyParser
             }
 
             // date variables
-            elseif (strpos($val, 'format=') !== false && preg_match("/.+?\s+?format=/", $val)) {
+            elseif (strpos($val, 'format') !== false && preg_match("/.+?\s+?format\s*=\s*/", $val)) {
                 $var_single[$val] = $this->extractDateFormat($val);
             } elseif (!is_numeric($val)) {  // single variables
                 $var_single[$val] = $val;

--- a/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
@@ -309,7 +309,7 @@ class LegacyParser
             }
 
             // date variables
-            elseif (strpos($val, 'format') !== false && preg_match("/.+?\s+?format/", $val)) {
+            elseif (strpos($val, 'format=') !== false && preg_match("/.+?\s+?format=/", $val)) {
                 $var_single[$val] = $this->extractDateFormat($val);
             } elseif (!is_numeric($val)) {  // single variables
                 $var_single[$val] = $val;


### PR DESCRIPTION
Resolved #4187 where Pro Variables tag was causing a warning

This was a result of using the 'formatting' parameter in a different single tag but the Variables/Parser was being too greedy and matched it as a date variable with 'format' parameter.
