### PR TITLE
Resolved issue where dates were missing leading zeros when using `dd.mm.yyyy` format

### DIFF
--- a/system/ee/legacy/core/Config.php
+++ b/system/ee/legacy/core/Config.php
@@ -1426,7 +1426,7 @@ class EE_Config
                     '%n/%j/%Y' => 'mm/dd/yyyy',
                     '%j/%n/%Y' => 'dd/mm/yyyy',
                     '%j-%n-%Y' => 'dd-mm-yyyy',
-                    '%j.%n.%Y' => 'dd.mm.yyyy',
+                    '%d.%m.%Y' => 'dd.mm.yyyy',
                     '%Y-%m-%d' => 'yyyy-mm-dd'
                 )),
                 'time_format' => array('r', array('24' => '24_hour', '12' => '12_hour')),


### PR DESCRIPTION
Resolved issue where dates were missing leading zeros when using `dd.mm.yyyy` format