### PR TITLE
Added conditional to allow for site_color config override

### DIFF
--- a/system/ee/legacy/core/Config.php
+++ b/system/ee/legacy/core/Config.php
@@ -326,6 +326,10 @@ class EE_Config
                 }
 
                 $config['site_bootstrap_checksums'] = unserialize($data);
+            } elseif ($name == 'site_color') {
+                if (! isset($config['site_color'])) {
+                  $config[str_replace('sites_', 'site_', $name)] = $data;
+                }
             } else {
                 $config[str_replace('sites_', 'site_', $name)] = $data;
             }


### PR DESCRIPTION
- Added ability to set site_color via a config override in config.php. Currently the setting is pulled from the DB  whether the site_color column is empty or a config override is present. This also allows for site_color to be used outside a MSM scenario where you may want to have different environments with different colors 🏳️‍🌈