### PR TITLE
Add buttons for template routes, variables and partials at the top of Template Manager

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Design/AbstractDesign.php
+++ b/system/ee/ExpressionEngine/Controller/Design/AbstractDesign.php
@@ -237,17 +237,42 @@ abstract class AbstractDesign extends CP_Controller
         $header = array(
             'title' => lang('template_manager'),
             'search_form_url' => ee('CP/URL')->make('design/template/search', array('return' => $return)),
-            'toolbar_items' => array(
-                'settings' => array(
-                    'href' => ee('CP/URL')->make('settings/template'),
-                    'title' => lang('settings')
-                ),
-            ),
+            'toolbar_items' => array(),
             'search_button_value' => lang('search_templates')
         );
 
-        if (! ee('Permission')->hasAll('can_access_sys_prefs', 'can_admin_design')) {
-            unset($header['toolbar_items']['settings']);
+        // Template Partials
+        if (ee('Permission')->hasAny('can_create_template_partials', 'can_edit_template_partials', 'can_delete_template_partials')) {
+            $header['toolbar_items']['snippets'] = array(
+                'href' => ee('CP/URL', 'design/snippets'),
+                'class' => 'fal fa-shapes',
+                'title' => lang('template_partials')
+            );
+        }
+
+        // Template Variables
+        if (ee('Permission')->hasAny('can_create_template_variables', 'can_edit_template_variables', 'can_delete_template_variables')) {
+            $header['toolbar_items']['variables'] = array(
+                'href' => ee('CP/URL', 'design/variables'),
+                'class' => 'fal fa-cube',
+                'title' => lang('template_variables')
+            );
+        }
+
+        // Template Routes
+        if (! TemplateRoute::getConfig() && ee('Permission')->can('admin_design')) {
+            $header['toolbar_items']['routes'] = array(
+                'href' => ee('CP/URL', 'design/routes'),
+                'class' => 'fal fa-truck',
+                'title' => lang('template_routes')
+            );
+        }
+
+        if (ee('Permission')->hasAll('can_access_sys_prefs', 'can_admin_design')) {
+            $header['toolbar_items']['settings'] = array(
+                'href' => ee('CP/URL', 'settings/template'),
+                'title' => lang('settings')
+            );
         }
 
         if (ee('Model')->get('Template')->count() > 0 && ee('Permission')->isSuperAdmin()) {

--- a/system/ee/ExpressionEngine/View/_templates/default-nav.php
+++ b/system/ee/ExpressionEngine/View/_templates/default-nav.php
@@ -13,7 +13,7 @@
     <div class="main-nav__toolbar">
         <?php if (isset($header['toolbar_items']) && $header['toolbar_items']): ?>
             <?php foreach ($header['toolbar_items'] as $name => $item): ?>
-                <a class="button button--secondary icon--<?=$name?>" href="<?=$item['href']?>" title="<?=$item['title']?> <?=lang('button')?>"><span class="hidden"><?=$item['title']?></span></a>
+                <a class="button button--secondary <?=(isset($item['class'])) ? $item['class'] : 'icon--' . $name?>" href="<?=$item['href']?>" title="<?=$item['title']?>"><span class="hidden"><?=$item['title'] . ' ' . lang('button')?></span></a>
             <?php endforeach; ?>
         <?php endif ?>
 

--- a/tests/cypress/cypress/integration/design/template_variables.ee6.js
+++ b/tests/cypress/cypress/integration/design/template_variables.ee6.js
@@ -47,7 +47,7 @@ context('Template Variables', () => {
     })
 
     it('Validate variable form', function() {
-        cy.get('a').contains('Template Variable').first().click()
+        cy.get('a.sidebar__link').contains('Template Variable').first().click()
         //page.get('create_new_button').click()
         cy.get('a').contains('Create New').first().click()
 
@@ -58,7 +58,7 @@ context('Template Variables', () => {
 
     it('Create new variable', function() {
         // 'Cannot figure out how to populate a codemirror form element'
-        cy.get('a').contains('Template Variable').first().click()
+        cy.get('a.sidebar__link').contains('Template Variable').first().click()
 
         //page.get('create_new_button').click()
         cy.get('a').contains('Create New').first().click()


### PR DESCRIPTION
I find it very inconvenient that every time I need to access template variables or routes I need to scroll all way down (I have a lot of template groups)

This PR is adding shortcut buttons for those at the top
![image](https://github.com/user-attachments/assets/24602f8f-8af8-48eb-b6fd-045306977e2d)
 