### PR TITLE
Decouple site query from log query when viewing CP logs

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Logs/Cp.php
+++ b/system/ee/ExpressionEngine/Controller/Logs/Cp.php
@@ -42,7 +42,6 @@ class Cp extends Logs
 
         if ($search = ee()->input->get_post('filter_by_keyword')) {
             $logs->search(['action', 'username', 'ip_address'], $search);
-            $sites->search(['Site.site_label'], $search);
         }
 
         $filters = ee('CP/Filter')

--- a/system/ee/ExpressionEngine/Controller/Logs/Cp.php
+++ b/system/ee/ExpressionEngine/Controller/Logs/Cp.php
@@ -96,8 +96,6 @@ class Cp extends Logs
             ->offset($offset)
             ->all();
 
-        $sites = $sites->order('site_id')->all();
-
         $pagination = ee('CP/Pagination', $count)
             ->perPage($this->params['perpage'])
             ->currentPage($page)
@@ -105,7 +103,7 @@ class Cp extends Logs
 
         $vars = array(
             'logs' => $logs,
-            'sites' => $sites,
+            'sites' => $sites->all(),
             'pagination' => $pagination,
             'form_url' => $this->base_url->compile(),
         );

--- a/system/ee/ExpressionEngine/Controller/Logs/Cp.php
+++ b/system/ee/ExpressionEngine/Controller/Logs/Cp.php
@@ -37,10 +37,12 @@ class Cp extends Logs
         $this->base_url->path = 'logs/cp';
         ee()->view->cp_page_title = lang('view_cp_log');
 
-        $logs = ee('Model')->get('CpLog')->with('Site');
+        $sites = ee('Model')->get('Site');
+        $logs = ee('Model')->get('CpLog');
 
         if ($search = ee()->input->get_post('filter_by_keyword')) {
-            $logs->search(['action', 'username', 'ip_address', 'Site.site_label'], $search);
+            $logs->search(['action', 'username', 'ip_address'], $search);
+            $sites->search(['Site.site_label'], $search);
         }
 
         $filters = ee('CP/Filter')
@@ -62,6 +64,7 @@ class Cp extends Logs
 
         if (! empty($this->params['filter_by_site'])) {
             $logs = $logs->filter('site_id', $this->params['filter_by_site']);
+            $sites = $sites->filter('site_id', $this->params['filter_by_site']);
         }
 
         if (! empty($this->params['filter_by_date'])) {
@@ -94,6 +97,8 @@ class Cp extends Logs
             ->offset($offset)
             ->all();
 
+        $sites = $sites->order('site_id')->all();
+
         $pagination = ee('CP/Pagination', $count)
             ->perPage($this->params['perpage'])
             ->currentPage($page)
@@ -101,6 +106,7 @@ class Cp extends Logs
 
         $vars = array(
             'logs' => $logs,
+            'sites' => $sites,
             'pagination' => $pagination,
             'form_url' => $this->base_url->compile(),
         );

--- a/system/ee/ExpressionEngine/View/logs/cp.php
+++ b/system/ee/ExpressionEngine/View/logs/cp.php
@@ -24,7 +24,7 @@
 						<a href="" title="<?=lang('delete')?>" rel="modal-confirm-<?=$log->id?>" class="m-link button button--default button--small float-right"><i class="fal fa-trash-alt"><span class="hidden"><?=lang('delete')?></span></i></a>
 						<div style="margin-bottom: 20px;">
 							<b><?=lang('date_logged')?>:</b> <?=$localize->human_time($log->act_date)?>,
-							<b><?=lang('site')?>:</b> <?=$log->getSite()->site_label?><br>
+							<b><?=lang('site')?>:</b> <?=$sites->filter('site_id', $log->site_id)->first()->site_label?><br>
 							<b><?=lang('username')?>:</b> <a href="<?=ee('CP/URL')->make('myaccount', array('id' => $log->member_id))?>"><?=$log->username?></a>,
 							<b><abbr title="<?=lang('internet_protocol')?>"><?=lang('ip')?></abbr>:</b> <?=$log->ip_address?>
 						</div>


### PR DESCRIPTION
TL;DR - when using MySQL specifically (not MariaDB), viewing the Control Panel logs takes 1-2 minutes to load because this query takes so long and returns a lot of data. This PR drastically improves page speed because the `site_pages` data isn't returned for each row of the query. Additionally, the page queries now only fetch `site_pages` once instead of for every row of the logs.

---

When viewing the Control Panel logs (`/admin.php?/cp/logs/cp`), there is a query that is joining the `cp_log` table with the `sites` table, and then selecting all columns. As seen in the CMS debugger, it takes a long time and it returns an unnecessary amount of data:

<img width="716" alt="image" src="https://github.com/user-attachments/assets/9fe0f2ec-b86a-4dc3-b83d-f23575a7802f" />

```
SELECT
    CpLog_cp_log.id as CpLog__id,
    CpLog_cp_log.site_id as CpLog__site_id,
    CpLog_cp_log.member_id as CpLog__member_id,
    CpLog_cp_log.username as CpLog__username,
    CpLog_cp_log.ip_address as CpLog__ip_address,
    CpLog_cp_log.act_date as CpLog__act_date,
    CpLog_cp_log.action as CpLog__action,
    Site_sites.site_id as Site__site_id,
    Site_sites.site_label as Site__site_label,
    Site_sites.site_name as Site__site_name,
    Site_sites.site_description as Site__site_description,
    Site_sites.site_color as Site__site_color,
    Site_sites.site_bootstrap_checksums as Site__site_bootstrap_checksums,
    Site_sites.site_pages as Site__site_pages
FROM
    (`exp_cp_log` as CpLog_cp_log)
    LEFT JOIN `exp_sites` AS Site_sites ON `Site_sites`.`site_id` = `CpLog_cp_log`.`site_id`
ORDER BY `CpLog_cp_log`.`act_date` desc
LIMIT 25;
```

It took over a minute to load this page with ~15k rows in `cp_log`, and the `sites.site_pages` field was 300 KB. That meant that for every row returned, it was also returning 300 KB of data, which was the same data for every row.

<img width="382" alt="image" src="https://github.com/user-attachments/assets/497b5643-36e1-44fd-b8b3-d5953fd7f2aa" />

Decoupling the `cp_log` query from the `sites` query (because we don't need to know that data per row, we just need all of the `sites` rows once) makes this page load nearly instantly, and only returns a small amount of data (from 14 MB to 42 KB).

<img width="293" alt="image" src="https://github.com/user-attachments/assets/9e1d0685-83da-4290-8b38-67d028ff7a15" />

<img width="971" alt="image" src="https://github.com/user-attachments/assets/fa538cfe-bb62-41f5-be61-140343a6030b" />

The returned results are the same and still include the `site_label`.

<img width="1651" alt="image" src="https://github.com/user-attachments/assets/b70c6643-bc96-4dc0-904e-5669ec9bf2c0" />
