### PR TITLE
Fixed #4490 Typo

### DIFF
--- a/system/ee/ExpressionEngine/View/_shared/table.php
+++ b/system/ee/ExpressionEngine/View/_shared/table.php
@@ -397,7 +397,7 @@ else: ?>
                             $column_badge = isset($columns[$key]['badge']) ? $columns[$key]['badge'] : '';
 
                             $column_label = "<div class=\"grid-field__column-label\"  role=\"rowheader\">
-                                <div class=\"grid-field__column-label__instraction\">
+                                <div class=\"grid-field__column-label__instruction\">
                                     <label>";
                             if (isset($columns[$key]['required']) && $columns[$key]['required']) {
                                 $column_label .= "


### PR DESCRIPTION
Fixed #4490 Typo

I checked all files, we don't use this class anywhere, neither in css nor in js