### PR TITLE
Resolved #4285 where original file dimensions were not returned in AJAX upload response

### DIFF
--- a/system/ee/ExpressionEngine/Addons/filepicker/mcp.filepicker.php
+++ b/system/ee/ExpressionEngine/Addons/filepicker/mcp.filepicker.php
@@ -368,7 +368,8 @@ class Filepicker_mcp
                         'isImage' => $file->isImage(),
                         'isSVG' => $file->isSVG(),
                         'thumb_path' => $file->getAbsoluteThumbnailURL(),
-                        'upload_location_id' => $file->upload_location_id
+                        'upload_location_id' => $file->upload_location_id,
+                        'file_hw_original' => $result['upload_response']['file_hw_original'],
                     ]
                 ];
             }


### PR DESCRIPTION
## What's in this pull request?

This pull request resolves an issue in the `ajaxUpload` method of `mcp.filepicker.php` where the original file dimensions (`file_hw_original`) were not being included in the AJAX upload response. This fix adds the missing `file_hw_original` key to the response array, ensuring that the returned `<img>` tag would contain the height and width attributes.

## Nature of the Change

- Added the line `'file_hw_original' => $result['upload_response']['file_hw_original'],` to the response array in the `ajaxUpload` method.

## Reasoning

This fix ensures that the required information is returned as part of the AJAX response.

## Issue Reference

Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/4285

## Labels

- Bug:Accepted

## Documentation

No documentation update needed.

