### PR TITLE
Enhancement - Add a get_keys() function to SmartForge class

### DIFF
--- a/system/ee/legacy/libraries/Smartforge.php
+++ b/system/ee/legacy/libraries/Smartforge.php
@@ -386,6 +386,44 @@ class Smartforge
 
         return false;
     }
+
+    /**
+     * List Keys
+     *
+     * Get all keys from the given database table.
+     *
+     * @access  public
+     * @param   string  $table  Table name
+     * @return  array
+     */
+    public function get_keys($table = '')
+    {
+        $keys = [];
+
+        // Check to make sure table exists
+        if (! ee()->db->table_exists($table)) {
+            ee()->logger->updater(__METHOD__ . " failed. Table '" . ee()->db->dbprefix . "$table' does not exist.", true);
+            return $keys;
+        }
+
+        // Get indexes
+        $query = ee()->db->query("SHOW INDEX FROM " . ee()->db->dbprefix . "$table");
+
+        if($query->num_rows() == 0) {
+            ee()->logger->updater(__METHOD__ . " failed. Unable to get indexes from '" . ee()->db->dbprefix . "$table'.", true);
+            return $keys;
+        }
+
+        foreach ($query->result_array() as $row) {
+            $key = [];
+            foreach ($row as $column => $value) {
+                $key[strtolower($column)] = $value;
+            }
+            $keys[] = $key;
+        }
+
+        return $keys;
+    }
 }
 
 // END SmartForge class


### PR DESCRIPTION
Smartforge allows for creation and deletion of keys, but only where you know the name of the key to be deleted.

This function adds the ability to obtain the output from the MySQL SHOW INDEX FROM command and presents the results as an associative array.

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
