### PR TITLE
Resolved #4393 where Low search settings were not saved when migrating to Pro search

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_settings.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_settings.php
@@ -107,7 +107,7 @@ class Pro_search_settings
      */
     public function set($settings)
     {
-        $this->_settings = array_merge($this->_default_settings, $settings);
+        $this->_settings = array_merge($this->get(), $settings);
     }
 
     /**


### PR DESCRIPTION
Resolved #4393 where Low search settings were not saved when migrating to Pro search