### PR TITLE
Added new partial format to allow better template organization

### DIFF
--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -427,7 +427,7 @@ class EE_Template
                     $partial = $this->fetch_template($template_group, $template_name, false, $site_id, true);
 
                     if (!$partial) {
-                        $partial = '';
+                        continue;
                     }
 
                     $this->template = str_replace($matches[0][$key], $partial, $this->template);

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -2480,7 +2480,7 @@ class EE_Template
      */
     public function fetch_template($template_group, $template, $show_default = true, $site_id = '', $is_partial = false)
     {
-        if ($site_id == '' or !is_numeric($site_id)) {
+        if ($site_id == '' || !is_numeric($site_id)) {
             $site_id = ee()->config->item('site_id');
         }
 
@@ -2513,9 +2513,9 @@ class EE_Template
 
             if (
                 $this->depth == 0
-                and substr($template, 0, 1) == $hidden_indicator
-                and ee()->uri->page_query_string == ''
-                and !$is_partial
+                && substr($template, 0, 1) == $hidden_indicator
+                && ee()->uri->page_query_string == ''
+                && !$is_partial
             ) { // Allow hidden templates to be used for Pages requests
                 /* -------------------------------------------
                 /*  Hidden Configuration Variable
@@ -2528,7 +2528,7 @@ class EE_Template
                 if (ee()->config->item('hidden_template_404') !== 'n') {
                     $x = explode("/", ee()->config->item('site_404'));
 
-                    if (isset($x[0]) and isset($x[1])) {
+                    if (isset($x[0]) && isset($x[1])) {
                         ee()->output->out_type = '404';
                         $this->template_type = '404';
 

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -409,19 +409,11 @@ class EE_Template
                 }
             }
 
-            // also parse the new {partial="group/template"} format
+            // Handle any partials using the new format {partial="group/template"}
             if (strpos($this->template, LD . 'partial') !== false && preg_match_all("/(" . LD . "partial\s*=)(.*?)" . RD . "/s", $this->template, $matches)) {
                 // $matches[2] is "group/template"
                 foreach ($matches[2] as $key => $val) {
                     $parts = preg_split("/\s+/", $val, 2);
-
-                    // $this->embed_vars = (isset($parts[1])) ? ee('Variables/Parser')->parseTagParameters($parts[1]) : array();
-
-                    // if ($this->embed_vars === false) {
-                    //     $this->embed_vars = array();
-                    // }
-
-                    // $this->cache_prefix = (isset($this->embed_vars['cache_prefix'])) ? $this->embed_vars['cache_prefix'] : '';
 
                     // get the "group/template" part of the tag plus site ID
                     $fetch_data = $this->_get_fetch_data($parts[0]);
@@ -432,7 +424,7 @@ class EE_Template
 
                     list($template_group, $template_name, $site_id) = $fetch_data;
 
-                    $partial = $this->fetch_template($template_group, $template_name, false, 1, true);
+                    $partial = $this->fetch_template($template_group, $template_name, false, $site_id, true);
 
                     if (!$partial) {
                         $partial = '';
@@ -2490,6 +2482,7 @@ class EE_Template
             $template,
             ($show_default ? 'true' : 'false'),
             $site_id,
+            $is_partial,
         ]);
 
         $query = isset(ee()->session) ? ee()->session->cache(__CLASS__, $cacheKey) : false;


### PR DESCRIPTION
Implemented https://github.com/ExpressionEngine/ExpressionEngine/discussions/3109 to allow partial template files to exist in other template group directories (like how embeds are able to be organized) and added the parsing logic for the new tag format like `{partial="group/template"}`.

User Guide PR coming soon.

---

Parent template:
<img width="672" alt="image" src="https://github.com/user-attachments/assets/75a83ef4-7a0d-4321-bbbc-580086b5227a" />

Old partial format (in `_partials`):
<img width="691" alt="image" src="https://github.com/user-attachments/assets/d1f9474f-7517-47b9-bdd7-b23537e1decb" />

New partial format (in `home.group/`):
<img width="389" alt="image" src="https://github.com/user-attachments/assets/b3406a06-cf46-424b-8f90-32b2317f9986" />

Another new partial:
<img width="419" alt="image" src="https://github.com/user-attachments/assets/63d1d725-b4fe-4939-8e4e-73cba573fa53" />

Final output:
<img width="526" alt="image" src="https://github.com/user-attachments/assets/04e7c1fa-71e4-4293-9998-3b6ea125505b" />

These new partials were added to the parent template twice to verify that internal template caching still worked as expected.
<img width="662" alt="image" src="https://github.com/user-attachments/assets/23fb86a2-ee24-4a60-8954-1f13c6af8cca" />
