### PR TITLE
Fix Pro Search 8.1 Warnings

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro_search/helpers/pro_search_helper.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/helpers/pro_search_helper.php
@@ -100,7 +100,7 @@ if (! function_exists('pro_strpos_all')) {
     {
         $all = array();
 
-        if (preg_match_all('#' . preg_quote($needle, '#') . '#', $haystack, $matches)) {
+        if ($haystack != null && preg_match_all('#' . preg_quote($needle, '#') . '#', $haystack, $matches)) {
             $total = count($matches[0]);
             $offset = 0;
 


### PR DESCRIPTION
<!--

What's in this pull request?

PHP 8.1 and later will not allow for null haystacks - short circuit out of the logic in the if whenever our haystack is null 

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
