### PR TITLE
Improve Filemanager Performance

### DIFF
--- a/system/ee/ExpressionEngine/Addons/filepicker/mcp.filepicker.php
+++ b/system/ee/ExpressionEngine/Addons/filepicker/mcp.filepicker.php
@@ -250,11 +250,21 @@ class Filepicker_mcp
         $result = $file->getValues();
 
         $result['path'] = $file->getAbsoluteURL();
-        $result['thumb_path'] = ee('Thumbnail')->get($file)->url;
+        $result = array_merge($result, $this->getThumbnailResponseData($file));
         $result['isImage'] = $file->isImage();
         $result['isSVG'] = $file->isSVG();
 
         ee()->output->send_ajax_response($result);
+    }
+
+    private function getThumbnailResponseData($file)
+    {
+        $thumb = ee('Thumbnail')->get($file);
+
+        return [
+            'thumb_path' => $thumb->url,
+            'thumb_fallback_path' => $file->getAbsoluteURL(),
+        ];
     }
 
     public function upload()
@@ -377,7 +387,7 @@ class Filepicker_mcp
 
                 return [
                     'ajax' => true,
-                    'body' => [
+                    'body' => array_merge([
                         // Inconsistent casing for backwards compatibility
                         'status' => 'success',
                         'title' => $file->file_name,
@@ -385,10 +395,10 @@ class Filepicker_mcp
                         'file_name' => $file->file_name,
                         'isImage' => $file->isImage(),
                         'isSVG' => $file->isSVG(),
-                        'thumb_path' => $file->getAbsoluteThumbnailURL(),
+                    ], $this->getThumbnailResponseData($file), [
                         'upload_location_id' => $file->upload_location_id,
                         'file_hw_original' => $result['upload_response']['file_hw_original'],
-                    ]
+                    ])
                 ];
             }
         }

--- a/system/ee/ExpressionEngine/Addons/filepicker/views/ModalView.php
+++ b/system/ee/ExpressionEngine/Addons/filepicker/views/ModalView.php
@@ -30,7 +30,8 @@
 				<td>
 					<a data-id="<?=$file->file_id ?: $file->file_name ?>" data-url="<?=ee('CP/URL')->make($data_url_base, array('file' => $file->file_id))?>" class="filepicker-item" href="#">
 						<?php if ($file->isEditableImage() || $file->isSVG()): ?>
-							<img src="<?=ee('Thumbnail')->get($file)->url?>" alt="<?=$file->file_name?>">
+							<?php $thumb = ee('Thumbnail')->get($file); ?>
+							<img src="<?=$thumb->url?>" fallback-src="<?=$file->getAbsoluteURL()?>" data-file-id="<?=$file->file_id?>" class="thumbnail_img" alt="<?=$file->file_name?>" onerror="window.EE.cp.fallbackImage(this)">
 						<?php else: ?>
 							<?php if (in_array($file->mime_type, ['text/plain', 'text/markdown'])): ?>
 								<i class="fal fa-file-alt fa-5x"></i>

--- a/system/ee/ExpressionEngine/Addons/pro_variables/types/pro_select_files/vt.pro_select_files.php
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/types/pro_select_files/vt.pro_select_files.php
@@ -162,7 +162,8 @@ class Pro_select_files extends Pro_variables_type
                 'id'    => $file->file_id,
                 'name'  => $file->title,
                 'url'   => $file->getAbsoluteURL(),
-                'thumb' => $file->getAbsoluteThumbnailURL()
+                'thumb' => $file->getAbsoluteThumbnailURL(),
+                'thumb_fallback' => $file->getAbsoluteURL()
             );
         }
 
@@ -204,7 +205,12 @@ class Pro_select_files extends Pro_variables_type
                 $name = htmlspecialchars($file['name'], ENT_QUOTES);
 
                 if ($data['thumbs'] && $file['thumb']) {
-                    $name = sprintf('<img src="%s" alt="" />', $file['thumb']) . $name;
+                    $name = sprintf(
+                        '<img src="%s" fallback-src="%s" data-file-id="%s" class="thumbnail_img" alt="" onerror="window.EE.cp.fallbackImage(this)" />',
+                        htmlspecialchars($file['thumb'], ENT_QUOTES),
+                        htmlspecialchars($file['thumb_fallback'], ENT_QUOTES),
+                        htmlspecialchars($file['id'], ENT_QUOTES)
+                    ) . $name;
                 }
 
                 $data['choices'][$file['url']] = $name;

--- a/system/ee/ExpressionEngine/Boot/boot.common.php
+++ b/system/ee/ExpressionEngine/Boot/boot.common.php
@@ -431,6 +431,7 @@ function set_status_header($code = 200, $text = '')
         304 => 'Not Modified',
         305 => 'Use Proxy',
         307 => 'Temporary Redirect',
+        308 => 'Permanent Redirect',
 
         400 => 'Bad Request',
         401 => 'Unauthorized',
@@ -449,13 +450,23 @@ function set_status_header($code = 200, $text = '')
         415 => 'Unsupported Media Type',
         416 => 'Requested Range Not Satisfiable',
         417 => 'Expectation Failed',
+        421 => 'Misdirected Request',
+        422 => 'Unprocessable Entity',
+        423 => 'Locked',
+        424 => 'Failed Dependency',
+        425 => 'Too Early',
+        426 => 'Upgrade Required',
+        429 => 'Too Many Requests',
+        431 => 'Request Header Fields Too Large',
+        451 => 'Unavailable For Legal Reasons',
 
         500 => 'Internal Server Error',
         501 => 'Not Implemented',
         502 => 'Bad Gateway',
         503 => 'Service Unavailable',
         504 => 'Gateway Timeout',
-        505 => 'HTTP Version Not Supported'
+        505 => 'HTTP Version Not Supported',
+        507 => 'Insufficient Storage',
     );
 
     if ($code == '' or ! is_numeric($code)) {

--- a/system/ee/ExpressionEngine/Controller/Files/File.php
+++ b/system/ee/ExpressionEngine/Controller/Files/File.php
@@ -575,6 +575,7 @@ class File extends AbstractFilesController
         force_download($file->file_name, $file->UploadDestination->getFilesystem()->read($file->getAbsolutePath()));
     }
 
+    // Check if a given file exists in the filesystem
     public function exists($id)
     {
         $file = ee('Model')->get('File', $id)

--- a/system/ee/ExpressionEngine/Controller/Files/File.php
+++ b/system/ee/ExpressionEngine/Controller/Files/File.php
@@ -587,6 +587,7 @@ class File extends AbstractFilesController
         force_download($file->file_name, $file->UploadDestination->getFilesystem()->read($file->getAbsolutePath()));
     }
 
+    // Check if a given file exists in the filesystem
     public function exists($id)
     {
         $file = ee('Model')->get('File', $id)

--- a/system/ee/ExpressionEngine/Controller/Files/File.php
+++ b/system/ee/ExpressionEngine/Controller/Files/File.php
@@ -574,6 +574,47 @@ class File extends AbstractFilesController
         ee()->load->helper('download');
         force_download($file->file_name, $file->UploadDestination->getFilesystem()->read($file->getAbsolutePath()));
     }
+
+    public function exists($id)
+    {
+        $file = ee('Model')->get('File', $id)
+            ->filter('site_id', 'IN', [ee()->config->item('site_id'), 0])
+            ->first();
+
+        if(empty($file) || !$file->exists()) {
+            return ee('Response')->setStatus(404);
+        }
+
+        return ee('Response')->setStatus(200);
+    }
+
+    // Ajax endpoint for creating and retrieving a File's thumbnail if applicable
+    public function createMissingThumbnail($id)
+    {
+        $file = ee('Model')->get('File', (int) $id)
+            ->filter('site_id', 'IN', [ee()->config->item('site_id'), 0])
+            ->first();
+
+        if(empty($file) || !$file->exists()) {
+            return ee('Response')->setStatus(404);
+        }
+
+        if(!$file->isFile() || !$file->isImage()) {
+            return ee('Response')->setStatus(422);
+        }
+
+        $thumb = ee('Thumbnail')->get($file);
+
+        if (! $thumb->exists()) {
+            $thumb = ee('Thumbnail')->make($file);
+        }
+
+        return ee()->output->send_ajax_response([
+            'url' => $thumb->url,
+            'path' => $thumb->path,
+            'tag' => $thumb->tag
+        ]);
+    }
 }
 
 // EOF

--- a/system/ee/ExpressionEngine/Controller/Files/File.php
+++ b/system/ee/ExpressionEngine/Controller/Files/File.php
@@ -587,18 +587,37 @@ class File extends AbstractFilesController
         force_download($file->file_name, $file->UploadDestination->getFilesystem()->read($file->getAbsolutePath()));
     }
 
-    // Check if a given file exists in the filesystem
-    public function exists($id)
+    // Check if the given files exist in the filesystem
+    public function exists($id = null)
     {
-        $file = ee('Model')->get('File', $id)
-            ->filter('site_id', 'IN', [ee()->config->item('site_id'), 0])
-            ->first();
+        $ids = ($id === null) ? ee('Request')->post('file_ids', []) : [$id];
 
-        if(empty($file) || !$file->memberHasAccess(ee()->session->getMember()) || !$file->exists()) {
-            return ee('Response')->setStatus(404);
+        $ids = array_values(array_unique(array_filter(array_map('intval', is_array($ids) ? $ids : [$ids]))));
+        $results = array_fill_keys($ids, ['exists' => false]);
+
+        if (empty($ids)) {
+            return ee()->output->send_ajax_response(['files' => $results]);
         }
 
-        return ee('Response')->setStatus(200);
+        $files = ee('Model')->get('File', $ids)
+            ->with('UploadDestination')
+            ->filter('site_id', 'IN', [ee()->config->item('site_id'), 0])
+            ->all()
+            ->indexBy('file_id');
+
+        foreach ($ids as $file_id) {
+            if (empty($files[$file_id]) || ! $files[$file_id]->memberHasAccess(ee()->session->getMember())) {
+                continue;
+            }
+
+            try {
+                $results[$file_id]['exists'] = (bool) $files[$file_id]->exists();
+            } catch (\Throwable $e) {
+                $results[$file_id]['exists'] = false;
+            }
+        }
+
+        return ee()->output->send_ajax_response(['files' => $results]);
     }
 
     // Ajax endpoint for creating and retrieving a File's thumbnail if applicable

--- a/system/ee/ExpressionEngine/Controller/Files/File.php
+++ b/system/ee/ExpressionEngine/Controller/Files/File.php
@@ -594,7 +594,7 @@ class File extends AbstractFilesController
             ->filter('site_id', 'IN', [ee()->config->item('site_id'), 0])
             ->first();
 
-        if(empty($file) || !$file->exists()) {
+        if(empty($file) || !$file->memberHasAccess(ee()->session->getMember()) || !$file->exists()) {
             return ee('Response')->setStatus(404);
         }
 
@@ -608,7 +608,7 @@ class File extends AbstractFilesController
             ->filter('site_id', 'IN', [ee()->config->item('site_id'), 0])
             ->first();
 
-        if(empty($file) || !$file->exists()) {
+        if(empty($file) || !$file->memberHasAccess(ee()->session->getMember()) || !$file->exists()) {
             return ee('Response')->setStatus(404);
         }
 

--- a/system/ee/ExpressionEngine/Controller/Files/File.php
+++ b/system/ee/ExpressionEngine/Controller/Files/File.php
@@ -586,6 +586,47 @@ class File extends AbstractFilesController
         ee()->load->helper('download');
         force_download($file->file_name, $file->UploadDestination->getFilesystem()->read($file->getAbsolutePath()));
     }
+
+    public function exists($id)
+    {
+        $file = ee('Model')->get('File', $id)
+            ->filter('site_id', 'IN', [ee()->config->item('site_id'), 0])
+            ->first();
+
+        if(empty($file) || !$file->exists()) {
+            return ee('Response')->setStatus(404);
+        }
+
+        return ee('Response')->setStatus(200);
+    }
+
+    // Ajax endpoint for creating and retrieving a File's thumbnail if applicable
+    public function createMissingThumbnail($id)
+    {
+        $file = ee('Model')->get('File', (int) $id)
+            ->filter('site_id', 'IN', [ee()->config->item('site_id'), 0])
+            ->first();
+
+        if(empty($file) || !$file->exists()) {
+            return ee('Response')->setStatus(404);
+        }
+
+        if(!$file->isFile() || !$file->isImage()) {
+            return ee('Response')->setStatus(422);
+        }
+
+        $thumb = ee('Thumbnail')->get($file);
+
+        if (! $thumb->exists()) {
+            $thumb = ee('Thumbnail')->make($file);
+        }
+
+        return ee()->output->send_ajax_response([
+            'url' => $thumb->url,
+            'path' => $thumb->path,
+            'tag' => $thumb->tag
+        ]);
+    }
 }
 
 // EOF

--- a/system/ee/ExpressionEngine/Controller/Files/Files.php
+++ b/system/ee/ExpressionEngine/Controller/Files/Files.php
@@ -419,6 +419,32 @@ class Files extends AbstractFilesController
         ee()->cp->render('files/delete_confirm', $vars);
     }
 
+    // Ajax endpoint for creating and retrieving a File's thumbnail if applicable
+    public function createMissingThumbnail($file)
+    {
+        $file = ee('Model')->get('FileSystemEntity', (int) $file)->first();
+
+        if(empty($file) || !$file->exists()) {
+            return ee('Response')->setStatus(404);
+        }
+
+        if(!$file->isFile() || !$file->isImage()) {
+            return ee('Response')->setStatus(422);
+        }
+
+        $thumb = ee('Thumbnail')->get($file);
+
+        if (! $thumb->exists()) {
+            $thumb = ee('Thumbnail')->make($file);
+        }
+
+        return ee()->output->send_ajax_response([
+            'url' => $thumb->url,
+            'path' => $thumb->path,
+            'tag' => $thumb->tag
+        ]);
+    }
+
     private function overwriteOrRename($file, $original_name)
     {
         $vars = array(

--- a/system/ee/ExpressionEngine/Controller/Files/Files.php
+++ b/system/ee/ExpressionEngine/Controller/Files/Files.php
@@ -419,32 +419,6 @@ class Files extends AbstractFilesController
         ee()->cp->render('files/delete_confirm', $vars);
     }
 
-    // Ajax endpoint for creating and retrieving a File's thumbnail if applicable
-    public function createMissingThumbnail($file)
-    {
-        $file = ee('Model')->get('FileSystemEntity', (int) $file)->first();
-
-        if(empty($file) || !$file->exists()) {
-            return ee('Response')->setStatus(404);
-        }
-
-        if(!$file->isFile() || !$file->isImage()) {
-            return ee('Response')->setStatus(422);
-        }
-
-        $thumb = ee('Thumbnail')->get($file);
-
-        if (! $thumb->exists()) {
-            $thumb = ee('Thumbnail')->make($file);
-        }
-
-        return ee()->output->send_ajax_response([
-            'url' => $thumb->url,
-            'path' => $thumb->path,
-            'tag' => $thumb->tag
-        ]);
-    }
-
     private function overwriteOrRename($file, $original_name)
     {
         $vars = array(

--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Columns/Title.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Columns/Title.php
@@ -30,9 +30,9 @@ class Title extends EntryManager\Columns\Title
             }
         }
 
-        if (! $file->exists()) {
-            $title .= '<br><em class="faded">' . lang('file_not_found') . '</em>';
-        }
+        // Append "file not found" text for JS display if needed
+        $title .= '<div class="hidden file-not-found"><em class="faded">' . lang('file_not_found') . '</em></div>';
+
 
         return $title;
     }

--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
@@ -334,22 +334,10 @@ trait FileManagerTrait
             ->all();
 
         $data = array();
-        $missing_files = false;
-
-        $destinationsToEagerLoad = [];
 
         foreach ($files as $file) {
             if (! $file->memberHasAccess($member)) {
                 continue;
-            }
-
-            // We only need to eager load contents for destinations that are displaying
-            // files in this current page of the listing
-            if (! in_array($file->upload_location_id, $destinationsToEagerLoad)) {
-                if ($file->UploadDestination->adapter != 'local' && $file->UploadDestination->exists()) {
-                    $file->UploadDestination->eagerLoadContents();
-                }
-                $destinationsToEagerLoad[$file->upload_location_id] = $file->upload_location_id;
             }
 
             $attrs = [
@@ -360,11 +348,6 @@ trait FileManagerTrait
 
             if ($file->isDirectory()) {
                 $attrs['file_upload_id'] = $file->upload_location_id . '.' . $file->file_id;
-            }
-
-            if (! $file->exists()) {
-                $attrs['class'] = 'missing';
-                $missing_files = true;
             }
 
             if ($preselectedFileId && $file->file_id == $preselectedFileId) {
@@ -408,14 +391,14 @@ trait FileManagerTrait
             );
         }
 
-        if ($missing_files) {
-            ee('CP/Alert')->makeInline('missing-files')
-                ->asWarning()
-                ->cannotClose()
-                ->withTitle(lang('files_not_found'))
-                ->addToBody(lang('files_not_found_desc'))
-                ->now();
-        }
+        // Add the missing files alert in a hidden state so that JS can show it if a file is missing
+        ee('CP/Alert')->makeInline('missing-files')
+            ->asWarning()
+            ->cannotClose()
+            ->withTitle(lang('files_not_found'))
+            ->addToBody(lang('files_not_found_desc'))
+            ->hide()
+            ->now();
 
         $table->setData($data);
 

--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
@@ -349,22 +349,10 @@ trait FileManagerTrait
             ->all();
 
         $data = array();
-        $missing_files = false;
-
-        $destinationsToEagerLoad = [];
 
         foreach ($files as $file) {
             if (! $file->memberHasAccess($member)) {
                 continue;
-            }
-
-            // We only need to eager load contents for destinations that are displaying
-            // files in this current page of the listing
-            if (! in_array($file->upload_location_id, $destinationsToEagerLoad)) {
-                if ($file->UploadDestination->getProperty('adapter') != 'local' && $file->UploadDestination->exists()) {
-                    $file->UploadDestination->eagerLoadContents();
-                }
-                $destinationsToEagerLoad[$file->upload_location_id] = $file->upload_location_id;
             }
 
             $attrs = [
@@ -375,11 +363,6 @@ trait FileManagerTrait
 
             if ($file->isDirectory()) {
                 $attrs['file_upload_id'] = $file->upload_location_id . '.' . $file->file_id;
-            }
-
-            if (! $file->exists()) {
-                $attrs['class'] = 'missing';
-                $missing_files = true;
             }
 
             if ($preselectedFileId && $file->file_id == $preselectedFileId) {
@@ -423,14 +406,14 @@ trait FileManagerTrait
             );
         }
 
-        if ($missing_files) {
-            ee('CP/Alert')->makeInline('missing-files')
-                ->asWarning()
-                ->cannotClose()
-                ->withTitle(lang('files_not_found'))
-                ->addToBody(lang('files_not_found_desc'))
-                ->now();
-        }
+        // Add the missing files alert in a hidden state so that JS can show it if a file is missing
+        ee('CP/Alert')->makeInline('missing-files')
+            ->asWarning()
+            ->cannotClose()
+            ->withTitle(lang('files_not_found'))
+            ->addToBody(lang('files_not_found_desc'))
+            ->hide()
+            ->now();
 
         $table->setData($data);
 

--- a/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
+++ b/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
@@ -354,10 +354,6 @@ class FileSystemEntity extends ContentModel
 
         $filesystem = $this->UploadDestination->getFilesystem();
 
-        if (! $filesystem->exists($this->getAbsoluteManipulationPath($manipulation))) {
-            return $this->getAbsoluteURL();
-        }
-
         return $filesystem->getUrl($this->getSubfoldersPath() . '_' . $manipulation . '/'  . $this->file_name);
     }
 

--- a/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
+++ b/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
@@ -342,10 +342,6 @@ class FileSystemEntity extends ContentModel
 
         $filesystem = $this->UploadDestination->getFilesystem();
 
-        if (! $filesystem->exists($this->getAbsoluteManipulationPath($manipulation))) {
-            return $this->getAbsoluteURL();
-        }
-
         return $filesystem->getUrl($this->getSubfoldersPath() . '_' . $manipulation . '/'  . $this->file_name);
     }
 

--- a/system/ee/ExpressionEngine/Service/Alert/Alert.php
+++ b/system/ee/ExpressionEngine/Service/Alert/Alert.php
@@ -57,6 +57,11 @@ class Alert
     protected $type = 'alert';
 
     /**
+     * @var boolean $hidden Flag to determine whether or not the alert is visible
+     */
+    protected $hidden = false;
+
+    /**
      * @var AlertCollection $collection A collection of alerts for use with
      *  deferring or immediately displaying alerts
      */
@@ -344,6 +349,18 @@ class Alert
         if (! $this->isEmpty()) {
             $this->collection->save($this);
         }
+
+        return $this;
+    }
+
+    /**
+     * Toggle the display status of the alert to hidden
+     *
+     * @return self
+     */
+    public function hide()
+    {
+        $this->hidden = true;
 
         return $this;
     }

--- a/system/ee/ExpressionEngine/Service/Thumbnail/Thumbnail.php
+++ b/system/ee/ExpressionEngine/Service/Thumbnail/Thumbnail.php
@@ -60,15 +60,12 @@ class Thumbnail
         $this->setDefault();
 
         if ($file) {
-            if (! $file->exists()) {
-                $this->setMissing();
-                return;
-            } elseif ($file->isDirectory()) {
+            if ($file->isDirectory()) {
                 $this->tag = '<i class="fal fa-folder fa-3x"></i>';
             } elseif ($file->isEditableImage() || $file->isSVG()) {
                 $this->url = $file->getAbsoluteThumbnailURL() . "?v={$file->modified_date}";
                 $this->path = $file->getAbsoluteThumbnailPath();
-                $this->tag = '<img src="' . $this->url . '" alt="' . $file->title . '" title="' . $file->title .'" class="thumbnail_img" />';
+                $this->tag = '<img src="' . $this->url . '" fallback-src="'. $file->getAbsoluteUrl().'" alt="' . $file->title . '" title="' . $file->title .'" class="thumbnail_img" onerror="window.addEventListener(\'load\', window.EE.cp.fallbackImage(this))" />';
             } else {
                 switch ($file->file_type) {
                     case 'doc':
@@ -100,7 +97,11 @@ class Thumbnail
                 }
             }
 
-            $this->filesystem = $file->UploadDestination->getFilesystem();
+            try {
+                $this->filesystem = $file->UploadDestination->getFilesystem();
+            }catch(\Exception $e) {
+                $this->setMissing();
+            }
         }
     }
 

--- a/system/ee/ExpressionEngine/Service/Thumbnail/Thumbnail.php
+++ b/system/ee/ExpressionEngine/Service/Thumbnail/Thumbnail.php
@@ -65,7 +65,7 @@ class Thumbnail
             } elseif ($file->isEditableImage() || $file->isSVG()) {
                 $this->url = $file->getAbsoluteThumbnailURL() . "?v={$file->modified_date}";
                 $this->path = $file->getAbsoluteThumbnailPath();
-                $this->tag = '<img src="' . $this->url . '" fallback-src="'. $file->getAbsoluteUrl().'" alt="' . $file->title . '" title="' . $file->title .'" class="thumbnail_img" onerror="window.addEventListener(\'load\', window.EE.cp.fallbackImage(this))" />';
+                $this->tag = '<img src="' . $this->url . '" fallback-src="'. $file->getAbsoluteUrl().'" alt="' . $file->title . '" title="' . $file->title .'" class="thumbnail_img" onerror="var that=this;window.addEventListener(\'load\', function(event) {window.EE.cp.fallbackImage(that);})" />';
             } else {
                 switch ($file->file_type) {
                     case 'doc':

--- a/system/ee/ExpressionEngine/Service/Thumbnail/Thumbnail.php
+++ b/system/ee/ExpressionEngine/Service/Thumbnail/Thumbnail.php
@@ -65,7 +65,7 @@ class Thumbnail
             } elseif ($file->isEditableImage() || $file->isSVG()) {
                 $this->url = $file->getAbsoluteThumbnailURL() . "?v={$file->modified_date}";
                 $this->path = $file->getAbsoluteThumbnailPath();
-                $this->tag = '<img src="' . $this->url . '" fallback-src="'. $file->getAbsoluteUrl().'" alt="' . $file->title . '" title="' . $file->title .'" class="thumbnail_img" onerror="var that=this;window.addEventListener(\'load\', function(event) {window.EE.cp.fallbackImage(that);})" />';
+                $this->tag = '<img src="' . $this->url . '" fallback-src="'. $file->getAbsoluteURL().'" data-file-id="' . $file->file_id . '" alt="' . $file->title . '" title="' . $file->title .'" class="thumbnail_img" onerror="window.EE.cp.fallbackImage(this)" />';
             } else {
                 switch ($file->file_type) {
                     case 'doc':

--- a/system/ee/ExpressionEngine/Service/Thumbnail/ThumbnailFactory.php
+++ b/system/ee/ExpressionEngine/Service/Thumbnail/ThumbnailFactory.php
@@ -19,19 +19,7 @@ class ThumbnailFactory
 {
     public function get(?File\FileSystemEntity $file = null)
     {
-        $thumb = new Thumbnail($file);
-
-        // If the thumbnail is missing, and this is an image file generate
-        // the thumbnail now
-        if (! $thumb->exists()
-            && $file
-            && $file->isFile()
-            && $file->exists()
-            && $file->isImage()) {
-            $thumb = $this->make($file);
-        }
-
-        return $thumb;
+        return new Thumbnail($file);
     }
 
     public function make(File\FileSystemEntity $file)

--- a/system/ee/ExpressionEngine/Service/Thumbnail/ThumbnailFactory.php
+++ b/system/ee/ExpressionEngine/Service/Thumbnail/ThumbnailFactory.php
@@ -19,19 +19,7 @@ class ThumbnailFactory
 {
     public function get(File\FileSystemEntity $file = null)
     {
-        $thumb = new Thumbnail($file);
-
-        // If the thumbnail is missing, and this is an image file generate
-        // the thumbnail now
-        if (! $thumb->exists()
-            && $file
-            && $file->isFile()
-            && $file->exists()
-            && $file->isImage()) {
-            $thumb = $this->make($file);
-        }
-
-        return $thumb;
+        return new Thumbnail($file);
     }
 
     public function make(File\FileSystemEntity $file)

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Controllers/Files/FileTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Controllers/Files/FileTest.php
@@ -32,6 +32,6 @@ class FileTest extends TestCase
 
         sort($controller_methods);
 
-        $this->assertEquals(['download', 'getuploadlocationsanddirectoriesdropdownchoices', 'view'], $controller_methods);
+        $this->assertEquals(['createmissingthumbnail', 'download', 'exists', 'getuploadlocationsanddirectoriesdropdownchoices', 'view'], $controller_methods);
     }
 }

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Controllers/Files/FileTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Controllers/Files/FileTest.php
@@ -230,6 +230,7 @@ class FileTest extends TestCase
         ee()->setMock('CP/URL', new UrlFactoryRecorder());
         ee()->setMock('Format', new FormatRecorder());
         ee()->setMock('File', new FileServiceRecorder($this->upload));
+        ee()->setMock('output', new OutputRecorder());
         ee()->setMock('load', $this->load);
         ee()->setMock('image_lib', new ImageLibRecorder());
         ee()->setMock('form_validation', $this->formValidation);
@@ -1357,6 +1358,87 @@ class FileTest extends TestCase
     }
 
     /**
+     * Assert exists() returns JSON for chunked file ID checks.
+     *
+     * @return void
+     */
+    public function testExistsReturnsJsonForBatchAndTreatsInaccessibleFilesAsMissing()
+    {
+        $available = new TestFileModel([
+            'file_id' => 11,
+            'exists' => true,
+        ]);
+        $missing = new TestFileModel([
+            'file_id' => 12,
+            'exists' => false,
+        ]);
+        $restricted = new TestFileModel([
+            'file_id' => 13,
+            'memberHasAccess' => false,
+            'exists' => true,
+        ]);
+
+        ee()->setMock('Request', new RequestRecorder([
+            'file_ids' => ['11', '12', '13', '99', 'bad'],
+        ]));
+        $this->bindFilesToModel([$available, $missing, $restricted]);
+
+        $response = $this->controller->exists();
+
+        $expected = [
+            'files' => [
+                11 => ['exists' => true],
+                12 => ['exists' => false],
+                13 => ['exists' => false],
+                99 => ['exists' => false],
+            ],
+        ];
+
+        $this->assertSame($expected, $response);
+        $this->assertSame($expected, ee()->output->ajaxResponses[0]);
+        $this->assertSame([
+            ['File', [11, 12, 13, 99]],
+        ], ee('Model')->getCalls);
+        $this->assertSame([
+            ['UploadDestination'],
+        ], $this->lastModelQuery()->withCalls);
+        $this->assertSame([
+            ['site_id', 'IN', [1, 0]],
+        ], $this->lastModelQuery()->filterCalls);
+        $this->assertCount(1, $available->memberAccessChecks);
+        $this->assertCount(1, $missing->memberAccessChecks);
+        $this->assertCount(1, $restricted->memberAccessChecks);
+    }
+
+    /**
+     * Assert route ID checks use the same JSON response shape.
+     *
+     * @return void
+     */
+    public function testExistsReturnsJsonForRouteId()
+    {
+        $file = new TestFileModel([
+            'file_id' => 44,
+            'exists' => true,
+        ]);
+        $this->bindFilesToModel([$file]);
+
+        $response = $this->controller->exists(44);
+
+        $expected = [
+            'files' => [
+                44 => ['exists' => true],
+            ],
+        ];
+
+        $this->assertSame($expected, $response);
+        $this->assertSame($expected, ee()->output->ajaxResponses[0]);
+        $this->assertSame([
+            ['File', [44]],
+        ], ee('Model')->getCalls);
+    }
+
+    /**
      * Attach a model query stub for the provided file lookup result.
      *
      * @param TestFileModel|null $file
@@ -1365,6 +1447,18 @@ class FileTest extends TestCase
     private function bindFileToModel($file): void
     {
         $query = new ModelQueryRecorder($file);
+        ee()->setMock('Model', new ModelServiceRecorder($query));
+    }
+
+    /**
+     * Attach a model query stub for a batch file lookup result.
+     *
+     * @param array<int, TestFileModel> $files
+     * @return void
+     */
+    private function bindFilesToModel(array $files): void
+    {
+        $query = new ModelQueryRecorder($files);
         ee()->setMock('Model', new ModelServiceRecorder($query));
     }
 
@@ -1903,12 +1997,37 @@ class RequestRecorder
 }
 
 /**
+ * Captures AJAX response payloads.
+ */
+class OutputRecorder
+{
+    /** @var array<int, mixed> */
+    public $ajaxResponses = [];
+
+    /**
+     * Record and return AJAX response payloads.
+     *
+     * @param mixed $payload
+     * @return mixed
+     */
+    public function send_ajax_response($payload)
+    {
+        $this->ajaxResponses[] = $payload;
+
+        return $payload;
+    }
+}
+
+/**
  * Supplies model queries for file lookups.
  */
 class ModelServiceRecorder
 {
     /** @var ModelQueryRecorder */
     public $lastQuery;
+
+    /** @var array<int, array{0: string, 1: mixed}> */
+    public $getCalls = [];
 
     /**
      * Store the query object returned by get().
@@ -1925,11 +2044,13 @@ class ModelServiceRecorder
      * Return the configured query recorder.
      *
      * @param string $model
-     * @param int $id
+     * @param mixed $id
      * @return ModelQueryRecorder
      */
-    public function get($model, $id)
+    public function get($model, $id = null)
     {
+        $this->getCalls[] = [$model, $id];
+
         return $this->lastQuery;
     }
 }
@@ -1939,7 +2060,7 @@ class ModelServiceRecorder
  */
 class ModelQueryRecorder
 {
-    /** @var TestFileModel|null */
+    /** @var TestFileModel|array<int, TestFileModel>|null */
     private $file;
 
     /** @var array<int, array<int, string>> */
@@ -1951,7 +2072,7 @@ class ModelQueryRecorder
     /**
      * Store the first() return value.
      *
-     * @param TestFileModel|null $file
+     * @param TestFileModel|array<int, TestFileModel>|null $file
      * @return void
      */
     public function __construct($file)
@@ -2004,7 +2125,31 @@ class ModelQueryRecorder
      */
     public function first()
     {
+        if (is_array($this->file)) {
+            return reset($this->file) ?: null;
+        }
+
         return $this->file;
+    }
+
+    /**
+     * Return the configured files indexed by a field.
+     *
+     * @param string $field
+     * @return array<int, TestFileModel>
+     */
+    public function indexBy($field)
+    {
+        $files = is_array($this->file) ? $this->file : [$this->file];
+        $indexed = [];
+
+        foreach ($files as $file) {
+            if ($file) {
+                $indexed[$file->$field] = $file;
+            }
+        }
+
+        return $indexed;
     }
 }
 

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Controllers/Files/FileTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Controllers/Files/FileTest.php
@@ -249,6 +249,22 @@ class FileTest extends TestCase
         ee()->config->resetConfig();
     }
 
+    public function testRoutableMethods()
+    {
+        $controller_methods = [];
+
+        foreach (get_class_methods('ExpressionEngine\Controller\Files\File') as $method) {
+            $method = strtolower($method);
+            if (strncmp($method, '_', 1) != 0) {
+                $controller_methods[] = $method;
+            }
+        }
+
+        sort($controller_methods);
+
+        $this->assertEquals(['createmissingthumbnail', 'download', 'exists', 'getuploadlocationsanddirectoriesdropdownchoices', 'view'], $controller_methods);
+    }
+
     /**
      * Ensure image metadata is considered usable only when dimensions are readable.
      *

--- a/system/ee/ExpressionEngine/View/_shared/alert.php
+++ b/system/ee/ExpressionEngine/View/_shared/alert.php
@@ -1,4 +1,4 @@
-<div class="app-notice app-notice-<?=$alert->name?> app-notice--<?=$alert->type?> app-notice---<?=$alert->severity?>">
+<div class="app-notice app-notice-<?=$alert->name?> app-notice--<?=$alert->type?> app-notice---<?=$alert->severity?> <?=$alert->hidden ? 'hidden': ''?>">
 	<div class="app-notice__tag">
 		<span class="app-notice__icon"></span>
 	</div>

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -191,6 +191,7 @@ class Cp
             'cp.dismissBannerURL' => ee('CP/URL', 'homepage/dismiss-banner')->compile(),
             'cp.acknowledgeLicenseNoticeURL' => ee('CP/URL', 'homepage/acknowledge-license-notice')->compile(),
             'cp.collapseSecondaryNavURL' => ee('CP/URL', 'homepage/toggle-secondary-sidebar-nav')->compile(),
+            'fileManager.thumbnailCreateUrl' => ee('CP/URL')->make('files/file/createMissingThumbnail/{file_id}')->compile(),
             'fileManagerCompatibilityMode' => bool_config_item('file_manager_compatibility_mode'),
         ));
 

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -191,6 +191,7 @@ class Cp
             'cp.dismissBannerURL' => ee('CP/URL', 'homepage/dismiss-banner')->compile(),
             'cp.acknowledgeLicenseNoticeURL' => ee('CP/URL', 'homepage/acknowledge-license-notice')->compile(),
             'cp.collapseSecondaryNavURL' => ee('CP/URL', 'homepage/toggle-secondary-sidebar-nav')->compile(),
+            'fileManager.fileExistsUrl' => ee('CP/URL')->make('files/file/exists')->compile(),
             'fileManager.thumbnailCreateUrl' => ee('CP/URL')->make('files/file/createMissingThumbnail/{file_id}')->compile(),
             'fileManagerCompatibilityMode' => bool_config_item('file_manager_compatibility_mode'),
         ));

--- a/tests/cypress/cypress/integration/content/default_theme.ee6.js
+++ b/tests/cypress/cypress/integration/content/default_theme.ee6.js
@@ -23,7 +23,7 @@ context('Install with default theme', () => {
         }
       })
     })
-    
+
     // Delete existing config and create a new one
     cy.task('db:clear')
     cy.task('cache:clear')
@@ -34,7 +34,7 @@ context('Install with default theme', () => {
       //cy.screenshot({capture: 'runner'})
       //cy.screenshot({capture: 'fullPage'})
       cy.hasNoErrors()
-  
+
       install_form.get('db_hostname').clear().type(Cypress.env("DB_HOST"))
       install_form.get('db_name').clear().type(Cypress.env("DB_DATABASE"))
       install_form.get('db_username').clear().type(Cypress.env("DB_USER"))
@@ -48,7 +48,7 @@ context('Install with default theme', () => {
       install_form.get('password').clear().type('1Password')
       install_form.get('license_agreement').click()
       install_form.get('install_submit').click()
-  
+
       cy.hasNoErrors()
     })
 
@@ -70,7 +70,7 @@ context('Install with default theme', () => {
     cy.task('installer:disable')
     cy.task('installer:revert_config').then(()=>{
         cy.task('installer:replace_config', {
-            file: 'support/config/config.php', 
+            file: 'support/config/config.php',
             options: {
                 database: {
                     hostname: Cypress.env("DB_HOST"),
@@ -108,7 +108,7 @@ context('Install with default theme', () => {
       cy.wait(2000)
       cy.login({ email: 'admin', password: '1Password' });
       cy.get('.ee-wrapper').should('exist')
-      cy.get('.app-notice-missing-files').should('not.exist')
+      cy.get('.app-notice-missing-files').should('not.be.visible')
       cy.hasNoErrors()
     })
 
@@ -210,7 +210,7 @@ context('Install with default theme', () => {
         // failing this test
         return false
       })
-      
+
       cy.visit('/index.php/blog/category/news')
       cy.hasNoErrors()
       cy.logFrontendPerformance()
@@ -302,7 +302,7 @@ context('Install with default theme', () => {
       cy.log('turn on compatibility mode and make sure everything still works')
       cy.eeConfig({ item: 'file_manager_compatibility_mode', value: 'y' })
       cy.wait(1000)
-      
+
       cy.visit('/index.php/about')
       cy.hasNoErrors()
       cy.get('figure.right img').should('be.visible').and(($img) => {

--- a/tests/cypress/cypress/integration/files/file_manager.ee6.js
+++ b/tests/cypress/cypress/integration/files/file_manager.ee6.js
@@ -162,7 +162,7 @@ context('File Manager', () => {
     it('Reverse sort by title/name', () => {
         beforeEach_all_files();
         // beforeEach_perpage_50();
-        
+
         cy.intercept('/admin.php?/cp/files*').as('fileRequest')
         page.get('title_name_header').find('a.column-sort').click()
         cy.wait('@fileRequest')
@@ -178,7 +178,7 @@ context('File Manager', () => {
             cy.wait('@fileRequest')
             cy.hasNoErrors()
             page.get('title_name_header').find('a.column-sort').should('have.class', 'column-sort--desc');
-            
+
             page.get('title_name_header').should('have.class', 'column-sort-header--active')
             page.get('title_names').then(function($td) {
                 let files_reversed = _.map($td, function(el) {
@@ -307,7 +307,7 @@ context('File Manager', () => {
         //page.get('manage_actions').eq(0).find('li.edit a').click()
         cy.get('tr[file_id="1"] .toolbar-wrap .js-dropdown-toggle').click()
         cy.get('a[title="Edit"]').filter(':visible').first().click()
-        
+
         cy.hasNoErrors()
 
 
@@ -798,7 +798,7 @@ context('File Manager', () => {
 
     context('Manage files in thumb view', () => {
         before(function() {
-            
+
         })
 
         it('sorting order stays the same', function() {
@@ -818,7 +818,7 @@ context('File Manager', () => {
 
                 cy.get('.file-grid__wrapper .file-grid__file .file-metadata__wrapper').then(function($td) {
                     let files_switched = _.map($td, function(el) {
-                        return $(el).find('span').first().text();
+                        return $(el).find('span').first().contents().get(0).nodeValue;
                     })
                     expect(files_switched).to.deep.equal(sorted_files)
                 })
@@ -872,13 +872,13 @@ context('File Manager', () => {
                             expect(files_by_title_reversed).to.deep.equal(files_by_title.reverse())
                         })
                     })
-                    
+
                 })
             })
 
         })
      })
 
-       
+
 
 })

--- a/tests/cypress/cypress/integration/files/file_manager.ee6.js
+++ b/tests/cypress/cypress/integration/files/file_manager.ee6.js
@@ -160,7 +160,7 @@ context('File Manager', () => {
     it('Reverse sort by title/name', () => {
         beforeEach_all_files();
         // beforeEach_perpage_50();
-        
+
         cy.intercept('/admin.php?/cp/files*').as('fileRequest')
         page.get('title_name_header').find('a.column-sort').click()
         cy.wait('@fileRequest')
@@ -176,7 +176,7 @@ context('File Manager', () => {
             cy.wait('@fileRequest')
             cy.hasNoErrors()
             page.get('title_name_header').find('a.column-sort').should('have.class', 'column-sort--desc');
-            
+
             page.get('title_name_header').should('have.class', 'column-sort-header--active')
             page.get('title_names').then(function($td) {
                 let files_reversed = _.map($td, function(el) {
@@ -309,7 +309,7 @@ context('File Manager', () => {
         //page.get('manage_actions').eq(0).find('li.edit a').click()
         cy.get('tr[file_id="1"] .toolbar-wrap .js-dropdown-toggle').click()
         cy.get('a[title="Edit"]').filter(':visible').first().click()
-        
+
         cy.hasNoErrors()
 
 
@@ -800,7 +800,7 @@ context('File Manager', () => {
 
     context('Manage files in thumb view', () => {
         before(function() {
-            
+
         })
 
         it('sorting order stays the same', function() {
@@ -820,7 +820,7 @@ context('File Manager', () => {
 
                 cy.get('.file-grid__wrapper .file-grid__file .file-metadata__wrapper').then(function($td) {
                     let files_switched = _.map($td, function(el) {
-                        return $(el).find('span').first().text();
+                        return $(el).find('span').first().contents().get(0).nodeValue;
                     })
                     expect(files_switched).to.deep.equal(sorted_files)
                 })
@@ -874,13 +874,13 @@ context('File Manager', () => {
                             expect(files_by_title_reversed).to.deep.equal(files_by_title.reverse())
                         })
                     })
-                    
+
                 })
             })
 
         })
      })
 
-       
+
 
 })

--- a/themes/ee/asset/javascript/src/cp/files/manager.js
+++ b/themes/ee/asset/javascript/src/cp/files/manager.js
@@ -156,7 +156,7 @@
 
 		function showBigImage(button) {
 			var tooltip = button.find('#preview');
-			var element = button.find('img.thumbnail_img');
+			var element = button.find('img.thumbnail_img, i');
 			var placement = 'top-end';
 			var offset = '60px, 25px';
 			new Popper(element, tooltip, {
@@ -190,7 +190,7 @@
 				} else {
 					style = 'max-height: 200px';
 				}
-				parent.prepend("<p id='preview'><img src='" + path + "' alt='"+alt+"' style='"+style+"' /></p>");
+                parent.prepend("<p id='preview'><img src='" + path + "' alt='"+alt+"' style='"+style+"' /></p>");
 				showBigImage(parent);
 			}, mouseleave: function () {
 				$("#preview").remove();

--- a/themes/ee/asset/javascript/src/cp/files/manager.js
+++ b/themes/ee/asset/javascript/src/cp/files/manager.js
@@ -196,5 +196,29 @@
 				$("#preview").remove();
 			}
 		}, '.f_manager-wrapper .imgpreview');
+
+        let checkForMissingFiles = function() {
+            $('.f_manager-wrapper tr[file_id], .f_manager-wrapper .file-grid__file[file_id]').each(function(index, el) {
+                let fileId = $(el).attr('file_id');
+                $.ajax({
+                    url: EE.BASE + "/files/file/exists/" + fileId,
+                    type: 'HEAD',
+                    success: function() {},
+                    error: function() {
+                        $(el).addClass('missing');
+                        $(el).find('.file-not-found.hidden').removeClass('hidden');
+
+                        // Display the missing-files alert banner if it is present
+                        $('.app-notice-missing-files.hidden').removeClass('hidden');
+                    }
+                })
+            });
+        };
+
+        checkForMissingFiles();
+
+        $('body').on('ee.filemanager.changed', function(event) {
+            checkForMissingFiles();
+        });
 	});
 })(jQuery);

--- a/themes/ee/asset/javascript/src/cp/files/manager.js
+++ b/themes/ee/asset/javascript/src/cp/files/manager.js
@@ -197,28 +197,10 @@
 			}
 		}, '.f_manager-wrapper .imgpreview');
 
-        let checkForMissingFiles = function() {
-            $('.f_manager-wrapper tr[file_id], .f_manager-wrapper .file-grid__file[file_id]').each(function(index, el) {
-                let fileId = $(el).attr('file_id');
-                $.ajax({
-                    url: EE.BASE + "/files/file/exists/" + fileId,
-                    type: 'HEAD',
-                    success: function() {},
-                    error: function() {
-                        $(el).addClass('missing');
-                        $(el).find('.file-not-found.hidden').removeClass('hidden');
+        EE.cp.fileManager.checkForMissingFiles();
 
-                        // Display the missing-files alert banner if it is present
-                        $('.app-notice-missing-files.hidden').removeClass('hidden');
-                    }
-                })
-            });
-        };
-
-        checkForMissingFiles();
-
-        $('body').on('ee.filemanager.changed', function(event) {
-            checkForMissingFiles();
+        $('body').on('ee.filemanager.changed', function(event, container) {
+            EE.cp.fileManager.checkForMissingFiles(container);
         });
 	});
 })(jQuery);

--- a/themes/ee/asset/javascript/src/cp/files/picker.js
+++ b/themes/ee/asset/javascript/src/cp/files/picker.js
@@ -14,6 +14,10 @@
 "use strict";
 
 (function ($) {
+	var getModalBox = function(modal) {
+		return $(modal).find('> .modal > .col-group > .col > .box').first();
+	};
+
 	var bind_modal = function(url, options) {
 		window.globalDropzone = options.input_value;
 		var modal = $("." + options.rel),
@@ -27,6 +31,21 @@
 				};
 				options.callback(data, picker);
 				window.document.dispatchEvent(new CustomEvent('filepicker:pick', { detail: data }));
+			},
+			initializeFileManagerContent = function(container) {
+				var $container = $(container);
+
+				// function that is responsible for the correct working of
+				// the search inside filter-search-bar__item
+				$.fuzzyFilter()
+
+				if (EE.cp.fileManager && EE.cp.fileManager.checkForMissingFiles) {
+					EE.cp.fileManager.checkForMissingFiles($container);
+				}
+
+				if (typeof FileField != 'undefined' && $('div[data-file-field-react]').length) {
+					FileField.renderFields();
+				}
 			};
 
 		if (options.iframe) {
@@ -34,11 +53,9 @@
 		}
 
 		$.get(url, function(data) {
-			modal.find('div.box').html(data);
+			var $box = getModalBox(modal);
 
-			// function that is responsible for the correct working of 
-			// the search inside filter-search-bar__item 
-			$.fuzzyFilter()
+			$box.html(data);
 
 			if (typeof options.selected != 'undefined') {
 				var selected = modal.find('tbody *[data-id="' + options.selected + '"]');
@@ -51,9 +68,7 @@
 				}
 			}
 
-			if ($('div[data-file-field-react]').length) {
-				FileField.renderFields();
-			}
+			initializeFileManagerContent($box);
 		});
 
 		$('.modal-file').off('click', '.filepicker-item, tbody > tr:not(.tbl-action)');
@@ -99,8 +114,11 @@
 		$('.modal-file').on('click', '.filters a:not([href=""]), .filter-bar a:not([href=""]), .paginate a:not([href=""], .pagination a:not([href=""]), thead a:not([href=""])', function(e) {
 			e.preventDefault();
 			var new_url = $(this).attr('href');
+			var $box = getModalBox($(this).closest('.modal-file'));
 
-			$(this).parents('div.box').load(new_url);
+			$box.load(new_url, function() {
+				initializeFileManagerContent($box);
+			});
 			if ($(options.source).hasClass('markItUpButton') || $(options.source).hasClass('rte-upload')) {
 				$('.publish .toolbar.rte li.m-link[rel="modal-file"], .publish .toolbar.html-btns li.m-link[rel="modal-file"]').attr('href', new_url);
 			}
@@ -117,7 +135,11 @@
 
 			e.preventDefault();
 
-			$(this).parents('div.box').load(url+'&'+payload_elements.serialize());
+			var $box = getModalBox($(this).closest('.modal-file'));
+
+			$box.load(url+'&'+payload_elements.serialize(), function() {
+				initializeFileManagerContent($box);
+			});
 		});
 		$('.modal-file').on('click', '.tbl-action .action, .tbl-action a.button, .panel-footer a.button', function(e) {
 			e.preventDefault()
@@ -125,7 +147,7 @@
 		});
 
 		function openInIframe(url) {
-			$('div.box', modal).html("<iframe></iframe>");
+			getModalBox(modal).html("<iframe></iframe>");
 
 			var theme = $('body').data('theme');
 			var frame = $('iframe', modal);
@@ -137,7 +159,7 @@
 			var bindFrameUnload = function() {
 				$(frame[0].contentWindow).on('unload', function() {
 					frame.hide();
-					$('.box', modal).height('auto');
+					getModalBox(modal).height('auto');
 					$(modal).height('auto');
 				});
 			};
@@ -184,7 +206,7 @@
 					}
 
 					var height = this.contentWindow.document.body.scrollHeight;
-					$('.box', modal).height(height);
+					getModalBox(modal).height(height);
 					$(this).height(height + 2);
 				}
 			});
@@ -300,7 +322,7 @@
 })(jQuery);
 
 function loadSettingsModal(modal, data) {
-	$('div.box', modal).html(data);
+	modal.find('> .modal > .col-group > .col > .box').first().html(data);
 
 	// Bind validation
 	EE.cp.formValidation.init(modal);

--- a/themes/ee/asset/javascript/src/cp/global_start.js
+++ b/themes/ee/asset/javascript/src/cp/global_start.js
@@ -564,6 +564,15 @@ EE.insert_placeholders = function () {
 	});
 };
 
+EE.cp.thumbnailCreateUrl = function(fileId)
+{
+    if (EE.fileManager && EE.fileManager.thumbnailCreateUrl) {
+        return EE.fileManager.thumbnailCreateUrl.replace('{file_id}', encodeURIComponent(fileId));
+    }
+
+    return EE.BASE + "/files/file/createMissingThumbnail/" + encodeURIComponent(fileId);
+};
+
 // Replace images with fallback-src if available
 EE.cp.fallbackImage = function(element)
 {
@@ -578,16 +587,30 @@ EE.cp.fallbackImage = function(element)
             $el.parent('.imgpreview').attr('data-url', $el.attr('fallback-src'));
         };
 
+        let addCacheBuster = function(url) {
+            let separator = url.indexOf('?') === -1 ? '?' : '&';
+
+            return url + separator + 'thumbnail_retry=' + Date.now();
+        };
+
         // If this is a thumbnail try to regenerate missing thumbnail
         if($el.hasClass('thumbnail_img')) {
-            let fileId = $el.closest('tr[title="'+$el.attr('title')+'"]').attr('file_id');
+            let $fileElement = $el.closest('[file_id], [data-file-id]');
+            let fileId = $el.data('file-id') || $el.attr('data-file-id') || $fileElement.attr('file_id') || $fileElement.data('file-id');
+
+            if($el.data('thumbnail-retry-attempted') || ! fileId) {
+                replaceSrc($el);
+                return;
+            }
+
             $.ajax({
-                url: EE.BASE + "/files/file/createMissingThumbnail/" + fileId,
+                url: EE.cp.thumbnailCreateUrl(fileId),
                 success: function(data) {
-                    if(data.url !== $el.attr('src')) {
-                        $el.attr('src', data.url);
+                    if(data.url) {
+                        $el.data('thumbnail-retry-attempted', true);
+                        $el.attr('src', addCacheBuster(data.url));
                         $el.parent('.imgpreview').attr('data-url', data.url);
-                    }else{
+                    }else {
                         replaceSrc($el);
                     }
                 },

--- a/themes/ee/asset/javascript/src/cp/global_start.js
+++ b/themes/ee/asset/javascript/src/cp/global_start.js
@@ -573,6 +573,104 @@ EE.cp.thumbnailCreateUrl = function(fileId)
     return EE.BASE + "/files/file/createMissingThumbnail/" + encodeURIComponent(fileId);
 };
 
+EE.cp.fileManager = EE.cp.fileManager || {};
+
+EE.cp.fileManager.fileExistsUrl = function()
+{
+    if (EE.fileManager && EE.fileManager.fileExistsUrl) {
+        return EE.fileManager.fileExistsUrl;
+    }
+
+    return EE.BASE + "/files/file/exists";
+};
+
+EE.cp.fileManager.checkForMissingFiles = function(container)
+{
+    let $container = container ? $(container) : $(document);
+    let selector = '.f_manager-wrapper tr[file_id], .f_manager-wrapper .file-grid__file[file_id]';
+    let $files = $container.is(selector) ? $container : $container.find(selector);
+    let filesById = {};
+    let fileIds = [];
+    let chunkSize = 5;
+
+    $files.each(function(index, el) {
+        let $el = $(el);
+        let fileId = $el.attr('file_id');
+
+        if (! fileId || $el.data('file-exists-check-pending') || $el.data('file-exists-check-complete')) {
+            return;
+        }
+
+        $el.data('file-exists-check-pending', true);
+
+        if (! filesById[fileId]) {
+            filesById[fileId] = [];
+            fileIds.push(fileId);
+        }
+
+        filesById[fileId].push($el);
+    });
+
+    let markFileMissing = function($el) {
+        $el.addClass('missing');
+        $el.find('.file-not-found.hidden').removeClass('hidden');
+
+        // Display the missing-files alert banner if it is present
+        let $wrapper = $el.closest('.f_manager-wrapper');
+        let $alert = $wrapper.length ? $wrapper.find('.app-notice-missing-files.hidden') : $('.app-notice-missing-files.hidden');
+        $alert.removeClass('hidden');
+    };
+
+    let markFileCheckComplete = function(fileId) {
+        $.each(filesById[fileId], function(index, $el) {
+            $el.data('file-exists-check-pending', false);
+            $el.data('file-exists-check-complete', true);
+        });
+    };
+
+    for (let i = 0; i < fileIds.length; i += chunkSize) {
+        let chunk = fileIds.slice(i, i + chunkSize);
+        let requestSucceeded = false;
+
+        $.ajax({
+            url: EE.cp.fileManager.fileExistsUrl(),
+            type: 'POST',
+            dataType: 'json',
+            data: {
+                file_ids: chunk
+            },
+            success: function(response) {
+                requestSucceeded = true;
+                let files = response && response.files ? response.files : {};
+
+                $.each(chunk, function(index, fileId) {
+                    let exists = files[fileId] && files[fileId].exists === true;
+
+                    if (! exists) {
+                        $.each(filesById[fileId], function(index, $el) {
+                            markFileMissing($el);
+                        });
+                    }
+                });
+            },
+            error: function() {
+                $.each(chunk, function(index, fileId) {
+                    $.each(filesById[fileId], function(index, $el) {
+                        $el.data('file-exists-check-pending', false);
+                    });
+                });
+            },
+            complete: function() {
+                if (requestSucceeded) {
+                    $.each(chunk, function(index, fileId) {
+                        markFileCheckComplete(fileId);
+                    });
+                }
+            }
+        });
+    }
+};
+
 // Replace images with fallback-src if available
 EE.cp.fallbackImage = function(element)
 {

--- a/themes/ee/asset/javascript/src/cp/global_start.js
+++ b/themes/ee/asset/javascript/src/cp/global_start.js
@@ -473,7 +473,7 @@ EE.cp.refreshSessionData = function(event, base) {
 
 	if (session_data) {
 		session_data = session_data[0];
-		var base_url = /^([^&]+)/.exec(EE.BASE); 
+		var base_url = /^([^&]+)/.exec(EE.BASE);
 		json_str = base_url[0] + '/login/refresh_csrf_token' + session_data;
 	}
 
@@ -563,6 +563,57 @@ EE.insert_placeholders = function () {
 		.trigger('blur');
 	});
 };
+
+// Replace images with fallback-src if available
+EE.cp.fallbackImage = function(element)
+{
+    let $el = $(element);
+
+    // If the element has a fallback-src and it is not the same as the current src we will swap
+    if($el.attr('fallback-src') && $el.attr('fallback-src') !== $el.attr('src')) {
+
+        let replaceSrc = function($el) {
+            $el.addClass('img-fallback');
+            $el.attr('src', $el.attr('fallback-src'));
+            $el.parent('.imgpreview').attr('data-url', $el.attr('fallback-src'));
+        };
+
+        // If this is a thumbnail try to regenerate missing thumbnail
+        if($el.hasClass('thumbnail_img')) {
+            let fileId = $el.closest('tr[title="'+$el.attr('title')+'"]').attr('file_id');
+            $.ajax({
+                url: EE.BASE + "/files/createMissingThumbnail/" + fileId,
+                success: function(data) {
+                    if(data.url !== $el.attr('src')) {
+                        $el.attr('src', data.url);
+                        $el.parent('.imgpreview').attr('data-url', data.url);
+                    }else{
+                        replaceSrc($el);
+                    }
+                },
+                error: function() {
+                    replaceSrc($el);
+                },
+                dataType: 'json'
+            });
+        }else{
+            replaceSrc($el);
+        }
+    }else{
+        $el.parent('.imgpreview').attr('data-url', EE.PATH_CP_GBL_IMG + 'missing.jpg');
+
+        // Update parent tr display
+        let $tr = $el.closest('tr[title="'+$el.attr('title')+'"]');
+        if($tr.length == 1) {
+            $tr.addClass('missing');
+            $tr.find('.file-not-found.hidden').removeClass('hidden');
+        }
+
+        // Display the missing-files alert banner if it is present
+        $('.app-notice-missing-files.hidden').removeClass('hidden');
+        $el.replaceWith('<i class="fal fa-exclamation-triangle fa-3x"></i>');
+    }
+}
 
 /**
  * Handle idle / inaction between windows
@@ -720,7 +771,7 @@ EE.cp.broadcastEvents = (function() {
 
 				if (session_data) {
 					session_data = session_data[0];
-					var base_url = /^([^&]+)/.exec(EE.BASE); 
+					var base_url = /^([^&]+)/.exec(EE.BASE);
 					json_str = base_url[0] + '/login/lock_cp' + session_data;
 				}
 

--- a/themes/ee/asset/javascript/src/cp/global_start.js
+++ b/themes/ee/asset/javascript/src/cp/global_start.js
@@ -582,7 +582,7 @@ EE.cp.fallbackImage = function(element)
         if($el.hasClass('thumbnail_img')) {
             let fileId = $el.closest('tr[title="'+$el.attr('title')+'"]').attr('file_id');
             $.ajax({
-                url: EE.BASE + "/files/createMissingThumbnail/" + fileId,
+                url: EE.BASE + "/files/file/createMissingThumbnail/" + fileId,
                 success: function(data) {
                     if(data.url !== $el.attr('src')) {
                         $el.attr('src', data.url);
@@ -601,16 +601,6 @@ EE.cp.fallbackImage = function(element)
         }
     }else{
         $el.parent('.imgpreview').attr('data-url', EE.PATH_CP_GBL_IMG + 'missing.jpg');
-
-        // Update parent tr display
-        let $tr = $el.closest('tr[title="'+$el.attr('title')+'"]');
-        if($tr.length == 1) {
-            $tr.addClass('missing');
-            $tr.find('.file-not-found.hidden').removeClass('hidden');
-        }
-
-        // Display the missing-files alert banner if it is present
-        $('.app-notice-missing-files.hidden').removeClass('hidden');
         $el.replaceWith('<i class="fal fa-exclamation-triangle fa-3x"></i>');
     }
 }

--- a/themes/ee/asset/javascript/src/cp/publish/entry-list.js
+++ b/themes/ee/asset/javascript/src/cp/publish/entry-list.js
@@ -44,7 +44,7 @@ $(document).ready(function () {
 		}
 	}
 
-	function searchEntries(type = 'GET', url = null) 
+	function searchEntries(type = 'GET', url = null)
 	{
 		if (searching) {
 			searching.abort();
@@ -55,7 +55,7 @@ $(document).ready(function () {
 		if (url === null) {
 			url = typeof(_form.data('search-url'))!='undefined' ? _form.data('search-url') : _form.attr('action');
 		}
-		
+
 		var data = {};
 		if (type != 'GET') {
 			data = $('input[name!="columns[]"]', _form).serialize();
@@ -74,6 +74,7 @@ $(document).ready(function () {
 				sortableColumns();
 				ddFileToNotEmptyTable();
 				if ( ($('.f_manager-wrapper tbody').length || $('.f_manager-wrapper .file-grid__wrapper').length) && (!$('.f_manager-wrapper tbody, .f_manager-wrapper .file-grid__wrapper').parents('.modal').length)) {
+                    $('.f_manager-wrapper').trigger('ee.filemanager.changed');
 
 					makeDirectoryDroppable();
 
@@ -149,7 +150,7 @@ $(document).ready(function () {
 		if ($('input[name="filter_by_keyword"]').val()!='') {
 			searchEntries('POST');
 		}
-	
+
 	});
 
 	// Selecting a channel filter

--- a/themes/ee/asset/javascript/src/fields/file/control_panel.js
+++ b/themes/ee/asset/javascript/src/fields/file/control_panel.js
@@ -42,7 +42,11 @@
 
 			if (data.isImage) {
 				// Set the thumbnail
-				references.input_img.attr('src', data.thumb_path);
+				references.input_img
+					.attr('fallback-src', data.thumb_fallback_path || data.path)
+					.attr('data-file-id', data.file_id)
+					.attr('onerror', 'window.EE.cp.fallbackImage(this)')
+					.attr('src', data.thumb_path);
 				if (figure.find('i').length) {
 					figure.find('i').remove();
 				}


### PR DESCRIPTION
This is an alternative approach to [PR #3630](https://github.com/ExpressionEngine/ExpressionEngine/pull/3630) 

Instead of trying to improve the back-end performance by bundling multiple API requests for file existence checks this PR focuses on front-end changes.  This moves the checks for file and thumbnail existence to the client side and also handles image fallbacks through javascript.

Changed thumbnail handling so accessing/rendering file thumbnail URLs no longer creates missing thumbnails synchronously; missing thumbnails are now generated on demand by Control Panel client-side recovery flows. Third-party code that relies on ee('Thumbnail')->get($file) or thumbnail URL access to create thumbnails should call the thumbnail creation service explicitly.