### PR TITLE
Added more URI variables for templates

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Settings/Settings.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Settings.php
@@ -82,9 +82,9 @@ class Settings extends CP_Controller
             $item->isActive();
         }
 
-        if (ee('Permission')->hasAll('can_access_design', 'can_admin_design')) {
-            $list->addItem(lang('template_settings'), ee('CP/URL')->make('settings/template'));
-        }
+        $list->addItem(lang('template_settings'), ee('CP/URL')->make('settings/template'));
+
+        $list->addItem(lang('uri_variables'), ee('CP/URL')->make('settings/uri-variables'));
 
         $sidebar->addItem(lang('frontedit'), ee('CP/URL')->make('settings/pro/frontedit'));
         $sidebar->addItem(lang('branding_settings'), ee('CP/URL')->make('settings/pro/branding'));

--- a/system/ee/ExpressionEngine/Controller/Settings/UriVariables.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/UriVariables.php
@@ -31,6 +31,17 @@ class UriVariables extends Settings
         $vars['sections'] = array(
             array(
                 array(
+                    'title' => 'enable_request_variables',
+                    'desc' => 'enable_request_variables_desc',
+                    'fields' => array(
+                        'enable_request_variables' => array(
+                            'type' => 'yes_no',
+                        ),
+                    )
+                ),
+            ),
+            array(
+                array(
                     'title' => 'enable_category_uri_variables',
                     'desc' => 'enable_category_uri_variables_desc',
                     'fields' => array(

--- a/system/ee/ExpressionEngine/Controller/Settings/UriVariables.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/UriVariables.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Controller\Settings;
+
+use CP_Controller;
+
+/**
+ * URI Variables Settings Controller
+ */
+class UriVariables extends Settings
+{
+    /**
+     * General Settings
+     */
+    public function index()
+    {
+        $categoryGroups = ee('Model')
+            ->get('CategoryGroup')
+            ->filter('site_id', ee()->config->item('site_id'))
+            ->all()
+            ->sortBy('group_name')
+            ->getDictionary('group_id', 'group_name');
+        $vars['sections'] = array(
+            array(
+                array(
+                    'title' => 'enable_category_uri_variables',
+                    'desc' => 'enable_category_uri_variables_desc',
+                    'fields' => array(
+                        'enable_category_uri_variables' => array(
+                            'type' => 'yes_no',
+                            'group_toggle' => array(
+                                'y' => 'category_uri_variables_settings'
+                            )
+                        ),
+                    )
+                ),
+            ),
+            'category_uri_variables_settings' => array(
+                'group' => 'category_uri_variables_settings',
+                'settings' => array(
+                    array(
+                        'title' => 'category_uri_variables_category_groups',
+                        'desc' => 'category_uri_variables_category_groups_desc',
+                        'fields' => array(
+                            'category_uri_variables_category_groups' => array(
+                                'type' => 'checkbox',
+                                'choices' => $categoryGroups,
+                            ),
+                        )
+                    ),
+                    array(
+                        'title' => 'category_uri_variables_uri_pattern',
+                        'desc' => 'category_uri_variables_uri_pattern_desc',
+                        'fields' => array(
+                            'category_uri_variables_uri_pattern' => array(
+                                'type' => 'text',
+                            ),
+                        )
+                    ),
+                    array(
+                        'title' => 'category_uri_variables_set_all_segments',
+                        'desc' => 'category_uri_variables_set_all_segments_desc',
+                        'fields' => array(
+                            'category_uri_variables_set_all_segments' => array(
+                                'type' => 'yes_no',
+                            ),
+                        )
+                    ),
+                    array(
+                        'title' => 'category_uri_variables_ignore_pagination',
+                        'desc' => 'category_uri_variables_ignore_pagination_desc',
+                        'fields' => array(
+                            'category_uri_variables_ignore_pagination' => array(
+                                'type' => 'yes_no',
+                            ),
+                        )
+                    ),
+                    array(
+                        'title' => 'category_uri_variables_parse_file_paths',
+                        'desc' => 'category_uri_variables_parse_file_paths_desc',
+                        'fields' => array(
+                            'category_uri_variables_parse_file_paths' => array(
+                                'type' => 'yes_no',
+                            ),
+                        )
+                    ),
+                ),
+            )
+        );
+
+        $base_url = ee('CP/URL')->make('settings/uri-variables');
+
+        /*ee()->form_validation->set_rules(array(
+            array(
+                'field' => 'dynamic_tracking_disabling',
+                'label' => 'lang:dynamic_tracking_disabling',
+                'rules' => 'is_numeric'
+            )
+        ));*/
+
+        ee()->form_validation->validateNonTextInputs($vars['sections']);
+
+        if (AJAX_REQUEST) {
+            ee()->form_validation->run_ajax();
+            exit;
+        } elseif (ee()->form_validation->run() !== false) {
+            if ($this->saveSettings($vars['sections'])) {
+                ee()->view->set_message('success', lang('preferences_updated'), lang('preferences_updated_desc'), true);
+            }
+
+            ee()->functions->redirect($base_url);
+        } elseif (ee()->form_validation->errors_exist()) {
+            ee()->view->set_message('issue', lang('settings_save_error'), lang('settings_save_error_desc'));
+        }
+
+        ee()->view->base_url = $base_url;
+        ee()->view->ajax_validate = true;
+        ee()->view->cp_page_title = lang('uri_variables');
+        ee()->view->save_btn_text = 'btn_save_settings';
+        ee()->view->save_btn_text_working = 'btn_saving';
+
+        ee()->view->cp_breadcrumbs = array(
+            '' => lang('uri_variables')
+        );
+
+        ee()->cp->render('settings/form', $vars);
+    }
+}
+// END CLASS
+
+// EOF

--- a/system/ee/ExpressionEngine/Service/JumpMenu/JumpMenu.php
+++ b/system/ee/ExpressionEngine/Service/JumpMenu/JumpMenu.php
@@ -1068,6 +1068,14 @@ class JumpMenu extends AbstractJumpMenu
                     ),
                 )
             ),
+            'systemSettingsUriVariables' => array(
+                'icon' => 'fa-wrench',
+                'command' => 'system_settings uri_variables',
+                'dynamic' => false,
+                'addon' => false,
+                'target' => 'settings/uri-variables',
+                'permission' => 'can_access_sys_prefs'
+            ),
             'systemSettingsTracking' => array(
                 'icon' => 'fa-wrench',
                 'command' => 'system_settings tracking    ',

--- a/system/ee/language/english/jump_menu_lang.php
+++ b/system/ee/language/english/jump_menu_lang.php
@@ -55,6 +55,7 @@ $lang = array(
     'jump_systemSettingsButtons' => 'Content & Design &raquo; <b>HTML Buttons</b> Settings',
     'jump_systemSettingsTemplate' => 'Content & Design &raquo; <b>Template</b> Settings',
     'jump_systemSettingsTracking' => 'Content & Design &raquo; <b>Tracking</b> Settings',
+    'jump_systemSettingsUriVariables' => 'Content & Design &raquo; <b>URI Variables</b> Settings',
     'jump_systemSettingsWordCensoring' => 'Content & Design &raquo; <b>Word Censoring</b> Settings',
     'jump_systemSettingsFrontedit' => 'Content & Design &raquo; <b>Front-End Editing</b> Settings',
     'jump_systemSettingsBranding' => 'Content & Design &raquo; <b>Branding</b> Settings',

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -47,6 +47,8 @@ $lang = array(
 
     'template_settings' => 'Template Settings',
 
+    'uri_variables' => 'URI Variables',
+
     'upload_directories' => 'Upload Directories',
 
     'url_path_settings' => 'URL and Path Settings',
@@ -910,6 +912,34 @@ $lang = array(
     'cookie_consent_disabled' => 'Cookie Consent Disabled',
 
     'cookie_consent_disabled_desc' => 'Cookie-related consent requests have no affect on the setting of cookies unless the <a href="%s">cookie consent setting</a> is enabled.',
+
+    /* URI Variables */
+
+    'enable_category_uri_variables' => 'Enable Category URI Variables',
+
+    'enable_category_uri_variables_desc' => 'Always parse URI segments as category URI variables for category URLs.',
+
+    'category_uri_variables_settings' => 'Category URI Variables Settings',
+
+    'category_uri_variables_category_groups' => 'Category groups',
+
+    'category_uri_variables_uri_pattern' => 'URI pattern',
+
+    'category_uri_variables_set_all_segments' => 'Set all segments',
+
+    'category_uri_variables_ignore_pagination' => 'Ignore pagination',
+
+    'category_uri_variables_parse_file_paths' => 'Parse file paths',
+
+    'category_uri_variables_category_groups_desc' => 'Limit the search for matching categories by selected groups. When no groups are selected, all groups will be searched.',
+
+    'category_uri_variables_uri_pattern_desc' => 'Enter a regex pattern or leave blank. If you enter a pattern, the variables will only be registered if the current URI matches it.',
+
+    'category_uri_variables_set_all_segments_desc' => 'Always set variables for all (9) segments, regardless of their presence.',
+
+    'category_uri_variables_ignore_pagination_desc' => 'Ignore the presence of a pagination segment at the end of a URI.',
+
+    'category_uri_variables_parse_file_paths_desc' => 'Parse upload directory variables inside the Category Image field',
 
     /* Logging */
 

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -919,6 +919,10 @@ $lang = array(
 
     'enable_category_uri_variables_desc' => 'Always parse URI segments as category URI variables for category URLs.',
 
+    'enable_request_variables' => 'Enable Request Variables',
+
+    'enable_request_variables_desc' => 'Populate HTTP request data as template variables',
+
     'category_uri_variables_settings' => 'Category URI Variables Settings',
 
     'category_uri_variables_category_groups' => 'Category groups',

--- a/system/ee/legacy/core/Config.php
+++ b/system/ee/legacy/core/Config.php
@@ -625,6 +625,12 @@ class EE_Config
             'automatic_frontedit_links',
             'enable_mfa',
             'anonymize_consent_logs',
+            'enable_category_uri_variables',
+            'category_uri_variables_category_groups',
+            'category_uri_variables_uri_pattern',
+            'category_uri_variables_set_all_segments',
+            'category_uri_variables_ignore_pagination',
+            'category_uri_variables_parse_file_paths'
         );
 
         $member_default = array(

--- a/system/ee/legacy/core/Config.php
+++ b/system/ee/legacy/core/Config.php
@@ -630,7 +630,8 @@ class EE_Config
             'category_uri_variables_uri_pattern',
             'category_uri_variables_set_all_segments',
             'category_uri_variables_ignore_pagination',
-            'category_uri_variables_parse_file_paths'
+            'category_uri_variables_parse_file_paths',
+            'enable_request_variables'
         );
 
         $member_default = array(

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -461,6 +461,22 @@ class EE_Core
      */
     public function loadUriVariables()
     {
+        // $data is used to add to global vars
+        $data = array();
+
+        if (bool_config_item('enable_request_variables')) {
+            $data['https'] = ee('Request')->isEncrypted();
+            foreach ($_POST as $key => $val) {
+                if (in_array($key, ['password', 'password_confirm', 'csrf_token', 'XID'])) {
+                    continue;
+                }
+                $data['post:' . ee()->input->_clean_input_keys($key)] = ee('Security/XSS')->clean($val);
+            }
+            foreach ($_GET as $key => $val) {
+                $data['get:' . ee()->input->_clean_input_keys($key)] = ee('Security/XSS')->clean($val);
+            }
+        }
+
         if (bool_config_item('enable_category_uri_variables')) {
             // --------------------------------------
             // Only continue if request is a page
@@ -514,11 +530,10 @@ class EE_Core
 
             // --------------------------------------
             // Initiate some vars
-            // $data is used to add to global vars
             // $ids is used to keep track of all category ids found
             // --------------------------------------
 
-            $data = $ids = array();
+            $ids = array();
 
             // Also initiate this single var to an empty string
             $data['segment_category_ids'] = '';
@@ -653,11 +668,12 @@ class EE_Core
                     $data['segment_category_ids_piped'] = implode('|', $ids);
                 }
             }
+        }
 
-            // --------------------------------------
-            // Finally, add data to global vars
-            // --------------------------------------
-
+        // --------------------------------------
+        // Finally, add data to global vars
+        // --------------------------------------
+        if (!empty($data)) {
             ee()->config->_global_vars = array_merge(ee()->config->_global_vars, $data);
         }
     }


### PR DESCRIPTION
Enabled automatic creation of template variables with category information based on current URI
(in other words, this integrated Low Seg2Cat with same variables)

Enabled displaying GET and POST variables in templates
(in other words, this integrates a bit of what is in Mo' Variables add-on)

Added 'URI Variables' section in settings