### PR TITLE
Address issue #4349

### DIFF
--- a/system/ee/legacy/libraries/File_field.php
+++ b/system/ee/legacy/libraries/File_field.php
@@ -837,7 +837,9 @@ class File_field
                 }
                 $files = ee('Model')->get('File', $file_ids)->with('UploadDestination')->all();
                 foreach ($files as $file) {
-                    $data = str_replace('{file:' . $file->file_id . ':url}', $file->getAbsoluteURL(), $data);
+                    if($file->getAbsoluteURL()) {
+                        $data = str_replace('{file:' . $file->file_id . ':url}', $file->getAbsoluteURL(), $data);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adds a simple conditional check to line 840 to ensure that the value returned by $file->getAbsoluteURL() is not null before calling str_replace().

There may be wider issues arising from this condition (that $file->getAbsoluteURL() returns null) so possibly some other conditional is needed to handle what to do if this substitution check fails... but looks the structure added is similar to the one used to check str_replace() on line 859 and there are no fancy routing options taking there if that test skips the str_replace, so am guessing this is all that is needed.

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
