### PR TITLE
Adds Backup Manager to Core

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Utilities/DbBackup.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/DbBackup.php
@@ -188,6 +188,7 @@ class DbBackup extends Utilities
         ]);
 
         ee()->view->cp_breadcrumbs = array(
+            ee('CP/URL')->make('utilities/db-backup')->compile() => lang('backups'),
             '' => lang('backup_database')
         );
 

--- a/system/ee/ExpressionEngine/Controller/Utilities/DbBackup.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/DbBackup.php
@@ -100,36 +100,38 @@ class DbBackup extends Utilities
         }
 
         $form = new Form;
-        $field_group = $form->getGroup('bm.form.header.remove_backup');
-        $field_set = $field_group->getFieldSet('bm.form.confirm_remove_backup');
-        $field_set->setDesc('bm.form.desc.confirm_delete');
+        $field_group = $form->getGroup('verify_remove_backup');
+        $field_set = $field_group->getFieldSet('confirm_remove_backup');
+        $field_set->setDesc('confirm_delete_desc');
         $field_set->getField('confirm', 'yes_no');
 
         $form = $form->toArray();
 
         if (!empty($_POST) && ee()->input->post('confirm') == 'y') {
-            ee('backup_manager:BackupsService')->deleteBackup($path);
+            ee('Database/Backup', PATH_CACHE)->deleteBackup($path);
             ee('CP/Alert')->makeInline('shared-form')
                 ->asSuccess()
-                ->withTitle(lang('bm.backup_deleted'))
+                ->withTitle(lang('backup_deleted'))
                 ->defer();
 
-            ee()->functions->redirect($this->url('index'));
+            ee()->functions->redirect(ee('CP/URL')->make($this->base_url));
         }
 
         $vars = [
-            'cp_page_title' => lang('bm.header.remove_backup'),
-            'base_url' => $this->url('remove/', true, ['id' => $id]),
-            'save_btn_text' => lang('bm.remove'),
-            'save_btn_text_working' => lang('bm.removing'),
+            'cp_page_title' => lang('remove_backup'),
+            'base_url' => ee('CP/URL')->make('utilities/db-backup/remove', ['id' => $id])->compile(),
+            'save_btn_text' => lang('remove'),
+            'save_btn_text_working' => lang('removing'),
         ];
 
-        $vars += $form->generate();
+        $vars += $form;
 
-        $this->addBreadcrumb($this->url('edit'), 'bm.header.remove_backup');
-        $this->setBody('Remove', $vars);
-        $this->setHeading('bm.header.remove_backup');
-        return $this;
+        ee()->view->cp_breadcrumbs = array(
+            ee('CP/URL')->make('utilities/db-backup')->compile() => lang('backups'),
+            '' => lang('remove_backup')
+        );
+
+        ee()->cp->render('settings/form', $vars);
     }
 
     public function backup()

--- a/system/ee/ExpressionEngine/Controller/Utilities/DbBackup.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/DbBackup.php
@@ -20,6 +20,15 @@ class DbBackup extends Utilities
 {
     protected $base_url = 'utilities/db-backup';
 
+    public function __construct()
+    {
+        parent::__construct();
+        if (! ee('Permission')->can('access_sql_manager')) {
+            show_error(lang('unauthorized_access'), 403);
+        }
+
+    }
+
     public function index()
     {
         $sort_col = ee('Request')->get('sort_col') ?: 'bm.id';

--- a/system/ee/ExpressionEngine/Controller/Utilities/DbBackup.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/DbBackup.php
@@ -91,6 +91,14 @@ class DbBackup extends Utilities
     public function download()
     {
         $path = ee('Database/Backup', PATH_CACHE)->getBackup(ee()->input->get('id'));
+        if($path) {
+            ee('CP/Alert')->makeInline('shared-form')
+                ->asSuccess()
+                ->withTitle(lang('backup_not_found'))
+                ->defer();
+
+            ee()->functions->redirect(ee('CP/URL')->make($this->base_url));
+        }
 
         header('Content-Type: application/octet-stream');
         header("Content-Transfer-Encoding: Binary");

--- a/system/ee/ExpressionEngine/Controller/Utilities/DbBackup.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/DbBackup.php
@@ -42,7 +42,7 @@ class DbBackup extends Utilities
             'class' => 'backup_manager'
         ]);
 
-        $vars['cp_page_title'] = lang('bm.title');
+        $vars['cp_page_title'] = lang('backups');
         $table->setColumns([
             'file_name' => ['sort' => false],
             'date' => ['sort' => false],
@@ -124,14 +124,21 @@ class DbBackup extends Utilities
 
         $form = $form->toArray();
 
-        if (!empty($_POST) && ee()->input->post('confirm') == 'y') {
-            ee('Database/Backup', PATH_CACHE)->deleteBackup($path);
-            ee('CP/Alert')->makeInline('shared-form')
-                ->asSuccess()
-                ->withTitle(lang('backup_deleted'))
-                ->defer();
+        if (!empty($_POST)) {
+            if(ee()->input->post('confirm') == 'y') {
+                ee('Database/Backup', PATH_CACHE)->deleteBackup($path);
+                ee('CP/Alert')->makeInline('shared-form')
+                    ->asSuccess()
+                    ->withTitle(lang('backup_deleted'))
+                    ->defer();
+                ee()->functions->redirect(ee('CP/URL')->make($this->base_url));
+            } else {
+                ee('CP/Alert')->makeInline('shared-form')
+                    ->asWarning()
+                    ->withTitle(lang('must_confirm_removal'))
+                    ->now();
+            }
 
-            ee()->functions->redirect(ee('CP/URL')->make($this->base_url));
         }
 
         $vars = [

--- a/system/ee/ExpressionEngine/Controller/Utilities/Utilities.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/Utilities.php
@@ -107,8 +107,18 @@ class Utilities extends CP_Controller
 
         if (ee('Permission')->can('access_sql_manager')) {
             $db_list = $sidebar->addHeader(lang('database'))->addBasicList();
-            $db_list->addItem(lang('backups'), ee('CP/URL')->make('utilities/db-backup'));
+            $item = $db_list->addItem(lang('backups'), ee('CP/URL')->make('utilities/db-backup'));
+            foreach (['backup', 'remove'] as $key => $value) {
+                $url = ee('CP/URL')->make('utilities/db-backup/' . $value);
+                if ($url->matchesTheRequestedURI()) {
+                    $item->isActive();
+                }
+            }
+
             $db_list->addItem(lang('sql_manager_abbr'), ee('CP/URL')->make('utilities/sql'));
+
+
+
             $url = ee('CP/URL')->make('utilities/query');
             $item = $db_list->addItem(lang('query_form'), $url);
             if ($url->matchesTheRequestedURI()) {

--- a/system/ee/ExpressionEngine/Controller/Utilities/Utilities.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/Utilities.php
@@ -107,7 +107,7 @@ class Utilities extends CP_Controller
 
         if (ee('Permission')->can('access_sql_manager')) {
             $db_list = $sidebar->addHeader(lang('database'))->addBasicList();
-            $db_list->addItem(lang('backup_database'), ee('CP/URL')->make('utilities/db-backup'));
+            $db_list->addItem(lang('backups'), ee('CP/URL')->make('utilities/db-backup'));
             $db_list->addItem(lang('sql_manager_abbr'), ee('CP/URL')->make('utilities/sql'));
             $url = ee('CP/URL')->make('utilities/query');
             $item = $db_list->addItem(lang('query_form'), $url);

--- a/system/ee/ExpressionEngine/Controller/Utilities/Utilities.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/Utilities.php
@@ -117,8 +117,6 @@ class Utilities extends CP_Controller
 
             $db_list->addItem(lang('sql_manager_abbr'), ee('CP/URL')->make('utilities/sql'));
 
-
-
             $url = ee('CP/URL')->make('utilities/query');
             $item = $db_list->addItem(lang('query_form'), $url);
             if ($url->matchesTheRequestedURI()) {

--- a/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
+++ b/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
@@ -466,6 +466,7 @@ EOT;
     public function getBackups(): array
     {
         $return = [];
+        $format = ee()->session->userdata('date_format', ee()->config->item('date_format'));
         $db_name = ee()->db->database;
         if(is_dir(PATH_CACHE)) {
             $files = scandir(PATH_CACHE, SCANDIR_SORT_DESCENDING,);
@@ -476,8 +477,8 @@ EOT;
                     $return[$file] = [
                         'filename' => $file,
                         'full_path' => $path,
-                        'size' => $details['size'],
-                        'date' => $details['mtime'],
+                        'size' => ee('Format')->make('Number', $details['size'])->bytes(),
+                        'date' => ee()->localize->format_date($format . ' - %g:%i:%s %A', $details['mtime']),
                         'hash' => ee('Encrypt')->encode($file)
                     ];
                 }

--- a/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
+++ b/system/ee/ExpressionEngine/Service/Database/Backup/Backup.php
@@ -432,6 +432,60 @@ class Backup
 EOT;
         $this->writeChunk($separator);
     }
+
+    /**
+     * @param string $path
+     * @return bool
+     */
+    public function deleteBackup(string $path): bool
+    {
+        return @unlink($path);
+    }
+
+    /**
+     * @param string $hash
+     * @return string|null
+     */
+    public function getBackup(string $hash): ?string
+    {
+        $path = ee('Encrypt')->decode($hash);
+        $return = null;
+        if($path) {
+            $full = realpath(rtrim(PATH_CACHE, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $path);
+            if(file_exists($full)) {
+                $return = $full;
+            }
+        }
+
+        return $return;
+    }
+
+    /**
+     * @return array
+     */
+    public function getBackups(): array
+    {
+        $return = [];
+        $db_name = ee()->db->database;
+        if(is_dir(PATH_CACHE)) {
+            $files = scandir(PATH_CACHE, SCANDIR_SORT_DESCENDING,);
+            foreach($files as $file) {
+                if(str_starts_with($file, $db_name) && str_ends_with($file, '.sql')) {
+                    $path = realpath(PATH_CACHE . '/' . $file);
+                    $details = stat($path);
+                    $return[$file] = [
+                        'filename' => $file,
+                        'full_path' => $path,
+                        'size' => $details['size'],
+                        'date' => $details['mtime'],
+                        'hash' => ee('Encrypt')->encode($file)
+                    ];
+                }
+            }
+        }
+
+        return $return;
+    }
 }
 
 // EOF

--- a/system/ee/ExpressionEngine/View/backups/index.php
+++ b/system/ee/ExpressionEngine/View/backups/index.php
@@ -1,0 +1,18 @@
+<?php $this->extend('_templates/default-nav', [], 'outer_box'); ?>
+<div class="box add-mrg-bottom">
+    <?php echo ee('CP/Alert')->getAllInlines(); ?>
+</div>
+<div class="box table-list-wrap">
+    <fieldset class="tbl-search right">
+        <a class="btn tn action" target="_blank" href="<?php echo ee('CP/URL')->make('utilities/db-backup'); ?>"><?php echo lang('bm.create.new_backup'); ?></a>
+    </fieldset>
+    <?php echo form_open($base_url, 'class="tbl-ctrls"'); ?>
+    <h1><?php echo lang('bm.backup_manager_header'); ?></h1>
+    <div class="app-notice-wrap">
+        <?php echo ee('CP/Alert')->get('items-table'); ?>
+    </div>
+
+    <?php $this->embed('ee:_shared/table', $table); ?>
+    <?php echo $pagination; ?>
+    <?php echo form_close(); ?>
+</div>

--- a/system/ee/ExpressionEngine/View/utilities/backups/index.php
+++ b/system/ee/ExpressionEngine/View/utilities/backups/index.php
@@ -1,18 +1,18 @@
 <?php $this->extend('_templates/default-nav', [], 'outer_box'); ?>
+
 <div class="box add-mrg-bottom">
     <?php echo ee('CP/Alert')->getAllInlines(); ?>
 </div>
 <div class="box table-list-wrap">
     <fieldset class="tbl-search right">
-        <a class="btn tn action" target="_blank" href="<?php echo ee('CP/URL')->make('utilities/db-backup'); ?>"><?php echo lang('bm.create.new_backup'); ?></a>
+        <a class="btn tn action" target="_blank" href="<?php echo ee('CP/URL')->make('utilities/db-backup'); ?>"><?php echo lang('backup_database'); ?></a>
     </fieldset>
     <?php echo form_open($base_url, 'class="tbl-ctrls"'); ?>
-    <h1><?php echo lang('bm.backup_manager_header'); ?></h1>
+    <h1><?php echo lang('backups'); ?></h1>
     <div class="app-notice-wrap">
         <?php echo ee('CP/Alert')->get('items-table'); ?>
     </div>
 
     <?php $this->embed('ee:_shared/table', $table); ?>
-    <?php echo $pagination; ?>
     <?php echo form_close(); ?>
 </div>

--- a/system/ee/ExpressionEngine/View/utilities/backups/index.php
+++ b/system/ee/ExpressionEngine/View/utilities/backups/index.php
@@ -1,18 +1,26 @@
 <?php $this->extend('_templates/default-nav', [], 'outer_box'); ?>
-
 <div class="box add-mrg-bottom">
     <?php echo ee('CP/Alert')->getAllInlines(); ?>
 </div>
+
+<div class="panel">
+    <div class="panel-heading">
+        <div class="title-bar">
+            <h3 class="title-bar__title"><?=lang('backups')?></h3>
+
+            <div class="title-bar__extra-tools">
+                <a class="button button--primary" href="<?php echo ee('CP/URL')->make('utilities/db-backup/backup'); ?>"><?php echo lang('backup_database'); ?></a>
+            </div>
+        </div>
+    </div>
+
 <div class="box table-list-wrap">
-    <fieldset class="tbl-search right">
-        <a class="btn tn action" target="_blank" href="<?php echo ee('CP/URL')->make('utilities/db-backup'); ?>"><?php echo lang('backup_database'); ?></a>
-    </fieldset>
     <?php echo form_open($base_url, 'class="tbl-ctrls"'); ?>
-    <h1><?php echo lang('backups'); ?></h1>
     <div class="app-notice-wrap">
         <?php echo ee('CP/Alert')->get('items-table'); ?>
     </div>
 
     <?php $this->embed('ee:_shared/table', $table); ?>
     <?php echo form_close(); ?>
+</div>
 </div>

--- a/system/ee/language/english/utilities_lang.php
+++ b/system/ee/language/english/utilities_lang.php
@@ -10,6 +10,16 @@ $lang = array(
 
     'backups' => 'Backups',
 
+    'remove_backup' => 'Remove Backup',
+
+    'verify_remove_backup' => 'Verify Remove Backup',
+
+    'confirm_remove_backup' => 'Confirm Removal',
+
+    'confirm_delete_desc' => 'Are you sure you want to remove this backup?',
+
+    'backup_deleted' => 'Backup Deleted',
+
     'cache_manager' => 'Cache Manager',
 
     'communicate' => 'Communicate',

--- a/system/ee/language/english/utilities_lang.php
+++ b/system/ee/language/english/utilities_lang.php
@@ -8,6 +8,8 @@ $lang = array(
 
     'backup_database' => 'Back Up Database',
 
+    'backups' => 'Backups',
+
     'cache_manager' => 'Cache Manager',
 
     'communicate' => 'Communicate',
@@ -505,7 +507,7 @@ $lang = array(
     'update_file_usage_explained_desc' => 'Run this utility to convert all files stored in the database from sites previous to ExpressionEngine 7 to the new ExpressionEngine 7 file format. This must be completed before newer File Manager features may be used. <a href="%s">Read more on Compatibility Mode in the docs</a> <br /><br />
 
     It is recommended that you make sure all installed add-ons are compatible with ExpressionEngine 7 and newer, and that you have made a <a href="%s">backup of your database</a> first.<br /><br />
-    
+
     After the update operation is completed, visit <a href="%s">Content & Design Settings</a> to disable Compatibility Mode for File Manager.<br /><br />',
 
     'update_file_usage_desc' => 'Will update content in %d database tables',

--- a/system/ee/language/english/utilities_lang.php
+++ b/system/ee/language/english/utilities_lang.php
@@ -16,6 +16,8 @@ $lang = array(
 
     'backup_not_found' => 'Backup not found',
 
+    'must_confirm_removal' => 'You must confirm removal to proceed',
+
     'confirm_delete_desc' => 'Are you sure you want to remove this backup?',
 
     'backup_deleted' => 'Backup Deleted',

--- a/system/ee/language/english/utilities_lang.php
+++ b/system/ee/language/english/utilities_lang.php
@@ -6,8 +6,6 @@ $lang = array(
 
     /* Menu */
 
-    'backup_database' => 'Back Up Database',
-
     'backups' => 'Backups',
 
     'remove_backup' => 'Remove Backup',
@@ -15,6 +13,8 @@ $lang = array(
     'verify_remove_backup' => 'Verify Remove Backup',
 
     'confirm_remove_backup' => 'Confirm Removal',
+
+    'backup_not_found' => 'Backup not found',
 
     'confirm_delete_desc' => 'Are you sure you want to remove this backup?',
 

--- a/system/ee/legacy/helpers/string_helper.php
+++ b/system/ee/legacy/helpers/string_helper.php
@@ -316,4 +316,21 @@ function surrounding_character($string)
     return ($first_char == substr($string, -1, 1)) ? $first_char : false;
 }
 
+if (!function_exists('str_starts_with'))
+{
+    function str_starts_with($haystack, $needle)
+    {
+        return strncmp($haystack, $needle, strlen($needle)) === 0;
+    }
+}
+
+if (!function_exists('str_ends_with'))
+{
+    function str_ends_with($haystack, $needle)
+    {
+        $length = strlen($needle);
+        return $length === 0 || (substr($haystack, -$length) === $needle);
+    }
+}
+
 // EOF

--- a/tests/cypress/cypress/integration/member_roles/member_roles_utilities.ee6.js
+++ b/tests/cypress/cypress/integration/member_roles/member_roles_utilities.ee6.js
@@ -56,7 +56,7 @@ context('Member Roles / Utilities Permissions', () => {
        cy.get('.box').contains('File Converter')
        cy.get('.box').contains('Member Import')
 
-       cy.get('.box').contains('Back Up Database')
+       cy.get('.box').contains('Backups')
        cy.get('.box').contains('SQL Manager')
        cy.get('.box').contains('Query Form')
 
@@ -99,7 +99,7 @@ context('Member Roles / Utilities Permissions', () => {
         cy.get('.box').contains('File Converter')
         cy.get('.box').contains('Member Import')
 
-        cy.get('.box').contains('Back Up Database')
+        cy.get('.box').contains('Backups')
         cy.get('.box').contains('SQL Manager')
         cy.get('.box').contains('Query Form')
 
@@ -142,7 +142,7 @@ context('Member Roles / Utilities Permissions', () => {
         cy.get('.box').contains('File Converter')
         cy.get('.box').contains('Member Import')
 
-        cy.get('.box').contains('Back Up Database')
+        cy.get('.box').contains('Backups')
         cy.get('.box').contains('SQL Manager')
         cy.get('.box').contains('Query Form')
 
@@ -186,7 +186,7 @@ context('Member Roles / Utilities Permissions', () => {
 
         cy.get('.box').contains('PHP Info')
 
-        cy.get('.box').contains('Back Up Database')
+        cy.get('.box').contains('Backups')
         cy.get('.box').contains('SQL Manager')
         cy.get('.box').contains('Query Form')
 
@@ -243,7 +243,7 @@ context('Member Roles / Utilities Permissions', () => {
         cy.get('.box').should('not.contain','CP Translations')
         cy.get('.box').should('not.contain','File Converter')
         cy.get('.box').should('not.contain','Member Import')
-        cy.get('.box').should('not.contain','Back Up Database')
+        cy.get('.box').should('not.contain','Backups')
         cy.get('.box').should('not.contain','SQL Manager')
         cy.get('.box').should('not.contain','Query Form')
 


### PR DESCRIPTION
Contains a native implementation of the Backup Manager Add-on. 

Resolves #4676 
Adds ability to manage database backups  within ExpressionEngine

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
