### PR TITLE
Fix PHP warning when resetting password.

### DIFF
--- a/system/ee/ExpressionEngine/Service/Validation/Rule/ValidPassword.php
+++ b/system/ee/ExpressionEngine/Service/Validation/Rule/ValidPassword.php
@@ -37,14 +37,17 @@ class ValidPassword extends ValidationRule
             return false;
         }
 
-        //  Make UN/PW lowercase for testing
-        $lc_user = strtolower($this->all_values['username']);
-        $lc_pass = strtolower($password);
-        $nm_pass = strtr($lc_pass, 'elos', '3105');
+        //  Username may not be set if resetting password
+        if (! empty($this->all_values['username'])) {
+            //  Make UN/PW lowercase for testing
+            $lc_user = strtolower($this->all_values['username']);
+            $lc_pass = strtolower($password);
+            $nm_pass = strtr($lc_pass, 'elos', '3105');
 
-        if ($lc_user == $lc_pass or $lc_user == strrev($lc_pass) or $lc_user == $nm_pass or $lc_user == strrev($nm_pass)) {
-            $this->last_error = 'password_based_on_username';
-            return false;
+            if ($lc_user == $lc_pass or $lc_user == strrev($lc_pass) or $lc_user == $nm_pass or $lc_user == strrev($nm_pass)) {
+                $this->last_error = 'password_based_on_username';
+                return false;
+            }
         }
 
         // Does password exist in dictionary?


### PR DESCRIPTION
PHP 8, when you reset the password on the frontend, you can get a 

Severity: E_WARNING  --> Undefined array key "username" /Users/robinsowell/Sites/6.1.5/system/ee/ExpressionEngine/Service/Validation/Rule/ValidPassword.php 41

May/may not show depending on redirects, but user saw the error and I see it in my logs.  Username isn't set when submitting the password change form.

Alternative fix would be to go get the username when missing. 
