### PR TITLE
Add colorpicker modifiers to manipulate the color value

### DIFF
--- a/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
+++ b/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
@@ -206,7 +206,7 @@ class Colorpicker_ft extends EE_Fieldtype
     public function replace_complementary($data, $params = [], $tagdata = false)
     {
         try {
-            return (new Color($data))->complementary();
+            return "#" . (new Color($data))->complementary();
         } catch (\Exception $e) {}
 
         return $data;
@@ -222,7 +222,7 @@ class Colorpicker_ft extends EE_Fieldtype
         try {
             $percent = $params['percent'] ?? 10;
             $percent = min(0, max(100, $percent)); // value between 0-100
-            return (new Color($data))->darken($percent);
+            return "#" . (new Color($data))->darken($percent);
         } catch (\Exception $e) {}
 
         return $data;
@@ -238,7 +238,7 @@ class Colorpicker_ft extends EE_Fieldtype
         try {
             $percent = $params['percent'] ?? 10;
             $percent = min(0, max(100, $percent)); // value between 0-100
-            return (new Color($data))->lighten($percent);
+            return "#" . (new Color($data))->lighten($percent);
         } catch (\Exception $e) {}
 
         return $data;
@@ -257,7 +257,7 @@ class Colorpicker_ft extends EE_Fieldtype
             $second = $params['color'] ?? (($first->isLight() ? '#000000' : '#ffffff'));
             $percent = $params['percent'] ?? 50;
             $percent = min(0, max(100, $percent)); // value between 0-100
-            return $first->mix($second, $percent);
+            return "#" . $first->mix($second, $percent);
         } catch (\Exception $e) {}
 
         return $data;

--- a/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
+++ b/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
@@ -198,6 +198,71 @@ class Colorpicker_ft extends EE_Fieldtype
         return $contrast;
     }
 
+    /**
+     * :complementary modifier
+     *
+     * Returns the color "opposite" or complementary to your color.
+     */
+    public function replace_complementary($data, $params = [], $tagdata = false)
+    {
+        try {
+            return (new Color($data))->complementary();
+        } catch (\Exception $e) {}
+
+        return $data;
+    }
+
+    /**
+     * :darken modifier
+     *
+     * Returns a darker shade of your color
+     */
+    public function replace_darken($data, $params = [], $tagdata = false)
+    {
+        try {
+            $percent = $params['percent'] ?? 10;
+            $percent = min(0, max(100, $percent)); // value between 0-100
+            return (new Color($data))->darken($percent);
+        } catch (\Exception $e) {}
+
+        return $data;
+    }
+
+    /**
+     * :lighten modifier
+     *
+     * Returns a lighter tint of your color
+     */
+    public function replace_lighten($data, $params = [], $tagdata = false)
+    {
+        try {
+            $percent = $params['percent'] ?? 10;
+            $percent = min(0, max(100, $percent)); // value between 0-100
+            return (new Color($data))->lighten($percent);
+        } catch (\Exception $e) {}
+
+        return $data;
+    }
+
+
+    /**
+     * :mix modifier
+     *
+     * Returns a combination of two colors
+     */
+    public function replace_mix($data, $params = [], $tagdata = false)
+    {
+        try {
+            $first = new Color($data);
+            $second = $params['color'] ?? (($first->isLight() ? '#000000' : '#ffffff'));
+            $percent = $params['percent'] ?? 50;
+            $percent = min(0, max(100, $percent)); // value between 0-100
+            return $first->mix($second, $percent);
+        } catch (\Exception $e) {}
+
+        return $data;
+    }
+
     // -----------------------------------------------------------------------
     // Settings
     // -----------------------------------------------------------------------

--- a/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
+++ b/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
@@ -221,7 +221,7 @@ class Colorpicker_ft extends EE_Fieldtype
     {
         try {
             $percent = $params['percent'] ?? 10;
-            $percent = min(0, max(100, $percent)); // value between 0-100
+            $percent = max(0, min(100, $percent)); // value between 0-100
             return "#" . (new Color($data))->darken($percent);
         } catch (\Exception $e) {}
 
@@ -237,8 +237,68 @@ class Colorpicker_ft extends EE_Fieldtype
     {
         try {
             $percent = $params['percent'] ?? 10;
-            $percent = min(0, max(100, $percent)); // value between 0-100
+            $percent = max(0, min(100, $percent)); // value between 0-100
             return "#" . (new Color($data))->lighten($percent);
+        } catch (\Exception $e) {}
+
+        return $data;
+    }
+
+     /**
+     * :rotate modifier
+     *
+     * Returns a color with a hue rotated X degrees
+     */
+    public function replace_rotate($data, $params = [], $tagdata = false)
+    {
+        try {
+            $degrees = $params['degrees'] ?? 0;
+            $hsl = Color::hexToHsl($data);
+            $hsl['H'] = ($hsl['H'] + $degrees) % 360;
+
+            return "#" . Color::hslToHex($hsl);
+        } catch (\Exception $e) {}
+
+        return $data;
+    }
+
+    /**
+     * :saturate modifier
+     *
+     * Returns a more saturated color
+     */
+    public function replace_saturate($data, $params = [], $tagdata = false)
+    {
+        try {
+            $percent = $params['percent'] ?? 10;
+            $percent = max(0, min(100, $percent)); // value between 0-100
+
+            $hsl = Color::hexToHsl($data);
+            $hsl['S'] = ($hsl['S'] * 100) + $percent;
+            $hsl['S'] = ($hsl['S'] > 100) ? 1 : $hsl['S'] / 100;
+
+            return "#" . Color::hslToHex($hsl);
+        } catch (\Exception $e) {}
+
+        return $data;
+    }
+
+    /**
+     * :desaturate modifier
+     *
+     * Returns a less saturated color
+     */
+    public function replace_desaturate($data, $params = [], $tagdata = false)
+    {
+        try {
+            $percent = $params['percent'] ?? 10;
+            $percent = max(0, min(100, $percent)); // value between 0-100
+
+            $hsl = Color::hexToHsl($data);
+            $hsl['S'] = ($hsl['S'] * 100) - $percent;
+            $hsl['S'] = ($hsl['S'] < 0) ? 0 : $hsl['S'] / 100;
+
+            return "#" . Color::hslToHex($hsl);
         } catch (\Exception $e) {}
 
         return $data;
@@ -256,8 +316,41 @@ class Colorpicker_ft extends EE_Fieldtype
             $first = new Color($data);
             $second = $params['color'] ?? (($first->isLight() ? '#000000' : '#ffffff'));
             $percent = $params['percent'] ?? 50;
-            $percent = min(0, max(100, $percent)); // value between 0-100
+            $percent = max(0, min(100, $percent)); // value between 0-100
             return "#" . $first->mix($second, $percent);
+        } catch (\Exception $e) {}
+
+        return $data;
+    }
+
+    /**
+     * :rgb modifier
+     *
+     * Returns the rgb string for the color
+     */
+    public function replace_rgb($data, $params = [], $tagdata = false)
+    {
+        try {
+            return implode(', ',(new Color($data))->getRgb());
+        } catch (\Exception $e) {}
+
+        return $data;
+    }
+
+    /**
+     * :hsl modifier
+     *
+     * Returns the hsl string for the color
+     */
+    public function replace_hsl($data, $params = [], $tagdata = false)
+    {
+        try {
+            $hsl = (new Color($data))->getHsl();
+            return implode(' ', [
+                (int) $hsl['H'],
+                (int) ($hsl['S'] * 100),
+                (int) ($hsl['L'] * 100),
+            ]);
         } catch (\Exception $e) {}
 
         return $data;

--- a/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
+++ b/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
@@ -8,6 +8,9 @@
  */
 
 use Mexitek\PHPColors\Color;
+use ExpressionEngine\Service\Accessibility\Color\ContrastAlgorithm;
+use ExpressionEngine\Service\Accessibility\Color\Gpc;
+use ExpressionEngine\Service\Accessibility\Color\Wcag;
 
 class Colorpicker_ft extends EE_Fieldtype
 {
@@ -206,7 +209,11 @@ class Colorpicker_ft extends EE_Fieldtype
     public function replace_complementary($data, $params = [], $tagdata = false)
     {
         try {
-            return "#" . (new Color($data))->complementary();
+            return $this->applyContrast(
+                $data,
+                "#" . (new Color($data))->complementary(),
+                $params
+            );
         } catch (\Exception $e) {}
 
         return $data;
@@ -224,10 +231,10 @@ class Colorpicker_ft extends EE_Fieldtype
             $color = new Color($data);
 
             if ((int) $percent === 0) {
-                return "#" . $color->getHex();
+                return $this->applyContrast($data, "#" . $color->getHex(), $params);
             }
 
-            return "#" . $color->darken((int) $percent);
+            return $this->applyContrast($data, "#" . $color->darken((int) $percent), $params);
         } catch (\Exception $e) {}
 
         return $data;
@@ -245,10 +252,10 @@ class Colorpicker_ft extends EE_Fieldtype
             $color = new Color($data);
 
             if ((int) $percent === 0) {
-                return "#" . $color->getHex();
+                return $this->applyContrast($data, "#" . $color->getHex(), $params);
             }
 
-            return "#" . $color->lighten((int) $percent);
+            return $this->applyContrast($data, "#" . $color->lighten((int) $percent), $params);
         } catch (\Exception $e) {}
 
         return $data;
@@ -270,7 +277,7 @@ class Colorpicker_ft extends EE_Fieldtype
                 $hsl['H'] += 360.0;
             }
 
-            return "#" . Color::hslToHex($hsl);
+            return $this->applyContrast($data, "#" . Color::hslToHex($hsl), $params);
         } catch (\Exception $e) {}
 
         return $data;
@@ -290,7 +297,7 @@ class Colorpicker_ft extends EE_Fieldtype
             $hsl['S'] = ($hsl['S'] * 100) + $percent;
             $hsl['S'] = ($hsl['S'] > 100) ? 1 : $hsl['S'] / 100;
 
-            return "#" . Color::hslToHex($hsl);
+            return $this->applyContrast($data, "#" . Color::hslToHex($hsl), $params);
         } catch (\Exception $e) {}
 
         return $data;
@@ -310,7 +317,7 @@ class Colorpicker_ft extends EE_Fieldtype
             $hsl['S'] = ($hsl['S'] * 100) - $percent;
             $hsl['S'] = ($hsl['S'] < 0) ? 0 : $hsl['S'] / 100;
 
-            return "#" . Color::hslToHex($hsl);
+            return $this->applyContrast($data, "#" . Color::hslToHex($hsl), $params);
         } catch (\Exception $e) {}
 
         return $data;
@@ -330,7 +337,7 @@ class Colorpicker_ft extends EE_Fieldtype
             $percent = $this->normalizePercent($params['percent'] ?? null, 50);
             $mixAmount = 100 - (2 * $percent);
 
-            return "#" . $first->mix($second, (int) $mixAmount);
+            return $this->applyContrast($data, "#" . $first->mix($second, (int) $mixAmount), $params);
         } catch (\Exception $e) {}
 
         return $data;
@@ -376,6 +383,49 @@ class Colorpicker_ft extends EE_Fieldtype
         }
 
         return max(0, min(100, (float) $value));
+    }
+
+    private function applyContrast($reference, string $color, array $params): string
+    {
+        $algorithm = $this->contrastAlgorithm($params);
+
+        if ($algorithm === null) {
+            return $color;
+        }
+
+        $target = $this->contrastTarget($params, $algorithm);
+
+        return $algorithm->adjustForegroundForBackground(
+            Color::hexToRgb($color),
+            Color::hexToRgb($reference),
+            $target
+        );
+    }
+
+    private function contrastAlgorithm(array $params)
+    {
+        if (array_key_exists('contrast_ratio', $params)) {
+            return new Wcag();
+        }
+
+        if (array_key_exists('perceptual_contrast', $params)) {
+            return new Gpc();
+        }
+
+        return null;
+    }
+
+    private function contrastTarget(array $params, ContrastAlgorithm $algorithm): float
+    {
+        $value = ($algorithm instanceof Gpc)
+            ? $params['perceptual_contrast']
+            : $params['contrast_ratio'];
+
+        if ($value === '' || ! is_numeric($value)) {
+            $value = $algorithm->defaultTarget();
+        }
+
+        return $algorithm->normalizeTarget((float) $value);
     }
 
     // -----------------------------------------------------------------------

--- a/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
+++ b/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
@@ -221,7 +221,13 @@ class Colorpicker_ft extends EE_Fieldtype
     {
         try {
             $percent = $this->normalizePercent($params['percent'] ?? null, 10);
-            return "#" . (new Color($data))->darken((int) $percent);
+            $color = new Color($data);
+
+            if ((int) $percent === 0) {
+                return "#" . $color->getHex();
+            }
+
+            return "#" . $color->darken((int) $percent);
         } catch (\Exception $e) {}
 
         return $data;
@@ -236,7 +242,13 @@ class Colorpicker_ft extends EE_Fieldtype
     {
         try {
             $percent = $this->normalizePercent($params['percent'] ?? null, 10);
-            return "#" . (new Color($data))->lighten((int) $percent);
+            $color = new Color($data);
+
+            if ((int) $percent === 0) {
+                return "#" . $color->getHex();
+            }
+
+            return "#" . $color->lighten((int) $percent);
         } catch (\Exception $e) {}
 
         return $data;
@@ -316,7 +328,9 @@ class Colorpicker_ft extends EE_Fieldtype
             $first = new Color($data);
             $second = $params['color'] ?? (($first->isLight() ? '#000000' : '#ffffff'));
             $percent = $this->normalizePercent($params['percent'] ?? null, 50);
-            return "#" . $first->mix($second, (int) $percent);
+            $mixAmount = 100 - (2 * $percent);
+
+            return "#" . $first->mix($second, (int) $mixAmount);
         } catch (\Exception $e) {}
 
         return $data;
@@ -345,10 +359,10 @@ class Colorpicker_ft extends EE_Fieldtype
     {
         try {
             $hsl = (new Color($data))->getHsl();
-            return implode(' ', [
-                (int) $hsl['H'],
-                (int) ($hsl['S'] * 100),
-                (int) ($hsl['L'] * 100),
+            return implode(', ', [
+                (int) round($hsl['H']),
+                (int) round($hsl['S'] * 100) . '%',
+                (int) round($hsl['L'] * 100) . '%',
             ]);
         } catch (\Exception $e) {}
 

--- a/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
+++ b/system/ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php
@@ -220,9 +220,8 @@ class Colorpicker_ft extends EE_Fieldtype
     public function replace_darken($data, $params = [], $tagdata = false)
     {
         try {
-            $percent = $params['percent'] ?? 10;
-            $percent = max(0, min(100, $percent)); // value between 0-100
-            return "#" . (new Color($data))->darken($percent);
+            $percent = $this->normalizePercent($params['percent'] ?? null, 10);
+            return "#" . (new Color($data))->darken((int) $percent);
         } catch (\Exception $e) {}
 
         return $data;
@@ -236,9 +235,8 @@ class Colorpicker_ft extends EE_Fieldtype
     public function replace_lighten($data, $params = [], $tagdata = false)
     {
         try {
-            $percent = $params['percent'] ?? 10;
-            $percent = max(0, min(100, $percent)); // value between 0-100
-            return "#" . (new Color($data))->lighten($percent);
+            $percent = $this->normalizePercent($params['percent'] ?? null, 10);
+            return "#" . (new Color($data))->lighten((int) $percent);
         } catch (\Exception $e) {}
 
         return $data;
@@ -252,9 +250,13 @@ class Colorpicker_ft extends EE_Fieldtype
     public function replace_rotate($data, $params = [], $tagdata = false)
     {
         try {
-            $degrees = $params['degrees'] ?? 0;
+            $degrees = (float) ($params['degrees'] ?? 0);
             $hsl = Color::hexToHsl($data);
-            $hsl['H'] = ($hsl['H'] + $degrees) % 360;
+            $hsl['H'] = fmod($hsl['H'] + $degrees, 360.0);
+
+            if ($hsl['H'] < 0) {
+                $hsl['H'] += 360.0;
+            }
 
             return "#" . Color::hslToHex($hsl);
         } catch (\Exception $e) {}
@@ -270,8 +272,7 @@ class Colorpicker_ft extends EE_Fieldtype
     public function replace_saturate($data, $params = [], $tagdata = false)
     {
         try {
-            $percent = $params['percent'] ?? 10;
-            $percent = max(0, min(100, $percent)); // value between 0-100
+            $percent = $this->normalizePercent($params['percent'] ?? null, 10);
 
             $hsl = Color::hexToHsl($data);
             $hsl['S'] = ($hsl['S'] * 100) + $percent;
@@ -291,8 +292,7 @@ class Colorpicker_ft extends EE_Fieldtype
     public function replace_desaturate($data, $params = [], $tagdata = false)
     {
         try {
-            $percent = $params['percent'] ?? 10;
-            $percent = max(0, min(100, $percent)); // value between 0-100
+            $percent = $this->normalizePercent($params['percent'] ?? null, 10);
 
             $hsl = Color::hexToHsl($data);
             $hsl['S'] = ($hsl['S'] * 100) - $percent;
@@ -315,9 +315,8 @@ class Colorpicker_ft extends EE_Fieldtype
         try {
             $first = new Color($data);
             $second = $params['color'] ?? (($first->isLight() ? '#000000' : '#ffffff'));
-            $percent = $params['percent'] ?? 50;
-            $percent = max(0, min(100, $percent)); // value between 0-100
-            return "#" . $first->mix($second, $percent);
+            $percent = $this->normalizePercent($params['percent'] ?? null, 50);
+            return "#" . $first->mix($second, (int) $percent);
         } catch (\Exception $e) {}
 
         return $data;
@@ -354,6 +353,15 @@ class Colorpicker_ft extends EE_Fieldtype
         } catch (\Exception $e) {}
 
         return $data;
+    }
+
+    private function normalizePercent($value, $default): float
+    {
+        if ($value === null || $value === '' || ! is_numeric($value)) {
+            $value = $default;
+        }
+
+        return max(0, min(100, (float) $value));
     }
 
     // -----------------------------------------------------------------------

--- a/system/ee/ExpressionEngine/Service/Accessibility/Color/ContrastAlgorithm.php
+++ b/system/ee/ExpressionEngine/Service/Accessibility/Color/ContrastAlgorithm.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace ExpressionEngine\Service\Accessibility\Color;
+
+/**
+ * Adjust colors against a contrast target.
+ *
+ * Implementations may use different contrast units, so callers should obtain
+ * the default and normalize targets through the selected algorithm instance.
+ */
+interface ContrastAlgorithm
+{
+    /**
+     * Return the default target used when a user enables the algorithm without
+     * providing a numeric value.
+     *
+     * @return float
+     */
+    public function defaultTarget(): float;
+
+    /**
+     * Clamp a requested target to the algorithm's supported range.
+     *
+     * @param float $value
+     * @return float
+     */
+    public function normalizeTarget(float $value): float;
+
+    /**
+     * Calculate the contrast value between two colors.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $foregroundRgb
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @return float
+     */
+    public function contrast(array $foregroundRgb, array $backgroundRgb): float;
+
+    /**
+     * Find a grayscale foreground color that reaches the requested target.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @param float $target
+     * @return string A normalized six-digit hex color including "#".
+     */
+    public function foregroundForBackground(array $backgroundRgb, float $target): string;
+
+    /**
+     * Adjust a foreground color until it reaches the requested target.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $foregroundRgb
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @param float $target
+     * @return string A normalized six-digit hex color including "#".
+     */
+    public function adjustForegroundForBackground(array $foregroundRgb, array $backgroundRgb, float $target): string;
+}

--- a/system/ee/ExpressionEngine/Service/Accessibility/Color/Gpc.php
+++ b/system/ee/ExpressionEngine/Service/Accessibility/Color/Gpc.php
@@ -1,0 +1,512 @@
+<?php
+
+namespace ExpressionEngine\Service\Accessibility\Color;
+
+/**
+ * Calculate and search generic perceptual contrast values for sRGB colors.
+ *
+ * The base contrast prediction math is polarity-sensitive. Public methods keep
+ * the terms "foreground" and "background" so callers do not swap colors and
+ * reuse a result without recalculating contrast.
+ */
+class Gpc implements ContrastAlgorithm
+{
+    /**
+     * Return the default generic perceptual contrast target.
+     *
+     * @return float
+     */
+    public function defaultTarget(): float
+    {
+        return 60.0;
+    }
+
+    /**
+     * Clamp a requested generic perceptual contrast target.
+     *
+     * @param float $value
+     * @return float
+     */
+    public function normalizeTarget(float $value): float
+    {
+        $sign = ($value < 0) ? -1 : 1;
+
+        return $sign * min(108, abs($value));
+    }
+
+    /**
+     * Calculate the signed perceptual contrast value between two colors.
+     *
+     * Positive values indicate a darker foreground on a lighter background.
+     * Negative values indicate a lighter foreground on a darker background.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $foregroundRgb
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @return float
+     */
+    public function contrast(array $foregroundRgb, array $backgroundRgb): float
+    {
+        return $this->contrastFromLuminance(
+            $this->sRgbToY($foregroundRgb),
+            $this->sRgbToY($backgroundRgb)
+        );
+    }
+
+    /**
+     * Calculate the signed perceptual contrast value between two colors.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $foregroundRgb
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @return float
+     */
+    public function lightnessContrast(array $foregroundRgb, array $backgroundRgb): float
+    {
+        return $this->contrast($foregroundRgb, $backgroundRgb);
+    }
+
+    /**
+     * Find a grayscale foreground color that reaches the requested target.
+     *
+     * Positive targets allow either readable polarity and prefer the practical
+     * polarity for the given background. Negative targets request a light
+     * foreground on a dark background. When the exact target cannot be reached,
+     * the method returns the highest contrast grayscale endpoint.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @param float $target
+     * @return string A normalized six-digit hex color including "#".
+     */
+    public function foregroundForBackground(array $backgroundRgb, float $target = 60): string
+    {
+        if ($target == 0) {
+            return $this->rgbToHex($backgroundRgb);
+        }
+
+        $backgroundY = $this->sRgbToY($backgroundRgb);
+
+        return $this->findForeground($backgroundY, $this->normalizeTarget($target));
+    }
+
+    /**
+     * Adjust a foreground color until it reaches the requested contrast target.
+     *
+     * The method first returns the foreground unchanged when it already satisfies
+     * the target. Otherwise it searches HSL lightness while preserving the
+     * foreground hue and saturation, tries the opposite polarity if needed, and
+     * finally falls back to a grayscale search.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $foregroundRgb
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @param float $target
+     * @return string A normalized six-digit hex color including "#".
+     */
+    public function adjustForegroundForBackground(array $foregroundRgb, array $backgroundRgb, float $target = 60): string
+    {
+        $target = $this->normalizeTarget($target);
+
+        if ($target == 0) {
+            return $this->rgbToHex($foregroundRgb);
+        }
+
+        $minimum = abs($target);
+        $current = $this->contrast($foregroundRgb, $backgroundRgb);
+
+        if ($this->contrastMeetsTarget($current, $target)) {
+            return $this->rgbToHex($foregroundRgb);
+        }
+
+        $backgroundY = $this->sRgbToY($backgroundRgb);
+        $preferredPolarity = $this->preferredPolarity($current, $backgroundY, $target);
+        $adjusted = $this->adjustLightness($foregroundRgb, $backgroundY, $minimum, $preferredPolarity);
+
+        if ($adjusted !== false) {
+            return $adjusted;
+        }
+
+        $oppositePolarity = ($preferredPolarity == 'light') ? 'dark' : 'light';
+        $adjusted = $this->adjustLightness($foregroundRgb, $backgroundY, $minimum, $oppositePolarity);
+
+        if ($adjusted !== false) {
+            return $adjusted;
+        }
+
+        $fallbackTarget = ($preferredPolarity == 'light') ? -$minimum : $minimum;
+
+        return $this->findForeground($backgroundY, $fallbackTarget);
+    }
+
+    /**
+     * Search for a grayscale foreground against a known background luminance.
+     *
+     * @param float $backgroundY
+     * @param float $target
+     * @return string
+     */
+    private function findForeground(float $backgroundY, float $target): string
+    {
+        $minimum = abs($target);
+        $blackContrast = $this->contrastFromLuminance($this->grayToY(0), $backgroundY);
+        $whiteContrast = $this->contrastFromLuminance($this->grayToY(255), $backgroundY);
+        $blackCapacity = max(0, $blackContrast);
+        $whiteCapacity = max(0, -$whiteContrast);
+
+        if ($target < 0 && $whiteCapacity >= $minimum) {
+            return $this->findGray($backgroundY, $minimum, 'light');
+        }
+
+        if ($blackCapacity >= $minimum && $whiteCapacity >= $minimum) {
+            $midY = $this->grayToY(128);
+            $polarity = ($backgroundY >= $midY) ? 'dark' : 'light';
+
+            return $this->findGray($backgroundY, $minimum, $polarity);
+        }
+
+        if ($blackCapacity >= $minimum) {
+            return $this->findGray($backgroundY, $minimum, 'dark');
+        }
+
+        if ($whiteCapacity >= $minimum) {
+            return $this->findGray($backgroundY, $minimum, 'light');
+        }
+
+        return ($blackCapacity >= $whiteCapacity) ? '#000000' : '#ffffff';
+    }
+
+    /**
+     * Determine whether a signed contrast value satisfies a target.
+     *
+     * Negative targets require light-on-dark polarity. Positive targets are
+     * treated as a non-polar minimum and accept either sign.
+     *
+     * @param float $contrast
+     * @param float $target
+     * @return bool
+     */
+    private function contrastMeetsTarget(float $contrast, float $target): bool
+    {
+        $minimum = abs($target);
+
+        if ($target < 0) {
+            return -$contrast >= $minimum;
+        }
+
+        return abs($contrast) >= $minimum;
+    }
+
+    /**
+     * Choose the first polarity to search for a color adjustment.
+     *
+     * Existing non-zero contrast keeps its current polarity. A negative target
+     * explicitly requests a light foreground, and zero contrast falls back to the
+     * practical polarity for the background lightness.
+     *
+     * @param float $currentContrast
+     * @param float $backgroundY
+     * @param float $target
+     * @return string "dark" or "light".
+     */
+    private function preferredPolarity(float $currentContrast, float $backgroundY, float $target): string
+    {
+        if ($target < 0) {
+            return 'light';
+        }
+
+        if ($currentContrast > 0) {
+            return 'dark';
+        }
+
+        if ($currentContrast < 0) {
+            return 'light';
+        }
+
+        return ($backgroundY >= $this->grayToY(128)) ? 'dark' : 'light';
+    }
+
+    /**
+     * Search HSL lightness for the smallest change that reaches the target.
+     *
+     * Hue and saturation are held constant so modifier-generated colors keep
+     * their intended color family whenever the contrast target can be met that
+     * way.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $rgb
+     * @param float $backgroundY
+     * @param float $target
+     * @param string $polarity "dark" or "light".
+     * @return string|false
+     */
+    private function adjustLightness(array $rgb, float $backgroundY, float $target, string $polarity)
+    {
+        $hsl = $this->rgbToHsl($rgb);
+        $low = 0.0;
+        $high = 1.0;
+        $best = null;
+
+        for ($i = 0; $i < 16; $i++) {
+            $mid = ($low + $high) / 2;
+            $candidateL = ($polarity == 'dark')
+                ? $hsl['L'] * (1 - $mid)
+                : $hsl['L'] + ((1 - $hsl['L']) * $mid);
+            $candidateRgb = $this->hslToRgb($hsl['H'], $hsl['S'], $candidateL);
+            $contrast = $this->contrastFromLuminance($this->sRgbToY($candidateRgb), $backgroundY);
+            $meets = ($polarity == 'dark') ? ($contrast >= $target) : (-$contrast >= $target);
+
+            if ($meets) {
+                $best = $candidateRgb;
+                $high = $mid;
+            } else {
+                $low = $mid;
+            }
+        }
+
+        if ($best === null) {
+            return false;
+        }
+
+        return $this->rgbToHex($best);
+    }
+
+    /**
+     * Binary-search a grayscale value for the requested polarity and contrast.
+     *
+     * @param float $backgroundY
+     * @param float $target
+     * @param string $polarity "dark" or "light".
+     * @return string
+     */
+    private function findGray(float $backgroundY, float $target, string $polarity): string
+    {
+        if ($polarity == 'dark') {
+            $best = 0;
+            $low = 0;
+            $high = 255;
+
+            while ($low <= $high) {
+            $mid = (int) floor(($low + $high) / 2);
+                $contrast = $this->contrastFromLuminance($this->grayToY($mid), $backgroundY);
+
+                if ($contrast >= $target) {
+                    $best = $mid;
+                    $low = $mid + 1;
+                } else {
+                    $high = $mid - 1;
+                }
+            }
+
+            return $this->grayHex($best);
+        }
+
+        $best = 255;
+        $low = 0;
+        $high = 255;
+
+        while ($low <= $high) {
+            $mid = (int) floor(($low + $high) / 2);
+            $contrast = -$this->contrastFromLuminance($this->grayToY($mid), $backgroundY);
+
+            if ($contrast >= $target) {
+                $best = $mid;
+                $high = $mid - 1;
+            } else {
+                $low = $mid + 1;
+            }
+        }
+
+        return $this->grayHex($best);
+    }
+
+    /**
+     * Convert sRGB channel values to screen luminance (Y).
+     *
+     * Constants are the sRGB coefficients and transfer exponent for the base
+     * perceptual contrast prediction equation.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $rgb
+     * @return float
+     */
+    private function sRgbToY(array $rgb): float
+    {
+        return 0.2126729 * pow($rgb['R'] / 255, 2.4)
+            + 0.7151522 * pow($rgb['G'] / 255, 2.4)
+            + 0.0721750 * pow($rgb['B'] / 255, 2.4);
+    }
+
+    /**
+     * Convert a single grayscale channel to screen luminance (Y).
+     *
+     * @param int $gray
+     * @return float
+     */
+    private function grayToY(int $gray): float
+    {
+        return $this->sRgbToY(['R' => $gray, 'G' => $gray, 'B' => $gray]);
+    }
+
+    /**
+     * Apply the base perceptual contrast prediction equation.
+     *
+     * The low-end black clamp, minimum delta, exponents, scale, and offsets are
+     * the sRGB constants used by the prediction equation.
+     *
+     * @param float $textY
+     * @param float $backgroundY
+     * @return float
+     */
+    private function contrastFromLuminance(float $textY, float $backgroundY): float
+    {
+        $blackThreshold = 0.022;
+        $blackClamp = 1.414;
+
+        $textY = ($textY > $blackThreshold)
+            ? $textY
+            : $textY + pow($blackThreshold - $textY, $blackClamp);
+        $backgroundY = ($backgroundY > $blackThreshold)
+            ? $backgroundY
+            : $backgroundY + pow($blackThreshold - $backgroundY, $blackClamp);
+
+        if (abs($backgroundY - $textY) < 0.0005) {
+            return 0.0;
+        }
+
+        if ($backgroundY > $textY) {
+            $contrast = (pow($backgroundY, 0.56) - pow($textY, 0.57)) * 1.14;
+
+            return ($contrast < 0.1) ? 0.0 : ($contrast - 0.027) * 100;
+        }
+
+        $contrast = (pow($backgroundY, 0.65) - pow($textY, 0.62)) * 1.14;
+
+        return ($contrast > -0.1) ? 0.0 : ($contrast + 0.027) * 100;
+    }
+
+    /**
+     * Format a grayscale channel as a six-digit hex color.
+     *
+     * @param int $gray
+     * @return string
+     */
+    private function grayHex(int $gray): string
+    {
+        $hex = str_pad(dechex($gray), 2, '0', STR_PAD_LEFT);
+
+        return '#' . $hex . $hex . $hex;
+    }
+
+    /**
+     * Convert an RGB color to HSL for local hue-preserving adjustment.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $rgb
+     * @return array{H:float,S:float,L:float}
+     */
+    private function rgbToHsl(array $rgb): array
+    {
+        $r = $rgb['R'] / 255;
+        $g = $rgb['G'] / 255;
+        $b = $rgb['B'] / 255;
+        $max = max($r, $g, $b);
+        $min = min($r, $g, $b);
+        $delta = $max - $min;
+        $lightness = ($max + $min) / 2;
+        $hue = 0;
+        $saturation = 0;
+
+        if ($delta != 0) {
+            $saturation = ($lightness > 0.5)
+                ? $delta / (2 - $max - $min)
+                : $delta / ($max + $min);
+
+            if ($max == $r) {
+                $hue = (($g - $b) / $delta) + (($g < $b) ? 6 : 0);
+            } elseif ($max == $g) {
+                $hue = (($b - $r) / $delta) + 2;
+            } else {
+                $hue = (($r - $g) / $delta) + 4;
+            }
+
+            $hue *= 60;
+        }
+
+        return ['H' => $hue, 'S' => $saturation, 'L' => $lightness];
+    }
+
+    /**
+     * Convert HSL components back to integer RGB channels.
+     *
+     * @param float $hue Degrees on the color wheel.
+     * @param float $saturation Unit interval saturation.
+     * @param float $lightness Unit interval lightness.
+     * @return array{R:int,G:int,B:int}
+     */
+    private function hslToRgb(float $hue, float $saturation, float $lightness): array
+    {
+        $hue = fmod($hue, 360.0);
+
+        if ($hue < 0) {
+            $hue += 360.0;
+        }
+
+        if ($saturation == 0) {
+            $value = (int) round($lightness * 255);
+
+            return ['R' => $value, 'G' => $value, 'B' => $value];
+        }
+
+        $q = ($lightness < 0.5)
+            ? $lightness * (1 + $saturation)
+            : $lightness + $saturation - ($lightness * $saturation);
+        $p = (2 * $lightness) - $q;
+        $h = $hue / 360;
+
+        return [
+            'R' => (int) round($this->hueToRgb($p, $q, $h + (1 / 3)) * 255),
+            'G' => (int) round($this->hueToRgb($p, $q, $h) * 255),
+            'B' => (int) round($this->hueToRgb($p, $q, $h - (1 / 3)) * 255),
+        ];
+    }
+
+    /**
+     * Interpolate one RGB channel for HSL to RGB conversion.
+     *
+     * @param float $p
+     * @param float $q
+     * @param float $hue Unit interval hue.
+     * @return float
+     */
+    private function hueToRgb(float $p, float $q, float $hue): float
+    {
+        if ($hue < 0) {
+            $hue++;
+        }
+
+        if ($hue > 1) {
+            $hue--;
+        }
+
+        if (6 * $hue < 1) {
+            return $p + (($q - $p) * 6 * $hue);
+        }
+
+        if (2 * $hue < 1) {
+            return $q;
+        }
+
+        if (3 * $hue < 2) {
+            return $p + (($q - $p) * ((2 / 3) - $hue) * 6);
+        }
+
+        return $p;
+    }
+
+    /**
+     * Format RGB channels as a normalized six-digit hex color.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $rgb
+     * @return string
+     */
+    private function rgbToHex(array $rgb): string
+    {
+        return '#' . str_pad(dechex((int) $rgb['R']), 2, '0', STR_PAD_LEFT)
+            . str_pad(dechex((int) $rgb['G']), 2, '0', STR_PAD_LEFT)
+            . str_pad(dechex((int) $rgb['B']), 2, '0', STR_PAD_LEFT);
+    }
+}

--- a/system/ee/ExpressionEngine/Service/Accessibility/Color/Wcag.php
+++ b/system/ee/ExpressionEngine/Service/Accessibility/Color/Wcag.php
@@ -1,0 +1,482 @@
+<?php
+
+namespace ExpressionEngine\Service\Accessibility\Color;
+
+/**
+ * Calculate and search WCAG 2.x contrast-ratio values for sRGB colors.
+ *
+ * This service implements the relative luminance and contrast-ratio formulas
+ * from WCAG 2.x for web content in the sRGB color space.
+ *
+ * Reference material:
+ * - https://www.w3.org/TR/WCAG22/#dfn-relative-luminance
+ * - https://www.w3.org/TR/WCAG22/#dfn-contrast-ratio
+ * - https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html
+ */
+class Wcag implements ContrastAlgorithm
+{
+    /**
+     * Return the default WCAG contrast-ratio target.
+     *
+     * @return float
+     */
+    public function defaultTarget(): float
+    {
+        return 4.5;
+    }
+
+    /**
+     * Clamp a requested WCAG contrast-ratio target.
+     *
+     * @param float $value
+     * @return float
+     */
+    public function normalizeTarget(float $value): float
+    {
+        return $this->normalizeRatio($value);
+    }
+
+    /**
+     * Calculate the WCAG contrast ratio between two colors.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $foregroundRgb
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @return float A ratio from 1.0 to 21.0.
+     */
+    public function contrast(array $foregroundRgb, array $backgroundRgb): float
+    {
+        return $this->contrastRatio($foregroundRgb, $backgroundRgb);
+    }
+
+    /**
+     * Calculate the WCAG contrast ratio between two colors.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $foregroundRgb
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @return float A ratio from 1.0 to 21.0.
+     */
+    public function contrastRatio(array $foregroundRgb, array $backgroundRgb): float
+    {
+        return $this->contrastRatioFromLuminance(
+            $this->relativeLuminance($foregroundRgb),
+            $this->relativeLuminance($backgroundRgb)
+        );
+    }
+
+    /**
+     * Find a grayscale foreground color that reaches the requested ratio.
+     *
+     * When the exact target cannot be reached, the method returns whichever
+     * grayscale endpoint has the highest available contrast.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @param float $targetRatio
+     * @return string A normalized six-digit hex color including "#".
+     */
+    public function foregroundForBackground(array $backgroundRgb, float $targetRatio = 4.5): string
+    {
+        $targetRatio = $this->normalizeRatio($targetRatio);
+
+        if ($targetRatio == 1.0) {
+            return $this->rgbToHex($backgroundRgb);
+        }
+
+        return $this->findForeground($this->relativeLuminance($backgroundRgb), $targetRatio);
+    }
+
+    /**
+     * Clamp a requested WCAG contrast ratio to the valid range.
+     *
+     * @param float $value
+     * @return float
+     */
+    public function normalizeRatio(float $value): float
+    {
+        return max(1.0, min(21.0, $value));
+    }
+
+    /**
+     * Adjust a foreground color until it reaches the requested contrast ratio.
+     *
+     * The method first returns the foreground unchanged when it already satisfies
+     * the target. Otherwise it searches HSL lightness while preserving the
+     * foreground hue and saturation, tries the opposite lightness direction if
+     * needed, and finally falls back to a grayscale search.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $foregroundRgb
+     * @param array{R:int|float,G:int|float,B:int|float} $backgroundRgb
+     * @param float $targetRatio
+     * @return string A normalized six-digit hex color including "#".
+     */
+    public function adjustForegroundForBackground(array $foregroundRgb, array $backgroundRgb, float $targetRatio = 4.5): string
+    {
+        $targetRatio = $this->normalizeRatio($targetRatio);
+        $backgroundLuminance = $this->relativeLuminance($backgroundRgb);
+        $foregroundLuminance = $this->relativeLuminance($foregroundRgb);
+
+        if ($this->contrastRatioFromLuminance($foregroundLuminance, $backgroundLuminance) >= $targetRatio) {
+            return $this->rgbToHex($foregroundRgb);
+        }
+
+        $preferredPolarity = $this->preferredPolarity($foregroundLuminance, $backgroundLuminance);
+        $adjusted = $this->adjustLightness($foregroundRgb, $backgroundLuminance, $targetRatio, $preferredPolarity);
+
+        if ($adjusted !== false) {
+            return $adjusted;
+        }
+
+        $oppositePolarity = ($preferredPolarity == 'light') ? 'dark' : 'light';
+        $adjusted = $this->adjustLightness($foregroundRgb, $backgroundLuminance, $targetRatio, $oppositePolarity);
+
+        if ($adjusted !== false) {
+            return $adjusted;
+        }
+
+        return $this->findForeground($backgroundLuminance, $targetRatio);
+    }
+
+    /**
+     * Search for a grayscale foreground against a known background luminance.
+     *
+     * @param float $backgroundLuminance
+     * @param float $targetRatio
+     * @return string
+     */
+    private function findForeground(float $backgroundLuminance, float $targetRatio): string
+    {
+        $blackContrast = $this->contrastRatioFromLuminance($this->grayToLuminance(0), $backgroundLuminance);
+        $whiteContrast = $this->contrastRatioFromLuminance($this->grayToLuminance(255), $backgroundLuminance);
+
+        if ($blackContrast >= $targetRatio && $whiteContrast >= $targetRatio) {
+            $polarity = ($backgroundLuminance >= $this->grayToLuminance(128)) ? 'dark' : 'light';
+
+            return $this->findGray($backgroundLuminance, $targetRatio, $polarity);
+        }
+
+        if ($blackContrast >= $targetRatio) {
+            return $this->findGray($backgroundLuminance, $targetRatio, 'dark');
+        }
+
+        if ($whiteContrast >= $targetRatio) {
+            return $this->findGray($backgroundLuminance, $targetRatio, 'light');
+        }
+
+        return ($blackContrast >= $whiteContrast) ? '#000000' : '#ffffff';
+    }
+
+    /**
+     * Choose the first lightness direction to search for a color adjustment.
+     *
+     * Existing non-zero contrast keeps its current direction. Equal luminance
+     * falls back to the practical direction for the background lightness.
+     *
+     * @param float $foregroundLuminance
+     * @param float $backgroundLuminance
+     * @return string "dark" or "light".
+     */
+    private function preferredPolarity(float $foregroundLuminance, float $backgroundLuminance): string
+    {
+        if ($foregroundLuminance < $backgroundLuminance) {
+            return 'dark';
+        }
+
+        if ($foregroundLuminance > $backgroundLuminance) {
+            return 'light';
+        }
+
+        return ($backgroundLuminance >= $this->grayToLuminance(128)) ? 'dark' : 'light';
+    }
+
+    /**
+     * Search HSL lightness for the smallest change that reaches the target.
+     *
+     * Hue and saturation are held constant so modifier-generated colors keep
+     * their intended color family whenever the contrast target can be met that
+     * way.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $rgb
+     * @param float $backgroundLuminance
+     * @param float $targetRatio
+     * @param string $polarity "dark" or "light".
+     * @return string|false
+     */
+    private function adjustLightness(array $rgb, float $backgroundLuminance, float $targetRatio, string $polarity)
+    {
+        $hsl = $this->rgbToHsl($rgb);
+        $low = 0.0;
+        $high = 1.0;
+        $best = null;
+
+        for ($i = 0; $i < 16; $i++) {
+            $mid = ($low + $high) / 2;
+            $candidateL = ($polarity == 'dark')
+                ? $hsl['L'] * (1 - $mid)
+                : $hsl['L'] + ((1 - $hsl['L']) * $mid);
+            $candidateRgb = $this->hslToRgb($hsl['H'], $hsl['S'], $candidateL);
+            $contrast = $this->contrastRatioFromLuminance(
+                $this->relativeLuminance($candidateRgb),
+                $backgroundLuminance
+            );
+
+            if ($contrast >= $targetRatio) {
+                $best = $candidateRgb;
+                $high = $mid;
+            } else {
+                $low = $mid;
+            }
+        }
+
+        if ($best === null) {
+            return false;
+        }
+
+        return $this->rgbToHex($best);
+    }
+
+    /**
+     * Binary-search a grayscale value for the requested lightness direction.
+     *
+     * @param float $backgroundLuminance
+     * @param float $targetRatio
+     * @param string $polarity "dark" or "light".
+     * @return string
+     */
+    private function findGray(float $backgroundLuminance, float $targetRatio, string $polarity): string
+    {
+        if ($polarity == 'dark') {
+            $best = 0;
+            $low = 0;
+            $high = 255;
+
+            while ($low <= $high) {
+                $mid = (int) floor(($low + $high) / 2);
+                $contrast = $this->contrastRatioFromLuminance($this->grayToLuminance($mid), $backgroundLuminance);
+
+                if ($contrast >= $targetRatio) {
+                    $best = $mid;
+                    $low = $mid + 1;
+                } else {
+                    $high = $mid - 1;
+                }
+            }
+
+            return $this->grayHex($best);
+        }
+
+        $best = 255;
+        $low = 0;
+        $high = 255;
+
+        while ($low <= $high) {
+            $mid = (int) floor(($low + $high) / 2);
+            $contrast = $this->contrastRatioFromLuminance($this->grayToLuminance($mid), $backgroundLuminance);
+
+            if ($contrast >= $targetRatio) {
+                $best = $mid;
+                $high = $mid - 1;
+            } else {
+                $low = $mid + 1;
+            }
+        }
+
+        return $this->grayHex($best);
+    }
+
+    /**
+     * Calculate WCAG relative luminance for an sRGB color.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $rgb
+     * @return float
+     */
+    private function relativeLuminance(array $rgb): float
+    {
+        return 0.2126 * $this->linearChannel($rgb['R'])
+            + 0.7152 * $this->linearChannel($rgb['G'])
+            + 0.0722 * $this->linearChannel($rgb['B']);
+    }
+
+    /**
+     * Convert one 8-bit sRGB channel to linear light.
+     *
+     * @param int|float $channel
+     * @return float
+     */
+    private function linearChannel($channel): float
+    {
+        $value = $channel / 255;
+
+        if ($value <= 0.04045) {
+            return $value / 12.92;
+        }
+
+        return pow(($value + 0.055) / 1.055, 2.4);
+    }
+
+    /**
+     * Calculate the WCAG contrast ratio between two relative luminance values.
+     *
+     * @param float $firstLuminance
+     * @param float $secondLuminance
+     * @return float
+     */
+    private function contrastRatioFromLuminance(float $firstLuminance, float $secondLuminance): float
+    {
+        $lighter = max($firstLuminance, $secondLuminance);
+        $darker = min($firstLuminance, $secondLuminance);
+
+        return ($lighter + 0.05) / ($darker + 0.05);
+    }
+
+    /**
+     * Convert a single grayscale channel to relative luminance.
+     *
+     * @param int $gray
+     * @return float
+     */
+    private function grayToLuminance(int $gray): float
+    {
+        return $this->relativeLuminance(['R' => $gray, 'G' => $gray, 'B' => $gray]);
+    }
+
+    /**
+     * Format a grayscale channel as a six-digit hex color.
+     *
+     * @param int $gray
+     * @return string
+     */
+    private function grayHex(int $gray): string
+    {
+        $hex = str_pad(dechex($gray), 2, '0', STR_PAD_LEFT);
+
+        return '#' . $hex . $hex . $hex;
+    }
+
+    /**
+     * Convert an RGB color to HSL for local hue-preserving adjustment.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $rgb
+     * @return array{H:float,S:float,L:float}
+     */
+    private function rgbToHsl(array $rgb): array
+    {
+        $r = $rgb['R'] / 255;
+        $g = $rgb['G'] / 255;
+        $b = $rgb['B'] / 255;
+        $max = max($r, $g, $b);
+        $min = min($r, $g, $b);
+        $delta = $max - $min;
+        $lightness = ($max + $min) / 2;
+        $hue = 0;
+        $saturation = 0;
+
+        if ($delta != 0) {
+            $saturation = ($lightness > 0.5)
+                ? $delta / (2 - $max - $min)
+                : $delta / ($max + $min);
+
+            if ($max == $r) {
+                $hue = (($g - $b) / $delta) + (($g < $b) ? 6 : 0);
+            } elseif ($max == $g) {
+                $hue = (($b - $r) / $delta) + 2;
+            } else {
+                $hue = (($r - $g) / $delta) + 4;
+            }
+
+            $hue *= 60;
+        }
+
+        return ['H' => $hue, 'S' => $saturation, 'L' => $lightness];
+    }
+
+    /**
+     * Convert HSL components back to integer RGB channels.
+     *
+     * @param float $hue Degrees on the color wheel.
+     * @param float $saturation Unit interval saturation.
+     * @param float $lightness Unit interval lightness.
+     * @return array{R:int,G:int,B:int}
+     */
+    private function hslToRgb(float $hue, float $saturation, float $lightness): array
+    {
+        $hue = fmod($hue, 360.0);
+
+        if ($hue < 0) {
+            $hue += 360.0;
+        }
+
+        if ($saturation == 0) {
+            $value = (int) round($lightness * 255);
+
+            return ['R' => $value, 'G' => $value, 'B' => $value];
+        }
+
+        $q = ($lightness < 0.5)
+            ? $lightness * (1 + $saturation)
+            : $lightness + $saturation - ($lightness * $saturation);
+        $p = (2 * $lightness) - $q;
+        $h = $hue / 360;
+
+        return [
+            'R' => (int) round($this->hueToRgb($p, $q, $h + (1 / 3)) * 255),
+            'G' => (int) round($this->hueToRgb($p, $q, $h) * 255),
+            'B' => (int) round($this->hueToRgb($p, $q, $h - (1 / 3)) * 255),
+        ];
+    }
+
+    /**
+     * Interpolate one RGB channel for HSL to RGB conversion.
+     *
+     * @param float $p
+     * @param float $q
+     * @param float $hue Unit interval hue.
+     * @return float
+     */
+    private function hueToRgb(float $p, float $q, float $hue): float
+    {
+        if ($hue < 0) {
+            $hue++;
+        }
+
+        if ($hue > 1) {
+            $hue--;
+        }
+
+        if (6 * $hue < 1) {
+            return $p + (($q - $p) * 6 * $hue);
+        }
+
+        if (2 * $hue < 1) {
+            return $q;
+        }
+
+        if (3 * $hue < 2) {
+            return $p + (($q - $p) * ((2 / 3) - $hue) * 6);
+        }
+
+        return $p;
+    }
+
+    /**
+     * Format RGB channels as a normalized six-digit hex color.
+     *
+     * @param array{R:int|float,G:int|float,B:int|float} $rgb
+     * @return string
+     */
+    private function rgbToHex(array $rgb): string
+    {
+        return '#' . str_pad(dechex($this->clampChannel($rgb['R'])), 2, '0', STR_PAD_LEFT)
+            . str_pad(dechex($this->clampChannel($rgb['G'])), 2, '0', STR_PAD_LEFT)
+            . str_pad(dechex($this->clampChannel($rgb['B'])), 2, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * Clamp an RGB channel to the valid 8-bit range.
+     *
+     * @param int|float $channel
+     * @return int
+     */
+    private function clampChannel($channel): int
+    {
+        return max(0, min(255, (int) round($channel)));
+    }
+}

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Colorpicker/ColorpickerFieldtypeTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Colorpicker/ColorpickerFieldtypeTest.php
@@ -6,6 +6,9 @@ require_once SYSPATH . 'ee/legacy/fieldtypes/EE_Fieldtype.php';
 require_once SYSPATH . 'ee/Mexitek/PHPColors/Color.php';
 require_once SYSPATH . 'ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php';
 
+use ExpressionEngine\Service\Accessibility\Color\Gpc;
+use ExpressionEngine\Service\Accessibility\Color\Wcag;
+use Mexitek\PHPColors\Color;
 use PHPUnit\Framework\TestCase;
 
 class ColorpickerFieldtypeTest extends TestCase
@@ -31,6 +34,73 @@ class ColorpickerFieldtypeTest extends TestCase
         $this->assertSame(
             '#993344',
             $this->fieldtype->replace_rotate('#336699', ['degrees' => '-220'])
+        );
+    }
+
+    public function testContrastRatioConstrainsColorModifiers()
+    {
+        $color = '#336699';
+        $params = ['contrast_ratio' => '4.5'];
+        $results = [
+            [$this->fieldtype->replace_complementary($color, $params), '#eeddcb'],
+            [$this->fieldtype->replace_darken($color, ['percent' => '10'] + $params), '#d2e1f0'],
+            [$this->fieldtype->replace_lighten($color, ['percent' => '10'] + $params), '#d2e1f0'],
+            [$this->fieldtype->replace_rotate($color, ['degrees' => '170'] + $params), '#f0dbd1'],
+            [$this->fieldtype->replace_saturate($color, ['percent' => '20'] + $params), '#cde2f6'],
+            [$this->fieldtype->replace_desaturate($color, ['percent' => '20'] + $params), '#d7e1ea'],
+            [$this->fieldtype->replace_mix($color, ['color' => '#ffffff', 'percent' => '50'] + $params), '#d7e1eb'],
+        ];
+
+        foreach ($results as [$actual, $expected]) {
+            $this->assertSame($expected, $actual);
+            $this->assertContrastRatioAtLeast($actual, $color, 4.5);
+        }
+    }
+
+    public function testContrastRatioDefaultsToFourPointFiveWhenEmpty()
+    {
+        $this->assertSame(
+            $this->fieldtype->replace_complementary('#336699', ['contrast_ratio' => '4.5']),
+            $this->fieldtype->replace_complementary('#336699', ['contrast_ratio' => ''])
+        );
+    }
+
+    public function testContrastRatioTakesPrecedenceOverPerceptualContrast()
+    {
+        $result = $this->fieldtype->replace_complementary('#336699', [
+            'contrast_ratio' => '4.5',
+            'perceptual_contrast' => '60',
+        ]);
+
+        $this->assertSame('#eeddcb', $result);
+        $this->assertContrastRatioAtLeast($result, '#336699', 4.5);
+    }
+
+    public function testPerceptualContrastConstrainsColorModifiers()
+    {
+        $color = '#336699';
+        $params = ['perceptual_contrast' => '60'];
+        $results = [
+            [$this->fieldtype->replace_complementary($color, $params), '#ead5bf'],
+            [$this->fieldtype->replace_darken($color, ['percent' => '10'] + $params), '#c8dbed'],
+            [$this->fieldtype->replace_lighten($color, ['percent' => '10'] + $params), '#c8dbed'],
+            [$this->fieldtype->replace_rotate($color, ['degrees' => '170'] + $params), '#ecd4c7'],
+            [$this->fieldtype->replace_saturate($color, ['percent' => '20'] + $params), '#c2dbf4'],
+            [$this->fieldtype->replace_desaturate($color, ['percent' => '20'] + $params), '#cedae5'],
+            [$this->fieldtype->replace_mix($color, ['color' => '#ffffff', 'percent' => '50'] + $params), '#cddae6'],
+        ];
+
+        foreach ($results as [$actual, $expected]) {
+            $this->assertSame($expected, $actual);
+            $this->assertPerceptualContrastAtLeast($actual, $color, 60);
+        }
+    }
+
+    public function testPerceptualContrastDefaultsToSixtyWhenEmpty()
+    {
+        $this->assertSame(
+            $this->fieldtype->replace_complementary('#336699', ['perceptual_contrast' => '60']),
+            $this->fieldtype->replace_complementary('#336699', ['perceptual_contrast' => ''])
         );
     }
 
@@ -70,10 +140,40 @@ class ColorpickerFieldtypeTest extends TestCase
             $this->assertSame('#2866a4', $this->fieldtype->replace_saturate('#336699', ['percent' => '10.5']));
             $this->assertSame('#3e668e', $this->fieldtype->replace_desaturate('#336699', ['percent' => '10.5']));
             $this->assertSame('#4876a3', $this->fieldtype->replace_mix('#336699', ['color' => '#ffffff', 'percent' => '10.5']));
+            $this->assertSame('#d6e1eb', $this->fieldtype->replace_mix('#336699', [
+                'color' => '#ffffff',
+                'percent' => '50.5',
+                'contrast_ratio' => '4.5',
+            ]));
+            $this->assertSame('#cddae6', $this->fieldtype->replace_mix('#336699', [
+                'color' => '#ffffff',
+                'percent' => '50.5',
+                'perceptual_contrast' => '60',
+            ]));
         } finally {
             restore_error_handler();
         }
 
         $this->assertSame([], $messages);
+    }
+
+    private function assertContrastRatioAtLeast(string $foreground, string $background, float $minimum): void
+    {
+        $wcag = new Wcag();
+
+        $this->assertGreaterThanOrEqual(
+            $minimum,
+            $wcag->contrastRatio(Color::hexToRgb($foreground), Color::hexToRgb($background))
+        );
+    }
+
+    private function assertPerceptualContrastAtLeast(string $foreground, string $background, float $minimum): void
+    {
+        $gpc = new Gpc();
+
+        $this->assertGreaterThanOrEqual(
+            $minimum,
+            abs($gpc->contrast(Color::hexToRgb($foreground), Color::hexToRgb($background)))
+        );
     }
 }

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Colorpicker/ColorpickerFieldtypeTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Colorpicker/ColorpickerFieldtypeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace ExpressionEngine\Tests\Addons\Colorpicker;
+
+require_once SYSPATH . 'ee/legacy/fieldtypes/EE_Fieldtype.php';
+require_once SYSPATH . 'ee/Mexitek/PHPColors/Color.php';
+require_once SYSPATH . 'ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php';
+
+use PHPUnit\Framework\TestCase;
+
+class ColorpickerFieldtypeTest extends TestCase
+{
+    private $fieldtype;
+
+    public function setUp(): void
+    {
+        $reflection = new \ReflectionClass(\Colorpicker_ft::class);
+        $this->fieldtype = $reflection->newInstanceWithoutConstructor();
+    }
+
+    public function testRotatePreservesFractionalHue()
+    {
+        $this->assertSame(
+            '#335599',
+            $this->fieldtype->replace_rotate('#336699', ['degrees' => '10'])
+        );
+    }
+
+    public function testRotateWrapsNegativeDegrees()
+    {
+        $this->assertSame(
+            '#993344',
+            $this->fieldtype->replace_rotate('#336699', ['degrees' => '-220'])
+        );
+    }
+
+    public function testDecimalPercentModifiersDoNotTriggerPrecisionDeprecations()
+    {
+        $messages = [];
+
+        set_error_handler(function ($severity, $message) use (&$messages) {
+            $messages[] = $message;
+
+            return true;
+        });
+
+        try {
+            $this->assertSame('#264d73', $this->fieldtype->replace_darken('#336699', ['percent' => '10.5']));
+            $this->assertSame('#4080bf', $this->fieldtype->replace_lighten('#336699', ['percent' => '10.5']));
+            $this->assertSame('#2866a4', $this->fieldtype->replace_saturate('#336699', ['percent' => '10.5']));
+            $this->assertSame('#3e668e', $this->fieldtype->replace_desaturate('#336699', ['percent' => '10.5']));
+            $this->assertSame('#8eaac6', $this->fieldtype->replace_mix('#336699', ['color' => '#ffffff', 'percent' => '10.5']));
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $messages);
+    }
+}

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Colorpicker/ColorpickerFieldtypeTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Colorpicker/ColorpickerFieldtypeTest.php
@@ -2,10 +2,6 @@
 
 namespace ExpressionEngine\Tests\Addons\Colorpicker;
 
-require_once SYSPATH . 'ee/legacy/fieldtypes/EE_Fieldtype.php';
-require_once SYSPATH . 'ee/Mexitek/PHPColors/Color.php';
-require_once SYSPATH . 'ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php';
-
 use ExpressionEngine\Service\Accessibility\Color\Gpc;
 use ExpressionEngine\Service\Accessibility\Color\Wcag;
 use Mexitek\PHPColors\Color;
@@ -17,8 +13,20 @@ class ColorpickerFieldtypeTest extends TestCase
 
     public function setUp(): void
     {
+        $this->loadFieldtype();
+
         $reflection = new \ReflectionClass(\Colorpicker_ft::class);
         $this->fieldtype = $reflection->newInstanceWithoutConstructor();
+    }
+
+    private function loadFieldtype(): void
+    {
+        if (! class_exists('EE_Fieldtype', false)) {
+            require_once SYSPATH . 'ee/legacy/fieldtypes/EE_Fieldtype.php';
+        }
+
+        require_once SYSPATH . 'ee/Mexitek/PHPColors/Color.php';
+        require_once SYSPATH . 'ee/ExpressionEngine/Addons/colorpicker/ft.colorpicker.php';
     }
 
     public function testRotatePreservesFractionalHue()

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Colorpicker/ColorpickerFieldtypeTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Colorpicker/ColorpickerFieldtypeTest.php
@@ -34,6 +34,26 @@ class ColorpickerFieldtypeTest extends TestCase
         );
     }
 
+    public function testZeroPercentDarkenAndLightenReturnOriginalColor()
+    {
+        $this->assertSame('#336699', $this->fieldtype->replace_darken('#336699', ['percent' => '0']));
+        $this->assertSame('#336699', $this->fieldtype->replace_lighten('#336699', ['percent' => '0']));
+    }
+
+    public function testMixPercentRepresentsAmountOfSecondColor()
+    {
+        $this->assertSame('#99b2cc', $this->fieldtype->replace_mix('#336699', ['color' => '#ffffff']));
+        $this->assertSame('#336699', $this->fieldtype->replace_mix('#336699', ['color' => '#ffffff', 'percent' => '0']));
+        $this->assertSame('#99b2cc', $this->fieldtype->replace_mix('#336699', ['color' => '#ffffff', 'percent' => '50']));
+        $this->assertSame('#ffffff', $this->fieldtype->replace_mix('#336699', ['color' => '#ffffff', 'percent' => '100']));
+    }
+
+    public function testHslReturnsRoundedCssComponents()
+    {
+        $this->assertSame('210, 50%, 40%', $this->fieldtype->replace_hsl('#336699'));
+        $this->assertSame('0, 0%, 100%', $this->fieldtype->replace_hsl('#ffffff'));
+    }
+
     public function testDecimalPercentModifiersDoNotTriggerPrecisionDeprecations()
     {
         $messages = [];
@@ -49,7 +69,7 @@ class ColorpickerFieldtypeTest extends TestCase
             $this->assertSame('#4080bf', $this->fieldtype->replace_lighten('#336699', ['percent' => '10.5']));
             $this->assertSame('#2866a4', $this->fieldtype->replace_saturate('#336699', ['percent' => '10.5']));
             $this->assertSame('#3e668e', $this->fieldtype->replace_desaturate('#336699', ['percent' => '10.5']));
-            $this->assertSame('#8eaac6', $this->fieldtype->replace_mix('#336699', ['color' => '#ffffff', 'percent' => '10.5']));
+            $this->assertSame('#4876a3', $this->fieldtype->replace_mix('#336699', ['color' => '#ffffff', 'percent' => '10.5']));
         } finally {
             restore_error_handler();
         }

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtAcceptsContentTypeTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtAcceptsContentTypeTest.php
@@ -41,13 +41,13 @@ class FileFtAcceptsContentTypeTest extends FileFtTestBase
             'field_content_type' => 'image',
         ], 24, 'hero_asset');
         $expectedSettings = $fieldtype->settings;
-        $expectedContentId = $fieldtype->content_id;
-        $expectedFieldName = $fieldtype->field_name;
+        $expectedContentId = $this->fieldtypeContentId($fieldtype);
+        $expectedFieldName = $this->fieldtypeName($fieldtype);
 
         $this->assertTrue($fieldtype->accepts_content_type('blocks/7'));
         $this->assertSame($expectedSettings, $fieldtype->settings);
-        $this->assertSame($expectedContentId, $fieldtype->content_id);
-        $this->assertSame($expectedFieldName, $fieldtype->field_name);
+        $this->assertSame($expectedContentId, $this->fieldtypeContentId($fieldtype));
+        $this->assertSame($expectedFieldName, $this->fieldtypeName($fieldtype));
     }
 
     /**

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtGetChainableModifiersThatRequireArrayTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtGetChainableModifiersThatRequireArrayTest.php
@@ -113,8 +113,8 @@ class FileFtGetChainableModifiersThatRequireArrayTest extends FileFtTestBase
             'field_content_type' => 'image',
         ], 22, 'hero_asset');
         $expectedSettings = $fieldtype->settings;
-        $expectedContentId = $fieldtype->content_id;
-        $expectedFieldName = $fieldtype->field_name;
+        $expectedContentId = $this->fieldtypeContentId($fieldtype);
+        $expectedFieldName = $this->fieldtypeName($fieldtype);
         $libraries = $this->loadRecorder->libraries;
         $models = $this->loadRecorder->models;
         $fileFieldCalls = $this->fileFieldMock->calls;
@@ -123,8 +123,8 @@ class FileFtGetChainableModifiersThatRequireArrayTest extends FileFtTestBase
             'title' => 'Manual PDF',
         ]));
         $this->assertSame($expectedSettings, $fieldtype->settings);
-        $this->assertSame($expectedContentId, $fieldtype->content_id);
-        $this->assertSame($expectedFieldName, $fieldtype->field_name);
+        $this->assertSame($expectedContentId, $this->fieldtypeContentId($fieldtype));
+        $this->assertSame($expectedFieldName, $this->fieldtypeName($fieldtype));
         $this->assertSame($libraries, $this->loadRecorder->libraries);
         $this->assertSame($models, $this->loadRecorder->models);
         $this->assertSame($fileFieldCalls, $this->fileFieldMock->calls);

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtGetTableColumnConfigTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtGetTableColumnConfigTest.php
@@ -36,16 +36,16 @@ class FileFtGetTableColumnConfigTest extends FileFtTestBase
             'field_content_type' => 'image',
         ], 13, 'hero_asset');
         $expectedSettings = $fieldtype->settings;
-        $expectedContentId = $fieldtype->content_id;
-        $expectedFieldName = $fieldtype->field_name;
+        $expectedContentId = $this->fieldtypeContentId($fieldtype);
+        $expectedFieldName = $this->fieldtypeName($fieldtype);
         $libraries = $this->loadRecorder->libraries;
         $models = $this->loadRecorder->models;
         $fileFieldCalls = $this->fileFieldMock->calls;
 
         $this->assertSame(['encode' => false], $fieldtype->getTableColumnConfig());
         $this->assertSame($expectedSettings, $fieldtype->settings);
-        $this->assertSame($expectedContentId, $fieldtype->content_id);
-        $this->assertSame($expectedFieldName, $fieldtype->field_name);
+        $this->assertSame($expectedContentId, $this->fieldtypeContentId($fieldtype));
+        $this->assertSame($expectedFieldName, $this->fieldtypeName($fieldtype));
         $this->assertSame($libraries, $this->loadRecorder->libraries);
         $this->assertSame($models, $this->loadRecorder->models);
         $this->assertSame($fileFieldCalls, $this->fileFieldMock->calls);

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtTestBase.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtTestBase.php
@@ -1545,10 +1545,34 @@ namespace {
             $fieldtype->settings = array_merge([
                 'field_required' => 'n',
             ], $settings);
-            $fieldtype->content_id = $contentId;
-            $fieldtype->field_name = $fieldName;
+            $fieldtype->_init([
+                'content_id' => $contentId,
+                'field_name' => $fieldName,
+            ]);
 
             return $fieldtype;
+        }
+
+        /**
+         * Return the fieldtype's current content id through the fieldtype API.
+         *
+         * @param File_ft $fieldtype
+         * @return int|null
+         */
+        protected function fieldtypeContentId($fieldtype)
+        {
+            return $fieldtype->content_id();
+        }
+
+        /**
+         * Return the fieldtype's current short name through the fieldtype API.
+         *
+         * @param File_ft $fieldtype
+         * @return string
+         */
+        protected function fieldtypeName($fieldtype)
+        {
+            return $fieldtype->name();
         }
 
         /**

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtUpdateTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtUpdateTest.php
@@ -58,16 +58,16 @@ class FileFtUpdateTest extends FileFtTestBase
             'field_content_type' => 'image',
         ], 41, 'hero_asset');
         $expectedSettings = $fieldtype->settings;
-        $expectedContentId = $fieldtype->content_id;
-        $expectedFieldName = $fieldtype->field_name;
+        $expectedContentId = $this->fieldtypeContentId($fieldtype);
+        $expectedFieldName = $this->fieldtypeName($fieldtype);
         $libraries = $this->loadRecorder->libraries;
         $models = $this->loadRecorder->models;
         $fileFieldCalls = $this->fileFieldMock->calls;
 
         $this->assertTrue($fieldtype->update('7.5.0'));
         $this->assertSame($expectedSettings, $fieldtype->settings);
-        $this->assertSame($expectedContentId, $fieldtype->content_id);
-        $this->assertSame($expectedFieldName, $fieldtype->field_name);
+        $this->assertSame($expectedContentId, $this->fieldtypeContentId($fieldtype));
+        $this->assertSame($expectedFieldName, $this->fieldtypeName($fieldtype));
         $this->assertSame($libraries, $this->loadRecorder->libraries);
         $this->assertSame($models, $this->loadRecorder->models);
         $this->assertSame($fileFieldCalls, $this->fileFieldMock->calls);

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Accessibility/Color/GpcTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Accessibility/Color/GpcTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace ExpressionEngine\Tests\Service\Accessibility\Color;
+
+use ExpressionEngine\Service\Accessibility\Color\ContrastAlgorithm;
+use ExpressionEngine\Service\Accessibility\Color\Gpc;
+use PHPUnit\Framework\TestCase;
+
+class GpcTest extends TestCase
+{
+    private $gpc;
+
+    public function setUp(): void
+    {
+        $this->gpc = new Gpc();
+    }
+
+    public function testImplementsContrastAlgorithmInterface()
+    {
+        $this->assertInstanceOf(ContrastAlgorithm::class, $this->gpc);
+        $this->assertSame(60.0, $this->gpc->defaultTarget());
+    }
+
+    public function testForegroundForBackgroundReturnsDefaultTargetColor()
+    {
+        $this->assertSame('#8e8e8e', $this->gpc->foregroundForBackground(['R' => 255, 'G' => 255, 'B' => 255]));
+        $this->assertSame('#b1b1b1', $this->gpc->foregroundForBackground(['R' => 0, 'G' => 0, 'B' => 0]));
+        $this->assertSame('#d8d8d8', $this->gpc->foregroundForBackground(['R' => 51, 'G' => 102, 'B' => 153]));
+    }
+
+    public function testForegroundForBackgroundAcceptsTarget()
+    {
+        $this->assertSame('#6e6e6e', $this->gpc->foregroundForBackground(['R' => 255, 'G' => 255, 'B' => 255], 75));
+        $this->assertSame('#ffffff', $this->gpc->foregroundForBackground(['R' => 136, 'G' => 136, 'B' => 136], 75));
+    }
+
+    public function testAdjustForegroundForBackgroundPreservesForegroundHue()
+    {
+        $background = ['R' => 51, 'G' => 102, 'B' => 153];
+
+        $this->assertSame(
+            '#ead5bf',
+            $this->gpc->adjustForegroundForBackground(['R' => 153, 'G' => 102, 'B' => 51], $background, 60)
+        );
+
+        $this->assertSame(
+            '#c8dbed',
+            $this->gpc->adjustForegroundForBackground(['R' => 38, 'G' => 77, 'B' => 115], $background, 60)
+        );
+    }
+
+    public function testAdjustedForegroundMeetsRequestedTarget()
+    {
+        $background = ['R' => 51, 'G' => 102, 'B' => 153];
+        $foreground = $this->hexToRgb(
+            $this->gpc->adjustForegroundForBackground(['R' => 153, 'G' => 102, 'B' => 51], $background, 60)
+        );
+
+        $this->assertGreaterThanOrEqual(60, abs($this->gpc->contrast($foreground, $background)));
+    }
+
+    public function testZeroTargetReturnsBackgroundColor()
+    {
+        $this->assertSame('#336699', $this->gpc->foregroundForBackground(['R' => 51, 'G' => 102, 'B' => 153], 0));
+    }
+
+    public function testNormalizeTargetClampsToSupportedRange()
+    {
+        $this->assertSame(60.0, $this->gpc->normalizeTarget(60));
+        $this->assertSame(108.0, $this->gpc->normalizeTarget(120));
+        $this->assertSame(-108.0, $this->gpc->normalizeTarget(-120));
+    }
+
+    private function hexToRgb(string $hex): array
+    {
+        $hex = ltrim($hex, '#');
+
+        return [
+            'R' => hexdec(substr($hex, 0, 2)),
+            'G' => hexdec(substr($hex, 2, 2)),
+            'B' => hexdec(substr($hex, 4, 2)),
+        ];
+    }
+}

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Accessibility/Color/WcagTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Accessibility/Color/WcagTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace ExpressionEngine\Tests\Service\Accessibility\Color;
+
+use ExpressionEngine\Service\Accessibility\Color\ContrastAlgorithm;
+use ExpressionEngine\Service\Accessibility\Color\Wcag;
+use PHPUnit\Framework\TestCase;
+
+class WcagTest extends TestCase
+{
+    private $wcag;
+
+    public function setUp(): void
+    {
+        $this->wcag = new Wcag();
+    }
+
+    public function testImplementsContrastAlgorithmInterface()
+    {
+        $this->assertInstanceOf(ContrastAlgorithm::class, $this->wcag);
+        $this->assertSame(4.5, $this->wcag->defaultTarget());
+    }
+
+    public function testContrastRatioMatchesKnownWcagEndpoints()
+    {
+        $this->assertSame(21.0, $this->wcag->contrastRatio(
+            ['R' => 0, 'G' => 0, 'B' => 0],
+            ['R' => 255, 'G' => 255, 'B' => 255]
+        ));
+
+        $this->assertSame(1.0, $this->wcag->contrastRatio(
+            ['R' => 51, 'G' => 102, 'B' => 153],
+            ['R' => 51, 'G' => 102, 'B' => 153]
+        ));
+
+        $this->assertSame(21.0, $this->wcag->contrast(
+            ['R' => 0, 'G' => 0, 'B' => 0],
+            ['R' => 255, 'G' => 255, 'B' => 255]
+        ));
+    }
+
+    public function testForegroundForBackgroundReturnsDefaultRatioColor()
+    {
+        $this->assertSame('#767676', $this->wcag->foregroundForBackground(['R' => 255, 'G' => 255, 'B' => 255]));
+        $this->assertSame('#757575', $this->wcag->foregroundForBackground(['R' => 0, 'G' => 0, 'B' => 0]));
+        $this->assertSame('#dfdfdf', $this->wcag->foregroundForBackground(['R' => 51, 'G' => 102, 'B' => 153]));
+    }
+
+    public function testForegroundForBackgroundAcceptsRatio()
+    {
+        $this->assertSame('#595959', $this->wcag->foregroundForBackground(['R' => 255, 'G' => 255, 'B' => 255], 7));
+        $this->assertSame('#212121', $this->wcag->foregroundForBackground(['R' => 136, 'G' => 136, 'B' => 136], 4.5));
+    }
+
+    public function testAdjustForegroundForBackgroundPreservesForegroundHue()
+    {
+        $background = ['R' => 51, 'G' => 102, 'B' => 153];
+
+        $this->assertSame(
+            '#eeddcb',
+            $this->wcag->adjustForegroundForBackground(['R' => 153, 'G' => 102, 'B' => 51], $background, 4.5)
+        );
+
+        $this->assertSame(
+            '#d2e1f0',
+            $this->wcag->adjustForegroundForBackground(['R' => 38, 'G' => 77, 'B' => 115], $background, 4.5)
+        );
+    }
+
+    public function testAdjustedForegroundMeetsRequestedRatio()
+    {
+        $background = ['R' => 51, 'G' => 102, 'B' => 153];
+        $foreground = $this->hexToRgb(
+            $this->wcag->adjustForegroundForBackground(['R' => 153, 'G' => 102, 'B' => 51], $background, 4.5)
+        );
+
+        $this->assertGreaterThanOrEqual(4.5, $this->wcag->contrastRatio($foreground, $background));
+    }
+
+    public function testMinimumRatioReturnsBackgroundColor()
+    {
+        $this->assertSame('#336699', $this->wcag->foregroundForBackground(['R' => 51, 'G' => 102, 'B' => 153], 1));
+    }
+
+    public function testNormalizeRatioClampsToWcagRange()
+    {
+        $this->assertSame(4.5, $this->wcag->normalizeRatio(4.5));
+        $this->assertSame(1.0, $this->wcag->normalizeRatio(0));
+        $this->assertSame(21.0, $this->wcag->normalizeRatio(40));
+        $this->assertSame(21.0, $this->wcag->normalizeTarget(40));
+    }
+
+    private function hexToRgb(string $hex): array
+    {
+        $hex = ltrim($hex, '#');
+
+        return [
+            'R' => hexdec(substr($hex, 0, 2)),
+            'G' => hexdec(substr($hex, 2, 2)),
+            'B' => hexdec(substr($hex, 4, 2)),
+        ];
+    }
+}

--- a/system/ee/Mexitek/PHPColors/Color.php
+++ b/system/ee/Mexitek/PHPColors/Color.php
@@ -35,14 +35,14 @@ class Color
      * Set this to FALSE to adjust automatic shade to be between given color
      * and black (for darken) or white (for lighten)
      */
-    const DEFAULT_ADJUST = 10;
+    public const DEFAULT_ADJUST = 10;
 
     /**
      * Instantiates the class with a HEX value
      * @param string $hex
      * @throws Exception
      */
-    public function __construct($hex)
+    public function __construct(string $hex)
     {
         $color = self::sanitizeHex($hex);
         $this->_hex = $color;
@@ -56,7 +56,7 @@ class Color
      * @return array HSL associative array
      * @throws Exception
      */
-    public static function hexToHsl($color)
+    public static function hexToHsl(string $color): array
     {
         // Sanity check
         $color = self::sanitizeHex($color);
@@ -121,7 +121,7 @@ class Color
      * @return string HEX string
      * @throws Exception "Bad HSL Array"
      */
-    public static function hslToHex($hsl = array())
+    public static function hslToHex(array $hsl = array()): string
     {
         // Make sure it's HSL
         if (empty($hsl) || !isset($hsl["H"], $hsl["S"], $hsl["L"])) {
@@ -143,15 +143,15 @@ class Color
 
             $var_1 = 2 * $L - $var_2;
 
-            $r = round(255 * self::hueToRgb($var_1, $var_2, $H + (1 / 3)));
-            $g = round(255 * self::hueToRgb($var_1, $var_2, $H));
-            $b = round(255 * self::hueToRgb($var_1, $var_2, $H - (1 / 3)));
+            $r = 255 * self::hueToRgb($var_1, $var_2, $H + (1 / 3));
+            $g = 255 * self::hueToRgb($var_1, $var_2, $H);
+            $b = 255 * self::hueToRgb($var_1, $var_2, $H - (1 / 3));
         }
 
         // Convert to hex
-        $r = dechex($r);
-        $g = dechex($g);
-        $b = dechex($b);
+        $r = dechex(round($r));
+        $g = dechex(round($g));
+        $b = dechex(round($b));
 
         // Make sure we get 2 digits for decimals
         $r = (strlen("" . $r) === 1) ? "0" . $r : $r;
@@ -161,13 +161,14 @@ class Color
         return $r . $g . $b;
     }
 
+
     /**
      * Given a HEX string returns a RGB array equivalent.
      * @param string $color
      * @return array RGB associative array
      * @throws Exception
      */
-    public static function hexToRgb($color)
+    public static function hexToRgb(string $color): array
     {
         // Sanity check
         $color = self::sanitizeHex($color);
@@ -184,13 +185,14 @@ class Color
         return $RGB;
     }
 
+
     /**
      * Given an RGB associative array returns the equivalent HEX string
      * @param array $rgb
      * @return string Hex string
      * @throws Exception "Bad RGB Array"
      */
-    public static function rgbToHex($rgb = array())
+    public static function rgbToHex(array $rgb = array()): string
     {
         // Make sure it's RGB
         if (empty($rgb) || !isset($rgb["R"], $rgb["G"], $rgb["B"])) {
@@ -199,9 +201,9 @@ class Color
 
         // https://github.com/mexitek/phpColors/issues/25#issuecomment-88354815
         // Convert RGB to HEX
-        $hex[0] = str_pad(dechex($rgb['R']), 2, '0', STR_PAD_LEFT);
-        $hex[1] = str_pad(dechex($rgb['G']), 2, '0', STR_PAD_LEFT);
-        $hex[2] = str_pad(dechex($rgb['B']), 2, '0', STR_PAD_LEFT);
+        $hex[0] = str_pad(dechex((int)$rgb['R']), 2, '0', STR_PAD_LEFT);
+        $hex[1] = str_pad(dechex((int)$rgb['G']), 2, '0', STR_PAD_LEFT);
+        $hex[2] = str_pad(dechex((int)$rgb['B']), 2, '0', STR_PAD_LEFT);
 
         // Make sure that 2 digits are allocated to each color.
         $hex[0] = (strlen($hex[0]) === 1) ? '0' . $hex[0] : $hex[0];
@@ -217,7 +219,7 @@ class Color
      * @return string rgb(r,g,b) string
      * @throws Exception "Bad RGB Array"
      */
-    public static function rgbToString($rgb = array())
+    public static function rgbToString(array $rgb = array()): string
     {
         // Make sure it's RGB
         if (empty($rgb) || !isset($rgb["R"], $rgb["G"], $rgb["B"])) {
@@ -236,7 +238,7 @@ class Color
      * @param string $color_name
      * @return string
      */
-    public static function nameToHex($color_name)
+    public static function nameToHex(string $color_name): string
     {
         $colors = array(
             'aliceblue' => 'F0F8FF',
@@ -403,7 +405,7 @@ class Color
      * @return string Darker HEX value
      * @throws Exception
      */
-    public function darken($amount = self::DEFAULT_ADJUST)
+    public function darken(int $amount = self::DEFAULT_ADJUST): string
     {
         // Darken
         $darkerHSL = $this->darkenHsl($this->_hsl, $amount);
@@ -418,7 +420,7 @@ class Color
      * @return string Lighter HEX value
      * @throws Exception
      */
-    public function lighten($amount = self::DEFAULT_ADJUST)
+    public function lighten(int $amount = self::DEFAULT_ADJUST): string
     {
         // Lighten
         $lighterHSL = $this->lightenHsl($this->_hsl, $amount);
@@ -433,7 +435,7 @@ class Color
      * @return string mixed HEX value
      * @throws Exception
      */
-    public function mix($hex2, $amount = 0)
+    public function mix(string $hex2, int $amount = 0): string
     {
         $rgb2 = self::hexToRgb($hex2);
         $mixed = $this->mixRgb($this->_rgb, $rgb2, $amount);
@@ -447,7 +449,7 @@ class Color
      * @return array An array with a 'light' and 'dark' index
      * @throws Exception
      */
-    public function makeGradient($amount = self::DEFAULT_ADJUST)
+    public function makeGradient(int $amount = self::DEFAULT_ADJUST): array
     {
         // Decide which color needs to be made
         if ($this->isLight()) {
@@ -462,13 +464,14 @@ class Color
         return array("light" => $lightColor, "dark" => $darkColor);
     }
 
+
     /**
      * Returns whether or not given color is considered "light"
      * @param string|bool $color
      * @param int $lighterThan
      * @return boolean
      */
-    public function isLight($color = false, $lighterThan = 130)
+    public function isLight($color = false, int $lighterThan = 130): bool
     {
         // Get our color
         $color = ($color) ? $color : $this->_hex;
@@ -487,7 +490,7 @@ class Color
      * @param int $darkerThan
      * @return boolean
      */
-    public function isDark($color = false, $darkerThan = 130)
+    public function isDark($color = false, int $darkerThan = 130): bool
     {
         // Get our color
         $color = ($color) ? $color : $this->_hex;
@@ -505,7 +508,7 @@ class Color
      * @return string Complementary hex color
      * @throws Exception
      */
-    public function complementary()
+    public function complementary(): string
     {
         // Get our HSL
         $hsl = $this->_hsl;
@@ -520,7 +523,7 @@ class Color
     /**
      * Returns the HSL array of your color
      */
-    public function getHsl()
+    public function getHsl(): array
     {
         return $this->_hsl;
     }
@@ -528,7 +531,7 @@ class Color
     /**
      * Returns your original color
      */
-    public function getHex()
+    public function getHex(): string
     {
         return $this->_hex;
     }
@@ -536,7 +539,7 @@ class Color
     /**
      * Returns the RGB array of your color
      */
-    public function getRgb()
+    public function getRgb(): array
     {
         return $this->_rgb;
     }
@@ -551,7 +554,7 @@ class Color
      * @throws Exception
      * @link http://caniuse.com/css-gradients Resource for the browser support
      */
-    public function getCssGradient($amount = self::DEFAULT_ADJUST, $vintageBrowsers = false, $suffix = "", $prefix = "")
+    public function getCssGradient($amount = self::DEFAULT_ADJUST, $vintageBrowsers = false, $suffix = "", $prefix = ""): string
     {
         // Get the recommended gradient
         $g = $this->makeGradient($amount);
@@ -592,7 +595,7 @@ class Color
      * @param int $amount
      * @return array $hsl
      */
-    private function darkenHsl($hsl, $amount = self::DEFAULT_ADJUST)
+    private function darkenHsl(array $hsl, int $amount = self::DEFAULT_ADJUST): array
     {
         // Check if we were provided a number
         if ($amount) {
@@ -612,7 +615,7 @@ class Color
      * @param int $amount
      * @return array
      */
-    private function lightenHsl($hsl, $amount = self::DEFAULT_ADJUST)
+    private function lightenHsl(array $hsl, int $amount = self::DEFAULT_ADJUST): array
     {
         // Check if we were provided a number
         if ($amount) {
@@ -634,7 +637,7 @@ class Color
      * @param int $amount ranged -100..0..+100
      * @return array
      */
-    private function mixRgb($rgb1, $rgb2, $amount = 0)
+    private function mixRgb(array $rgb1, array $rgb2, int $amount = 0): array
     {
         $r1 = ($amount + 100) / 100;
         $r2 = 2 - $r1;
@@ -653,7 +656,7 @@ class Color
      * @param float $vH
      * @return float
      */
-    private static function hueToRgb($v1, $v2, $vH)
+    private static function hueToRgb(float $v1, float $v2, float $vH): float
     {
         if ($vH < 0) {
             ++$vH;
@@ -684,7 +687,7 @@ class Color
      * @return string
      * @throws Exception
      */
-    private static function sanitizeHex($hex)
+    private static function sanitizeHex(string $hex): string
     {
         // Strip # sign if it is present
         $color = str_replace("#", "", $hex);
@@ -717,7 +720,7 @@ class Color
      * @param string $name
      * @return mixed|null
      */
-    public function __get($name)
+    public function __get(string $name)
     {
         switch (strtolower($name)) {
             case 'red':
@@ -745,7 +748,6 @@ class Color
             'Undefined property via __get(): ' . $name . ' in ' . $trace[0]['file'] . ' on line ' . $trace[0]['line'],
             E_USER_NOTICE
         );
-
         return null;
     }
 
@@ -754,7 +756,7 @@ class Color
      * @param mixed $value
      * @throws Exception
      */
-    public function __set($name, $value)
+    public function __set(string $name, $value)
     {
         switch (strtolower($name)) {
             case 'red':
@@ -762,35 +764,30 @@ class Color
                 $this->_rgb["R"] = $value;
                 $this->_hex = self::rgbToHex($this->_rgb);
                 $this->_hsl = self::hexToHsl($this->_hex);
-
                 break;
             case 'green':
             case 'g':
                 $this->_rgb["G"] = $value;
                 $this->_hex = self::rgbToHex($this->_rgb);
                 $this->_hsl = self::hexToHsl($this->_hex);
-
                 break;
             case 'blue':
             case 'b':
                 $this->_rgb["B"] = $value;
                 $this->_hex = self::rgbToHex($this->_rgb);
                 $this->_hsl = self::hexToHsl($this->_hex);
-
                 break;
             case 'hue':
             case 'h':
                 $this->_hsl["H"] = $value;
                 $this->_hex = self::hslToHex($this->_hsl);
                 $this->_rgb = self::hexToRgb($this->_hex);
-
                 break;
             case 'saturation':
             case 's':
                 $this->_hsl["S"] = $value;
                 $this->_hex = self::hslToHex($this->_hsl);
                 $this->_rgb = self::hexToRgb($this->_hex);
-
                 break;
             case 'lightness':
             case 'light':
@@ -798,7 +795,6 @@ class Color
                 $this->_hsl["L"] = $value;
                 $this->_hex = self::hslToHex($this->_hsl);
                 $this->_rgb = self::hexToRgb($this->_hex);
-
                 break;
         }
     }


### PR DESCRIPTION
Given a field named `color` here are some possible uses of these modifiers and how they can chain

```
{color:darken percent="20"}
{color:lighten percent="20"}
{color:lighten:contrast_color percent="20"}
{color:complementary}
{color:complementary:darken percent="20"}
{color:complementary:lighten percent="20"}
{color:mix color="#F00"}
{color:mix:darken color="#F00" percent="20"}
{color:mix:darken percent="20"}
{color:saturate percent="20"}
{color:desaturate percent="20"}
{color:rotate degrees="170"}
{color:rgb}
{color:hsl}
```

Full Docs PR: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1151