### PR TITLE
Treat smart quotes more lightly when searching; #4359

### DIFF
--- a/system/ee/legacy/database/drivers/mysqli/mysqli_driver.php
+++ b/system/ee/legacy/database/drivers/mysqli/mysqli_driver.php
@@ -233,6 +233,8 @@ class CI_DB_mysqli_driver extends CI_DB
         // escape LIKE condition wildcards
         if ($like === true) {
             $str = str_replace(array('%', '_'), array('\\%', '\\_'), $str);
+            // fancy quotes can cause confusion on both sides, make them match any character
+            $str = str_replace(['“', '”', '‘', '’'], '_', $str);
         }
 
         return $str;


### PR DESCRIPTION
Treat smart quotes more lightly when searching; #4359

As described in referenced discussion, if you use fancy quotes in entry title and then try to search for it using normal quotes, the entry is not found.

Which is - technically - to be expected because these are different characters and we're using mysql LIKE to search

The most obvious solution was to replace fancy quotes with normal quotes when searching, but that would only solve one side of the problem and would have exactly opposite effect if both entry title and search string would use fancy quotes - nothing will be found.

So the proposed solution here is to *ignore* fancy quotes when building LIKE string, i.e. any character would match.

The thing we need to be aware of is that this is global change that would affect all LIKE queries