### PR TITLE
Adding mysql errors to file error logging

### DIFF
--- a/system/ee/legacy/core/Exceptions.php
+++ b/system/ee/legacy/core/Exceptions.php
@@ -240,6 +240,10 @@ class EE_Exceptions
         // Replace system path
         $filepath = str_replace($syspath, '', $filepath);
         $message = str_replace($syspath, '', $message);
+		
+        if (strpos($message, 'SQLSTATE') !== false) {
+			log_message('error', 'MySQL Error: ' . $message);
+        }
 
         $message = htmlentities($message, ENT_QUOTES, 'UTF-8', false);
 


### PR DESCRIPTION
Didn't log them before, does now.

Came up in slack the other day, the file logs didn't log mysql errors, which ... I would like them to.

This adds it- looks like this in the logs:

<img width="1061" alt="Screenshot 2024-05-10 at 1 33 29 PM" src="https://github.com/ExpressionEngine/ExpressionEngine/assets/1181219/38684ff4-2f62-4043-a66c-2eb6f1d2d025">

Hitting @matthewjohns0n because we do write these to the file and I just want to be sure nobody could take advantage of that to do anything nefarious.  I also wonder if we should add a new 'type' of log- mysql - and have it set separately.  But I also 100% can see wanting to catch both the php and mysql errors in one go.  Hence the current approach.
