### PR TITLE
Add function to list indexes of nominated table

### DIFF
--- a/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php
+++ b/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php
@@ -194,6 +194,44 @@ class CI_DB_mysqli_connection
     {
         return isset($this->connection);
     }
+    
+    /**
+     * List Indexes
+     *
+     * Get all indexes from a given database table and return them as an associative array.
+     *
+     * @access  public
+     * @param   string  $table  Table name
+     * @return  array
+     */
+    public function get_indexes($table = '')
+    {
+        $indexes = [];
+
+        // Check to make sure table exists
+        if (! ee()->db->table_exists($table)) {
+            ee()->logger->updater(__METHOD__ . " failed. Table '" . ee()->db->dbprefix . "$table' does not exist.", true);
+            return $keys;
+        }
+
+        // Get indexes
+        $query = ee()->db->query("SHOW INDEX FROM " . ee()->db->dbprefix . "$table");
+
+        if($query->num_rows() == 0) {
+            ee()->logger->updater(__METHOD__ . " failed. Unable to get indexes from '" . ee()->db->dbprefix . "$table'.", true);
+            return $keys;
+        }
+
+        foreach ($query->result_array() as $row) {
+            $index = [];
+            foreach ($row as $column => $value) {
+                $index[strtolower($column)] = $value;
+            }
+            $indexes[] = $index;
+        }
+
+        return $indexes;
+    }
 
     /**
      * Set emulate prepares to false for SELECT statements so as not to clash

--- a/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php
+++ b/system/ee/legacy/database/drivers/mysqli/mysqli_connection.php
@@ -207,11 +207,13 @@ class CI_DB_mysqli_connection
     public function get_indexes($table = '')
     {
         $indexes = [];
+        ee()->load->library('logger');
+        ee()->load->helper('array');
 
         // Check to make sure table exists
         if (! ee()->db->table_exists($table)) {
             ee()->logger->updater(__METHOD__ . " failed. Table '" . ee()->db->dbprefix . "$table' does not exist.", true);
-            return $keys;
+            return $indexes;
         }
 
         // Get indexes
@@ -219,7 +221,7 @@ class CI_DB_mysqli_connection
 
         if($query->num_rows() == 0) {
             ee()->logger->updater(__METHOD__ . " failed. Unable to get indexes from '" . ee()->db->dbprefix . "$table'.", true);
-            return $keys;
+            return $indexes;
         }
 
         foreach ($query->result_array() as $row) {


### PR DESCRIPTION
Tools exist within EE db drivers to add and remove indexes from tables, but only work if you know the name of the index(es) you want to work on.

This function makes it possible to get an array of the names of the index(es) already defined for a table, making manipulation of index(es) easier.

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
