### PR TITLE
Enabled use of all file field variables within modifier tag pair; #4335

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -656,11 +656,11 @@ JSC;
             return ($return_as_path ? $destination_path : $destination_url);
         } else {
             // tag pair
-            $vars = [
+            $vars = array_merge($data, [
                 'url' => $destination_url,
                 'width' => $props['width'],
                 'height' => $props['height']
-            ];
+            ]);
 
             return ee()->TMPL->parse_variables($tagdata, [$vars]);
         }


### PR DESCRIPTION
Enabled use of all file field variables within modifier tag pair; #4335

e.g. {title}, {file_name}, {description} within {image:resize} tag pair
