### PR TITLE
allowing ability to pass filename through to channel set export

### DIFF
--- a/system/ee/ExpressionEngine/Service/ChannelSet/Export.php
+++ b/system/ee/ExpressionEngine/Service/ChannelSet/Export.php
@@ -43,10 +43,16 @@ class Export
      * @param Array $channels List of channel instances
      * @return String Path to the generated zip file
      */
-    public function zip($channels)
+    public function zip($channels, $file_name = null)
     {
         $this->zip = new ZipArchive();
-        $location = PATH_CACHE . "cset/{$channels[0]->channel_name}.zip";
+
+        if(empty($file_name)) {
+            $location = PATH_CACHE . "cset/{$channels[0]->channel_name}.zip";
+        }
+        else {
+            $location = PATH_CACHE . "cset/$file_name.zip";
+        }
 
         if (! is_dir(PATH_CACHE . 'cset/')) {
             ee('Filesystem')->mkdir(PATH_CACHE . 'cset/');

--- a/system/ee/ExpressionEngine/Service/ChannelSet/Factory.php
+++ b/system/ee/ExpressionEngine/Service/ChannelSet/Factory.php
@@ -36,11 +36,11 @@ class Factory
      * @param Array $channels Array/collection of channels
      * @return String Path to the zip file
      */
-    public function export($channels)
+    public function export($channels, $file_name = null)
     {
         $export = new Export();
 
-        return $export->zip($channels);
+        return $export->zip($channels, $file_name);
     }
 
     /**


### PR DESCRIPTION
Allowing you to set temporary name of file in Channel set export.  Also opens door for exporting multiple channels channel sets at a time.