### PR TITLE
Fix htmlentities(): Handle array case in Filter.php

### DIFF
--- a/system/ee/ExpressionEngine/Service/Filter/Filter.php
+++ b/system/ee/ExpressionEngine/Service/Filter/Filter.php
@@ -93,14 +93,25 @@ abstract class Filter
         if (isset($this->selected_value)) {
             return $this->selected_value;
         }
-
+    
         $value = $this->derivedValue();
-
+    
         if (! $this->has_custom_value) {
             $value = $this->isValid() ? $value : null;
         }
-
-        return is_null($value) ? null : htmlentities($value, ENT_NOQUOTES, 'UTF-8');
+    
+        // Check if $value is an array, and handle it appropriately
+        if (is_null($value)) {
+            return null;
+        }
+    
+        // If it's an array, you could handle it in various ways (e.g., convert it to a string)
+        if (is_array($value)) {
+            // Convert array to a string (e.g., comma-separated values)
+            $value = implode(', ', $value);
+        }
+    
+        return htmlentities($value, ENT_NOQUOTES, 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/ExpressionEngine/ExpressionEngine/issues/4525

Issue:

When navigating the Developer Logs section, if a specific date is selected from the date filter dropdown and a pagination link is clicked, the following error occurs:

```
TypeError Caught
htmlentities(): Argument #1 ($string) must be of type string, array given
```

Location:
ee/ExpressionEngine/Service/Filter/Filter.php:103

Cause:
The value() method in Filter.php is passing an array to htmlentities(), which expects a string.

Fix:
Updated the value() method in Filter.php to handle cases where the value is an array by converting it to a string before passing it to htmlentities().