### PR TITLE
Make parseLayoutVariables public

### DIFF
--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -691,10 +691,11 @@ class EE_Template
      * @param  array $layout_vars Layout variables to parser, 'variable_name' => 'content'
      * @return string The parsed template/string
      */
-    private function parseLayoutVariables($str, $layout_vars)
+    public function parseLayoutVariables($str, $layout_vars)
     {
         $this->log_item("Layout Variables:", $layout_vars);
         $this->layout_conditionals = [];
+        $layout_conditionals = [];
 
         // get all the declared layout variables (excluding layout:contents)
         if (preg_match_all('/' . LD . 'layout:(?!\bset|contents\b)([^!]+?)(' . RD . '|\s|:)/', $str, $matches)) {


### PR DESCRIPTION
Making this public will let me greatly improve how Speedy parses cached templates that use layout variables.

$this->layout_vars is already public, along with most other methods to parse globals, vars etc, and even some methods that are prefixed with an underscore, which is usually indicative of a private method. Making this public doesn't feel like it would have adverse side effects?