### PR TITLE
Fix PHP deprecation in file module.

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/mod.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/mod.file.php
@@ -21,6 +21,8 @@ class File
     public $valid_thumbs = array();
     public $query;
     public $return_data = '';
+    public $temp_array = array();
+    public $cat_array= array();	
 
     /**
       * Constructor


### PR DESCRIPTION
Error

Creation of dynamic property File::$cat_array is deprecated /Users/robinsowell/Sites/75gen/system/ee/ExpressionEngine/Addons/file/mod.file.php 259