### PR TITLE
Forgotten password redirect in member module

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -779,7 +779,8 @@ class Member_auth extends Member
                 'link' => array($return, $site_name)
             );
 
-            ee()->output->show_message($data);
+            // If we have a success return link, go to that, otherwise, output the standard message.
+            ee()->output->show_message($data, true, $return_success_link);	
         }
 
         $member_id = $memberQuery->row('member_id');


### PR DESCRIPTION
The behavior of the forgotten password form should be the same for submitting a bad email (one that doesn't exist) vs a good email, to eliminate attempts to brute force it.

However, the behavior can vary under certain settings, so this cleans that up.

