### PR TITLE
Restore field_name_badge view that may be used by Third Party Add-ons

### DIFF
--- a/system/ee/ExpressionEngine/View/publish/partials/field_name_badge.php
+++ b/system/ee/ExpressionEngine/View/publish/partials/field_name_badge.php
@@ -1,0 +1,5 @@
+<span class="app-badge label-app-badge js-app-badge">
+    <span class="txt-only">{<?=$name?>}</span>
+    <i class="fa-light fa-copy"></i>
+    <i class="fa-sharp fa-solid fa-circle-check hidden"></i>
+</span>


### PR DESCRIPTION
This file was removed because it was no longer referenced by the core in 7.5.0. However it was possible for Third-Party Add-ons to include it so we are restoring the file to avoid breaking changes in this release