### PR TITLE
Resolved #4468 where link to list all members in a role was not correct on Roles page

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Roles/Roles.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Roles/Roles.php
@@ -141,7 +141,7 @@ class Roles extends AbstractRolesController
                 'selected' => ($role_id && $role->getId() == $role_id),
                 'toolbar_items' => [
                     'members' => [
-                        'href' => ee('CP/URL', 'members', ['role_filter' => $role->getId()]),
+                        'href' => ee('CP/URL')->make('members', ['role_filter' => $role->getId()]),
                         'title' => lang('members'),
                         'content' => '<i class="fal fa-users"></i> ' . $role->total_members . ' ' . lang('members')
                     ]


### PR DESCRIPTION
Resolved #4468 where link to list all members in a role was not correct on Roles page