### PR TITLE
Gets stable chrome version from release schedule in cypress test

### DIFF
--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -122,7 +122,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: [8.3]
-                os: [ubuntu-latest]
+                os: [ubuntu-22.04]
                 containers: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
         name: Cypress Tests, PHP${{ matrix.php }} - ${{ matrix.os }} ${{ matrix.containers }}

--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -232,10 +232,31 @@ jobs:
               env:
                 CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 
+            # This will get a Stable Chrome version that is 2 releases back from latest, and install it
+            # It gets the version from the Official Chromium Dash API
+            # Get a couple releases back ensures we do not run into the issue where not all runners have the latest version
+            - name: Get Chrome Version
+              id: get-chrome-version
+              run: |
+                latest_version=$(curl -s 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0' | jq -r '.[0].version')
+                major_version=$(echo $latest_version | cut -d '.' -f 1)
+                previous_major_version=$((major_version - 1))
+                echo "Previous major version of Chrome: $previous_major_version"
+                echo "chrome_version=$previous_major_version" >> $GITHUB_OUTPUT
+
             - name: Install Chrome
               uses: browser-actions/setup-chrome@latest
               with:
-                chrome-version: latest
+                chrome-version: ${{ steps.get-chrome-version.outputs.chrome_version }}
+                install-chromedriver: true
+                install-dependencies: true
+            - run: chrome --version
+
+            - name: Output the Chrome version and info
+              run: |
+                echo "Setup Chrome: ${{ steps.setup-chrome }}"
+                echo "Chrome version: ${{ steps.get-chrome-version.outputs.chrome_version }}"
+                chrome --version
 
             - name: Run Cypress Tests
               uses: cypress-io/github-action@v6

--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -250,13 +250,17 @@ jobs:
                 chrome-version: ${{ steps.get-chrome-version.outputs.chrome_version }}
                 install-chromedriver: true
                 install-dependencies: true
-            - run: chrome --version
+
+            - name: Update Chrome PATH
+              run: |
+                sudo ln -sf /opt/hostedtoolcache/setup-chrome/chromium/stable/x64/chrome /usr/bin/google-chrome
 
             - name: Output the Chrome version and info
               run: |
                 echo "Setup Chrome: ${{ steps.setup-chrome }}"
                 echo "Chrome version: ${{ steps.get-chrome-version.outputs.chrome_version }}"
                 chrome --version
+                chromedriver --version
 
             - name: Run Cypress Tests
               uses: cypress-io/github-action@v6

--- a/.github/workflows/tests-minimal.yml
+++ b/.github/workflows/tests-minimal.yml
@@ -214,6 +214,24 @@ jobs:
                 npm install -g maildev
                 maildev &
 
+            # This will get a Stable Chrome version that is 2 releases back from latest, and install it
+            # It gets the version from the Official Chromium Dash API
+            # Get a couple releases back ensures we do not run into the issue where not all runners have the latest version
+            - name: Get Chrome Version
+              id: get-chrome-version
+              run: |
+                latest_version=$(curl -s 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0' | jq -r '.[0].version')
+                major_version=$(echo $latest_version | cut -d '.' -f 1)
+                previous_major_version=$((major_version - 1))
+                echo "Previous major version of Chrome: $previous_major_version"
+                echo "chrome_version=$previous_major_version" >> $GITHUB_OUTPUT
+
+            - name: Install Specific Chrome Version
+              uses: browser-actions/setup-chrome@latest
+              id: setup-chrome
+              with:
+                chrome-version: ${{ steps.get-chrome-version.outputs.chrome_version }}
+
             - name: Get Cypress Specs
               if: "${{ env.CYPRESS_RECORD_KEY == '' }}"
               env:
@@ -227,46 +245,17 @@ jobs:
               if: "${{ env.CYPRESS_RECORD_KEY == '' }}"
               with:
                 spec: ${{ steps.specs.outputs.SPECS }}
-                browser: chrome
+                browser: ${{ steps.setup-chrome.outputs.chrome-path }}
                 working-directory: tests/cypress
               env:
                 CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-
-            # This will get a Stable Chrome version that is 2 releases back from latest, and install it
-            # It gets the version from the Official Chromium Dash API
-            # Get a couple releases back ensures we do not run into the issue where not all runners have the latest version
-            - name: Get Chrome Version
-              id: get-chrome-version
-              run: |
-                latest_version=$(curl -s 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0' | jq -r '.[0].version')
-                major_version=$(echo $latest_version | cut -d '.' -f 1)
-                previous_major_version=$((major_version - 1))
-                echo "Previous major version of Chrome: $previous_major_version"
-                echo "chrome_version=$previous_major_version" >> $GITHUB_OUTPUT
-
-            - name: Install Chrome
-              uses: browser-actions/setup-chrome@latest
-              with:
-                chrome-version: ${{ steps.get-chrome-version.outputs.chrome_version }}
-                install-chromedriver: true
-                install-dependencies: true
-
-            - name: Update Chrome PATH
-              run: |
-                sudo ln -sf /opt/hostedtoolcache/setup-chrome/chromium/stable/x64/chrome /usr/bin/google-chrome
-
-            - name: Output the Chrome version and info
-              run: |
-                echo "Setup Chrome: ${{ steps.setup-chrome }}"
-                echo "Chrome version: ${{ steps.get-chrome-version.outputs.chrome_version }}"
-                chrome --version
-                chromedriver --version
+                DEBUG: '@cypress/github-action'
 
             - name: Run Cypress Tests
               uses: cypress-io/github-action@v6
               if: "${{ env.CYPRESS_RECORD_KEY != '' }}"
               with:
-                browser: chrome
+                browser: ${{ steps.setup-chrome.outputs.chrome-path }}
                 working-directory: tests/cypress
                 record: true
                 parallel: true
@@ -276,6 +265,7 @@ jobs:
                 CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                 COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
+                DEBUG: '@cypress/github-action'
 
             - name: Run Cypress Tests (Electron)
               uses: cypress-io/github-action@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -257,27 +257,21 @@ jobs:
                 latest_version=$(curl -s 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0' | jq -r '.[0].version')
                 major_version=$(echo $latest_version | cut -d '.' -f 1)
                 previous_major_version=$((major_version - 1))
-                previous_version="${previous_major_version}"
-                echo "Previous major version of Chrome: $previous_version"
-                echo "chrome_version=$previous_version" >> $GITHUB_OUTPUT
+                echo "Previous major version of Chrome: $previous_major_version"
+                echo "chrome_version=$previous_major_version" >> $GITHUB_OUTPUT
 
-            - name: Install Chrome
+            - name: Install Specific Chrome Version
               uses: browser-actions/setup-chrome@latest
+              id: setup-chrome
               with:
                 chrome-version: ${{ steps.get-chrome-version.outputs.chrome_version }}
-                install-chromedriver: true
-
-            - name: Output the Chrome version and info
-              run: |
-                echo "Chrome version: ${{ steps.get-chrome-version.outputs.chrome_version }}"
-                echo "Chrome Binary: ${{ steps.setup-chrome.outputs.chrome-path }}"
 
             - name: Run Cypress Tests
               if: matrix.php != '5.6'
               uses: cypress-io/github-action@v6
               with:
                 # spec: ${{ steps.specs.outputs.SPECS }}
-                browser: chrome
+                browser: ${{ steps.setup-chrome.outputs.chrome-path }}
                 working-directory: tests/cypress
                 record: true
                 parallel: true
@@ -291,7 +285,7 @@ jobs:
               if: matrix.php == '5.6'
               uses: cypress-io/github-action@v6
               with:
-                browser: chrome
+                browser: ${{ steps.setup-chrome.outputs.chrome-path }}
                 working-directory: tests/cypress
                 config: specPattern=cypress/integration/!(updater|pro)/**.ee6.js
                 record: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,10 +248,20 @@ jobs:
             #     echo "::set-output name=SPECS::$(node tests/cypress-split.js 4 ${{ matrix.containers }})"
             #   id: specs
 
+            # This will get a Stable Chrome version that is 2 releases back from latest, and install it
+            # It gets the version from the Official Chromium Dash API
+            # Get a couple releases back ensures we do not run into the issue where not all runners have the latest version
+            - name: Get Chrome Version
+              id: get-chrome-version
+              run: |
+                latest_version=$(curl -s 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=3' | jq -r '.[0].version')
+                echo "Version of Chrome to use: $latest_version"
+                echo "::set-output name=chrome_version::$latest_version"
+
             - name: Install Chrome
               uses: browser-actions/setup-chrome@latest
               with:
-                chrome-version: latest
+                chrome-version: ${{ steps.get-chrome-version.outputs.chrome_version }}
 
             - name: Run Cypress Tests
               if: matrix.php != '5.6'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -254,14 +254,23 @@ jobs:
             - name: Get Chrome Version
               id: get-chrome-version
               run: |
-                latest_version=$(curl -s 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=3' | jq -r '.[0].version')
-                echo "Version of Chrome to use: $latest_version"
-                echo "::set-output name=chrome_version::$latest_version"
+                latest_version=$(curl -s 'https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1&offset=0' | jq -r '.[0].version')
+                major_version=$(echo $latest_version | cut -d '.' -f 1)
+                previous_major_version=$((major_version - 1))
+                previous_version="${previous_major_version}"
+                echo "Previous major version of Chrome: $previous_version"
+                echo "chrome_version=$previous_version" >> $GITHUB_OUTPUT
 
             - name: Install Chrome
               uses: browser-actions/setup-chrome@latest
               with:
                 chrome-version: ${{ steps.get-chrome-version.outputs.chrome_version }}
+                install-chromedriver: true
+
+            - name: Output the Chrome version and info
+              run: |
+                echo "Chrome version: ${{ steps.get-chrome-version.outputs.chrome_version }}"
+                echo "Chrome Binary: ${{ steps.setup-chrome.outputs.chrome-path }}"
 
             - name: Run Cypress Tests
               if: matrix.php != '5.6'

--- a/tests/cypress/cypress/integration/files/watermark_edit.ee6.js
+++ b/tests/cypress/cypress/integration/files/watermark_edit.ee6.js
@@ -8,7 +8,7 @@ context('Watermark Create/Edit', () => {
   before(function() {
     cy.task('db:seed')
   })
-  
+
   beforeEach(function() {
     cy.auth();
     page.load()
@@ -132,15 +132,15 @@ context('Watermark Create/Edit', () => {
     cy.hasNoErrors()
 
     page.get('wm_name').invoke('val').then((val) => { expect(val).to.be.equal('Test') })
-    page.get('wm_type').filter('[value=text]').should('be.checked')
-    page.get('wm_vrt_alignment').filter('[value=middle]').should('be.checked')
-    page.get('wm_hor_alignment').filter('[value=right]').should('be.checked')
+    page.get('wm_type').filter('[value="text"]').should('be.checked')
+    page.get('wm_vrt_alignment').filter('[value="middle"]').should('be.checked')
+    page.get('wm_hor_alignment').filter('[value="right"]').should('be.checked')
     page.get('wm_padding').invoke('val').then((val) => { expect(val).to.be.equal('10') })
     page.get('wm_hor_offset').invoke('val').then((val) => { expect(val).to.be.equal('20') })
     page.get('wm_vrt_offset').invoke('val').then((val) => { expect(val).to.be.equal('30') })
     page.get('wm_use_font').should('have.class', "on")
     page.get('wm_text').invoke('val').then((val) => { expect(val).to.be.equal('Test text') })
-    page.get('wm_font').filter('[value=texb.ttf]').should('be.checked')
+    page.get('wm_font').filter('[value="texb.ttf"]').should('be.checked')
     page.get('wm_font_size').invoke('val').then((val) => { expect(val).to.be.equal('18') })
     page.get('wm_font_color').invoke('val').then((val) => { expect(val).to.be.equal('#CCCCCC') })
     page.get('wm_use_drop_shadow').should('have.class', "on")

--- a/tests/cypress/package-lock.json
+++ b/tests/cypress/package-lock.json
@@ -24,7 +24,7 @@
                 "mysqldump": "^3.2.0"
             },
             "devDependencies": {
-                "cypress": "^13.7.1",
+                "cypress": "^13.16.0",
                 "find-test-names": "^1.28.12"
             }
         },
@@ -540,9 +540,9 @@
             }
         },
         "node_modules/@cypress/request": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
-            "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.6.tgz",
+            "integrity": "sha512-fi0eVdCOtKu5Ed6+E8mYxUF6ZTFJDZvHogCBelM0xVXmrDEkyM22gRArQzq1YcHPm1V47Vf/iAD+WgVdUlJCGg==",
             "dependencies": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -550,16 +550,16 @@
                 "combined-stream": "~1.0.6",
                 "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "http-signature": "~1.3.6",
+                "form-data": "~4.0.0",
+                "http-signature": "~1.4.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
                 "mime-types": "~2.1.19",
                 "performance-now": "^2.1.0",
-                "qs": "6.10.4",
+                "qs": "6.13.0",
                 "safe-buffer": "^5.1.2",
-                "tough-cookie": "^4.1.3",
+                "tough-cookie": "^5.0.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^8.3.2"
             },
@@ -955,9 +955,9 @@
             }
         },
         "node_modules/aws4": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
         },
         "node_modules/axe-core": {
             "version": "4.2.3",
@@ -975,19 +975,6 @@
                 "follow-redirects": "^1.15.4",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
-            }
-        },
-        "node_modules/axios/node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/axios/node_modules/proxy-from-env": {
@@ -1230,13 +1217,18 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
             "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.1",
-                "set-function-length": "^1.1.1"
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -1371,9 +1363,9 @@
             "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
         },
         "node_modules/ci-info": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+            "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==",
             "funding": [
                 {
                     "type": "github",
@@ -1601,12 +1593,12 @@
             }
         },
         "node_modules/cypress": {
-            "version": "13.7.1",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.1.tgz",
-            "integrity": "sha512-4u/rpFNxOFCoFX/Z5h+uwlkBO4mWzAjveURi3vqdSu56HPvVdyGTxGw4XKGWt399Y1JwIn9E1L9uMXQpc0o55w==",
+            "version": "13.16.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.16.0.tgz",
+            "integrity": "sha512-g6XcwqnvzXrqiBQR/5gN+QsyRmKRhls1y5E42fyOvsmU7JuY+wM6uHJWj4ZPttjabzbnRvxcik2WemR8+xT6FA==",
             "hasInstallScript": true,
             "dependencies": {
-                "@cypress/request": "^3.0.0",
+                "@cypress/request": "^3.0.6",
                 "@cypress/xvfb": "^1.2.4",
                 "@types/sinonjs__fake-timers": "8.1.1",
                 "@types/sizzle": "^2.3.2",
@@ -1617,6 +1609,7 @@
                 "cachedir": "^2.3.0",
                 "chalk": "^4.1.0",
                 "check-more-types": "^2.24.0",
+                "ci-info": "^4.0.0",
                 "cli-cursor": "^3.1.0",
                 "cli-table3": "~0.6.1",
                 "commander": "^6.2.1",
@@ -1631,7 +1624,6 @@
                 "figures": "^3.2.0",
                 "fs-extra": "^9.1.0",
                 "getos": "^3.2.1",
-                "is-ci": "^3.0.1",
                 "is-installed-globally": "~0.4.0",
                 "lazy-ass": "^1.6.0",
                 "listr2": "^3.8.3",
@@ -1645,7 +1637,8 @@
                 "request-progress": "^3.0.0",
                 "semver": "^7.5.3",
                 "supports-color": "^8.1.1",
-                "tmp": "~0.2.1",
+                "tmp": "~0.2.3",
+                "tree-kill": "1.2.2",
                 "untildify": "^4.0.0",
                 "yauzl": "^2.10.0"
             },
@@ -1839,16 +1832,19 @@
             "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
         },
         "node_modules/define-data-property": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dependencies": {
-                "get-intrinsic": "^1.2.1",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
             },
             "engines": {
                 "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/del": {
@@ -1970,6 +1966,25 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/es-define-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "dependencies": {
+                "get-intrinsic": "^1.2.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/escalade": {
@@ -2181,16 +2196,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+            "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
             "dependencies": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
+                "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
             },
             "engines": {
-                "node": ">= 0.12"
+                "node": ">= 6"
             }
         },
         "node_modules/fs-constants": {
@@ -2251,14 +2266,18 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
             "dependencies": {
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
                 "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -2423,20 +2442,20 @@
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dependencies": {
-                "get-intrinsic": "^1.2.2"
+                "es-define-property": "^1.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2501,13 +2520,13 @@
             "integrity": "sha512-qsh/wKe1Mk1vtYEFr+LpQBFWTO1gxZQBdii2D0Umj+IUQ23r5sT088Rhpq4XzpSyIpaX7vwjB8Rrtx8u9JTg+Q=="
         },
         "node_modules/http-signature": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
-            "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+            "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
             "dependencies": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^2.0.2",
-                "sshpk": "^1.14.1"
+                "sshpk": "^1.18.0"
             },
             "engines": {
                 "node": ">=0.10"
@@ -2662,17 +2681,6 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        },
-        "node_modules/is-ci": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-            "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-            "dependencies": {
-                "ci-info": "^3.2.0"
-            },
-            "bin": {
-                "is-ci": "bin.js"
-            }
         },
         "node_modules/is-docker": {
             "version": "2.2.1",
@@ -3506,9 +3514,12 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+            "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -3851,11 +3862,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/psl": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-        },
         "node_modules/pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -3863,14 +3869,6 @@
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
-            }
-        },
-        "node_modules/punycode": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/pupa": {
@@ -3934,11 +3932,11 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.10.4",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
-            "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.0.6"
             },
             "engines": {
                 "node": ">=0.6"
@@ -3946,11 +3944,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/querystringify": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
         },
         "node_modules/queue": {
             "version": "6.0.2",
@@ -4076,11 +4069,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/requires-port": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
         },
         "node_modules/responselike": {
             "version": "1.0.2",
@@ -4283,15 +4271,16 @@
             "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
         },
         "node_modules/set-function-length": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
-            "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
             "dependencies": {
-                "define-data-property": "^1.1.1",
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.2",
+                "get-intrinsic": "^1.2.4",
                 "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.1"
+                "has-property-descriptors": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -4317,13 +4306,17 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
             "dependencies": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "object-inspect": "^1.13.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4558,15 +4551,28 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/tmp": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+        "node_modules/tldts": {
+            "version": "6.1.61",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.61.tgz",
+            "integrity": "sha512-rv8LUyez4Ygkopqn+M6OLItAOT9FF3REpPQDkdMx5ix8w4qkuE7Vo2o/vw1nxKQYmJDV8JpAMJQr1b+lTKf0FA==",
             "dependencies": {
-                "rimraf": "^3.0.0"
+                "tldts-core": "^6.1.61"
             },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.61",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.61.tgz",
+            "integrity": "sha512-In7VffkDWUPgwa+c9picLUxvb0RltVwTkSgMNFgvlGSWveCzGBemBqTsgJCL4EDFWZ6WH0fKTsot6yNhzy3ZzQ=="
+        },
+        "node_modules/tmp": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
             "engines": {
-                "node": ">=8.17.0"
+                "node": ">=14.14"
             }
         },
         "node_modules/to-fast-properties": {
@@ -4599,31 +4605,28 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-            "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+            "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
             "dependencies": {
-                "psl": "^1.1.33",
-                "punycode": "^2.1.1",
-                "universalify": "^0.2.0",
-                "url-parse": "^1.5.3"
+                "tldts": "^6.1.32"
             },
             "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tough-cookie/node_modules/universalify": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-            "engines": {
-                "node": ">= 4.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "node_modules/tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+            "bin": {
+                "tree-kill": "cli.js"
+            }
         },
         "node_modules/tryer": {
             "version": "1.0.1",
@@ -4839,15 +4842,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/url-parse": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-            "dependencies": {
-                "querystringify": "^2.1.1",
-                "requires-port": "^1.0.0"
             }
         },
         "node_modules/url-parse-lax": {
@@ -5445,9 +5439,9 @@
             "optional": true
         },
         "@cypress/request": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.1.tgz",
-            "integrity": "sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.6.tgz",
+            "integrity": "sha512-fi0eVdCOtKu5Ed6+E8mYxUF6ZTFJDZvHogCBelM0xVXmrDEkyM22gRArQzq1YcHPm1V47Vf/iAD+WgVdUlJCGg==",
             "requires": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -5455,16 +5449,16 @@
                 "combined-stream": "~1.0.6",
                 "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "http-signature": "~1.3.6",
+                "form-data": "~4.0.0",
+                "http-signature": "~1.4.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
                 "mime-types": "~2.1.19",
                 "performance-now": "^2.1.0",
-                "qs": "6.10.4",
+                "qs": "6.13.0",
                 "safe-buffer": "^5.1.2",
-                "tough-cookie": "^4.1.3",
+                "tough-cookie": "^5.0.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^8.3.2"
             }
@@ -5779,9 +5773,9 @@
             "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
         },
         "aws4": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+            "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
         },
         "axe-core": {
             "version": "4.2.3",
@@ -5798,16 +5792,6 @@
                 "proxy-from-env": "^1.1.0"
             },
             "dependencies": {
-                "form-data": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-                    "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.8",
-                        "mime-types": "^2.1.12"
-                    }
-                },
                 "proxy-from-env": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -5973,13 +5957,15 @@
             "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ=="
         },
         "call-bind": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+            "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
             "requires": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.1",
-                "set-function-length": "^1.1.1"
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.1"
             }
         },
         "camelcase": {
@@ -6073,9 +6059,9 @@
             }
         },
         "ci-info": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.1.0.tgz",
+            "integrity": "sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A=="
         },
         "clean-stack": {
             "version": "2.2.0",
@@ -6241,11 +6227,11 @@
             }
         },
         "cypress": {
-            "version": "13.7.1",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.1.tgz",
-            "integrity": "sha512-4u/rpFNxOFCoFX/Z5h+uwlkBO4mWzAjveURi3vqdSu56HPvVdyGTxGw4XKGWt399Y1JwIn9E1L9uMXQpc0o55w==",
+            "version": "13.16.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.16.0.tgz",
+            "integrity": "sha512-g6XcwqnvzXrqiBQR/5gN+QsyRmKRhls1y5E42fyOvsmU7JuY+wM6uHJWj4ZPttjabzbnRvxcik2WemR8+xT6FA==",
             "requires": {
-                "@cypress/request": "^3.0.0",
+                "@cypress/request": "^3.0.6",
                 "@cypress/xvfb": "^1.2.4",
                 "@types/sinonjs__fake-timers": "8.1.1",
                 "@types/sizzle": "^2.3.2",
@@ -6256,6 +6242,7 @@
                 "cachedir": "^2.3.0",
                 "chalk": "^4.1.0",
                 "check-more-types": "^2.24.0",
+                "ci-info": "^4.0.0",
                 "cli-cursor": "^3.1.0",
                 "cli-table3": "~0.6.1",
                 "commander": "^6.2.1",
@@ -6270,7 +6257,6 @@
                 "figures": "^3.2.0",
                 "fs-extra": "^9.1.0",
                 "getos": "^3.2.1",
-                "is-ci": "^3.0.1",
                 "is-installed-globally": "~0.4.0",
                 "lazy-ass": "^1.6.0",
                 "listr2": "^3.8.3",
@@ -6284,7 +6270,8 @@
                 "request-progress": "^3.0.0",
                 "semver": "^7.5.3",
                 "supports-color": "^8.1.1",
-                "tmp": "~0.2.1",
+                "tmp": "~0.2.3",
+                "tree-kill": "1.2.2",
                 "untildify": "^4.0.0",
                 "yauzl": "^2.10.0"
             },
@@ -6438,13 +6425,13 @@
             "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
         },
         "define-data-property": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "requires": {
-                "get-intrinsic": "^1.2.1",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.0"
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
             }
         },
         "del": {
@@ -6540,6 +6527,19 @@
             "version": "7.8.1",
             "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
             "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw=="
+        },
+        "es-define-property": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+            "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+            "requires": {
+                "get-intrinsic": "^1.2.4"
+            }
+        },
+        "es-errors": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
         },
         "escalade": {
             "version": "3.1.1",
@@ -6684,12 +6684,12 @@
             "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
         },
         "form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+            "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
             "requires": {
                 "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
+                "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
             }
         },
@@ -6739,10 +6739,11 @@
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
         "get-intrinsic": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+            "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
             "requires": {
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
                 "has-symbols": "^1.0.3",
@@ -6868,17 +6869,17 @@
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "has-property-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "requires": {
-                "get-intrinsic": "^1.2.2"
+                "es-define-property": "^1.0.0"
             }
         },
         "has-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
+            "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q=="
         },
         "has-symbols": {
             "version": "1.0.3",
@@ -6919,13 +6920,13 @@
             "integrity": "sha512-qsh/wKe1Mk1vtYEFr+LpQBFWTO1gxZQBdii2D0Umj+IUQ23r5sT088Rhpq4XzpSyIpaX7vwjB8Rrtx8u9JTg+Q=="
         },
         "http-signature": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
-            "integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+            "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
             "requires": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^2.0.2",
-                "sshpk": "^1.14.1"
+                "sshpk": "^1.18.0"
             }
         },
         "https-proxy-agent": {
@@ -7029,14 +7030,6 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        },
-        "is-ci": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
-            "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
-            "requires": {
-                "ci-info": "^3.2.0"
-            }
         },
         "is-docker": {
             "version": "2.2.1",
@@ -7660,9 +7653,9 @@
             }
         },
         "object-inspect": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+            "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="
         },
         "once": {
             "version": "1.4.0",
@@ -7903,11 +7896,6 @@
             "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-7.2.0.tgz",
             "integrity": "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ=="
         },
-        "psl": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-        },
         "pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -7916,11 +7904,6 @@
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
             }
-        },
-        "punycode": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
         },
         "pupa": {
             "version": "2.1.1",
@@ -7963,17 +7946,12 @@
             }
         },
         "qs": {
-            "version": "6.10.4",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
-            "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "requires": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.0.6"
             }
-        },
-        "querystringify": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
         },
         "queue": {
             "version": "6.0.2",
@@ -8063,11 +8041,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
-        },
-        "requires-port": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
         },
         "responselike": {
             "version": "1.0.2",
@@ -8211,15 +8184,16 @@
             "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
         },
         "set-function-length": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
-            "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
             "requires": {
-                "define-data-property": "^1.1.1",
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.2",
+                "get-intrinsic": "^1.2.4",
                 "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.1"
+                "has-property-descriptors": "^1.0.2"
             }
         },
         "shebang-command": {
@@ -8236,13 +8210,14 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
         },
         "side-channel": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+            "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
             "requires": {
-                "call-bind": "^1.0.0",
-                "get-intrinsic": "^1.0.2",
-                "object-inspect": "^1.9.0"
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "object-inspect": "^1.13.1"
             }
         },
         "signal-exit": {
@@ -8412,13 +8387,23 @@
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
             "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA=="
         },
-        "tmp": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+        "tldts": {
+            "version": "6.1.61",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.61.tgz",
+            "integrity": "sha512-rv8LUyez4Ygkopqn+M6OLItAOT9FF3REpPQDkdMx5ix8w4qkuE7Vo2o/vw1nxKQYmJDV8JpAMJQr1b+lTKf0FA==",
             "requires": {
-                "rimraf": "^3.0.0"
+                "tldts-core": "^6.1.61"
             }
+        },
+        "tldts-core": {
+            "version": "6.1.61",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.61.tgz",
+            "integrity": "sha512-In7VffkDWUPgwa+c9picLUxvb0RltVwTkSgMNFgvlGSWveCzGBemBqTsgJCL4EDFWZ6WH0fKTsot6yNhzy3ZzQ=="
+        },
+        "tmp": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+            "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w=="
         },
         "to-fast-properties": {
             "version": "2.0.0",
@@ -8441,27 +8426,22 @@
             }
         },
         "tough-cookie": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
-            "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
+            "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
             "requires": {
-                "psl": "^1.1.33",
-                "punycode": "^2.1.1",
-                "universalify": "^0.2.0",
-                "url-parse": "^1.5.3"
-            },
-            "dependencies": {
-                "universalify": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-                    "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg=="
-                }
+                "tldts": "^6.1.32"
             }
         },
         "tr46": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="
         },
         "tryer": {
             "version": "1.0.1",
@@ -8614,15 +8594,6 @@
                         "has-flag": "^4.0.0"
                     }
                 }
-            }
-        },
-        "url-parse": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-            "requires": {
-                "querystringify": "^2.1.1",
-                "requires-port": "^1.0.0"
             }
         },
         "url-parse-lax": {

--- a/tests/cypress/package-lock.json
+++ b/tests/cypress/package-lock.json
@@ -24,7 +24,7 @@
                 "mysqldump": "^3.2.0"
             },
             "devDependencies": {
-                "cypress": "^13.16.0",
+                "cypress": "^13.17.0",
                 "find-test-names": "^1.28.12"
             }
         },
@@ -1593,9 +1593,9 @@
             }
         },
         "node_modules/cypress": {
-            "version": "13.16.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.16.0.tgz",
-            "integrity": "sha512-g6XcwqnvzXrqiBQR/5gN+QsyRmKRhls1y5E42fyOvsmU7JuY+wM6uHJWj4ZPttjabzbnRvxcik2WemR8+xT6FA==",
+            "version": "13.17.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
+            "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
             "hasInstallScript": true,
             "dependencies": {
                 "@cypress/request": "^3.0.6",
@@ -6227,9 +6227,9 @@
             }
         },
         "cypress": {
-            "version": "13.16.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.16.0.tgz",
-            "integrity": "sha512-g6XcwqnvzXrqiBQR/5gN+QsyRmKRhls1y5E42fyOvsmU7JuY+wM6uHJWj4ZPttjabzbnRvxcik2WemR8+xT6FA==",
+            "version": "13.17.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
+            "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
             "requires": {
                 "@cypress/request": "^3.0.6",
                 "@cypress/xvfb": "^1.2.4",

--- a/tests/cypress/package.json
+++ b/tests/cypress/package.json
@@ -14,7 +14,7 @@
     "author": "",
     "license": "ISC",
     "devDependencies": {
-        "cypress": "^13.7.1",
+        "cypress": "^13.16.0",
         "find-test-names": "^1.28.12"
     },
     "dependencies": {

--- a/tests/cypress/package.json
+++ b/tests/cypress/package.json
@@ -14,7 +14,7 @@
     "author": "",
     "license": "ISC",
     "devDependencies": {
-        "cypress": "^13.16.0",
+        "cypress": "^13.17.0",
         "find-test-names": "^1.28.12"
     },
     "dependencies": {


### PR DESCRIPTION
This will get a Stable Chrome version that is 2 releases back from latest, and install it 
It gets the version from the Official Chromium Dash API
Get a couple releases back ensures we do not run into the issue where not all runners have the latest version