### PR TITLE
Fixes for Pending Member Management

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Members.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Members.php
@@ -1246,12 +1246,13 @@ class Members extends CP_Controller
 
         $vars['bulk_options'] = [];
         if (!empty($primaryRole) && $primaryRole->role_id == Member::PENDING) {
-            if (ee('Permission')->can('edit_members')) {
-                $vars['bulk_options'][] = [
-                    'value' => "approve",
-                    'text' => lang('approve')
-                ];
-            }
+            // Removing for now - confirmation modals (like decline/delete) do not currently play well with other options
+            // if (ee('Permission')->can('edit_members')) {
+            //     $vars['bulk_options'][] = [
+            //         'value' => "approve",
+            //         'text' => lang('approve')
+            //     ];
+            // }
             if (ee('Permission')->can('delete_members')) {
                 $vars['bulk_options'][] = [
                     'value' => "decline",

--- a/system/ee/ExpressionEngine/Controller/Settings/Members.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Members.php
@@ -33,6 +33,7 @@ class Members extends Settings
     {
         $roles = ee('Model')->get('Role')
             ->filter('is_locked', 'n')
+            ->filter('short_name', '!=', 'pending')
             ->order('name', 'asc')
             ->all()
             ->getDictionary('role_id', 'name');

--- a/system/ee/ExpressionEngine/Library/CP/MemberManager/Columns/Manage.php
+++ b/system/ee/ExpressionEngine/Library/CP/MemberManager/Columns/Manage.php
@@ -48,7 +48,7 @@ class Manage extends EntryManager\Columns\Column
         //if (! ee('Permission')->can('ban_users')) {
         if ($member->role_id == Member::PENDING) {
             $toolbar['approve'] = array(
-                'href' => ee('CP/URL')->make('files/directory/' . $member->upload_location_id, ['directory_id' => $member->getId()]),
+                'href' => ee('CP/URL')->make('members/approve/' . $member->getId()),
                 'title' => lang('approve'),
             );
             if (ee()->config->item('req_mbr_activation') !== 'email' && ee('Permission')->can('edit_members')) {


### PR DESCRIPTION
- Resolved #4295 where CP actions for member approval were incorrect
- Resolved #4296 where members could be set to pending after approval
