### PR TITLE
Add before_version_delete hook

### DIFF
--- a/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
+++ b/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
@@ -701,6 +701,10 @@ class ChannelEntry extends ContentModel
             $versions = $this->Versions->sortBy('version_date')->asArray();
             $versions = array_slice($versions, 0, $diff);
 
+            if (ee()->extensions->active_hook('before_channel_entry_version_delete') === true) {
+                $versions = ee()->extensions->call('before_channel_entry_version_delete', $this, $versions);
+            }
+
             foreach ($versions as $version) {
                 $version->delete();
             }


### PR DESCRIPTION
This allows devs to adjust the logic of which versions get deleted. For example, when using Publisher, it allows us to maintain x languages _per language_ per entry, instead of just x languages per entry.

User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/935
