### PR TITLE
Allow exclusion of IP addresses from Throttling; #4677

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Settings/Throttling.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Throttling.php
@@ -96,13 +96,6 @@ class Throttling extends Settings
             ),
             'throttling_allow_settings' => array(
                 array(
-                    'title' => 'throttle_ignore_logged_in',
-                    'desc' => 'throttle_ignore_logged_in_desc',
-                    'fields' => array(
-                        'throttle_ignore_logged_in' => array('type' => 'yes_no')
-                    )
-                ),
-                array(
                     'title' => 'throttling_allowed_ips',
                     'desc' => 'throttling_allowed_ips_desc',
                     'fields' => array(

--- a/system/ee/ExpressionEngine/Controller/Settings/Throttling.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Throttling.php
@@ -43,7 +43,7 @@ class Throttling extends Settings
                     'fields' => array(
                         'banish_masked_ips' => array('type' => 'yes_no')
                     )
-                )
+                ),
             ),
             'throttling_limit_settings' => array(
                 array(
@@ -91,6 +91,22 @@ class Throttling extends Settings
                     'title' => 'banishment_message',
                     'fields' => array(
                         'banishment_message' => array('type' => 'textarea')
+                    )
+                )
+            ),
+            'throttling_allow_settings' => array(
+                array(
+                    'title' => 'throttle_ignore_logged_in',
+                    'desc' => 'throttle_ignore_logged_in_desc',
+                    'fields' => array(
+                        'throttle_ignore_logged_in' => array('type' => 'yes_no')
+                    )
+                ),
+                array(
+                    'title' => 'throttling_allowed_ips',
+                    'desc' => 'throttling_allowed_ips_desc',
+                    'fields' => array(
+                        'throttling_allowed_ips' => array('type' => 'textarea')
                     )
                 )
             )

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -865,6 +865,8 @@ $lang = array(
 
     'banishment_url_desc' => '<abbr title="Uniform Resource Location">URL</abbr> location for locked out members.',
 
+    'throttling_allow_settings' => 'Allow Settings',
+
     'enable_throttling' => 'Enable throttling?',
 
     'enable_throttling_desc' => 'When enabled, members will be locked out of the system when they meet the lock out requirement.',

--- a/system/ee/language/english/settings_lang.php
+++ b/system/ee/language/english/settings_lang.php
@@ -869,6 +869,14 @@ $lang = array(
 
     'enable_throttling_desc' => 'When enabled, members will be locked out of the system when they meet the lock out requirement.',
 
+    'throttle_ignore_logged_in' => 'Ignore Logged in Requests',
+
+    'throttle_ignore_logged_in_desc' => 'Ignore requests for throttling by logged in members.',
+
+    'throttling_allowed_ips' => 'Allowed IPs',
+
+    'throttling_allowed_ips_desc' => 'Enter 1 IP Address per line to allow a bypass of the Throttling',
+
     'lockout_time' => 'Lockout time',
 
     'lockout_time_desc' => 'The number of seconds a user should be locked out of your site if they exceed the limits.',

--- a/system/ee/legacy/libraries/Throttling.php
+++ b/system/ee/legacy/libraries/Throttling.php
@@ -24,7 +24,7 @@ class EE_Throttling
     /** ----------------------------------------------*/
     public function run()
     {
-        if (ee()->config->item('enable_throttling') != 'y') {
+        if (!$this->should_throttle()) {
             return;
         }
 
@@ -45,6 +45,27 @@ class EE_Throttling
         $this->throttle_ip_check();
         $this->throttle_check();
         $this->throttle_update();
+    }
+
+    public function should_throttle(): bool
+    {
+        $return = false;
+        if (ee()->config->item('enable_throttling') == 'y') {
+            $return = true;
+            if (ee()->config->item('throttling_allowed_ips') != '') {
+                $ips = explode(',', ee()->config->item('throttling_allowed_ips'));
+                if ($ips && is_array($ips) && count($ips) >= 1) {
+                    foreach ($ips AS $ip) {
+                        if ($ip != '' && $ip == ee()->input->ip_address()) {
+                            $return = false;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $return;
     }
 
     /** ----------------------------------------------

--- a/system/ee/legacy/libraries/Throttling.php
+++ b/system/ee/legacy/libraries/Throttling.php
@@ -24,7 +24,7 @@ class EE_Throttling
     /** ----------------------------------------------*/
     public function run()
     {
-        if (!$this->should_throttle()) {
+        if (! $this->should_throttle()) {
             return;
         }
 
@@ -56,7 +56,7 @@ class EE_Throttling
                 $ips = explode(',', ee()->config->item('throttling_allowed_ips'));
                 if ($ips && is_array($ips) && count($ips) >= 1) {
                     foreach ($ips AS $ip) {
-                        if ($ip != '' && $ip == ee()->input->ip_address()) {
+                        if (filter_var($ip, FILTER_VALIDATE_IP) && $ip == ee()->input->ip_address()) {
                             $return = false;
                             break;
                         }


### PR DESCRIPTION
Contains a native implementation of the Throttle Whitelist Add-on. (renamed nomenclature to be 2025 friendly)

Adds IP Access Throttling to Core

- should resolve #4677 

 