### PR TITLE
Resolved #1333 where having template files stored outside of site folder could cause PHP warnings

### DIFF
--- a/system/ee/ExpressionEngine/Model/Template/TemplateGroup.php
+++ b/system/ee/ExpressionEngine/Model/Template/TemplateGroup.php
@@ -153,6 +153,11 @@ class TemplateGroup extends Model
             return null;
         }
 
+        // Templates are always site-specific
+        if (empty($this->site_id)) {
+            return null;
+        }
+
         $basepath = PATH_TMPL;
 
         if (ee()->config->item('save_tmpl_files') != 'y' || $basepath == '') {


### PR DESCRIPTION
Resolved #1333 where having template files stored outside of site folder could cause PHP warnings