### PR TITLE
Add must-interact functionality to modals to prevent closing

### DIFF
--- a/cp-styles/app/styles/components/_modals.scss
+++ b/cp-styles/app/styles/components/_modals.scss
@@ -29,6 +29,10 @@
 	max-width: 550px;
 }
 
+.modal-wrap.must-interact .dialog__close {
+  display: none;
+}
+
 .modal {
 	background-color: color(bg-0);
 	margin-bottom: 40px;

--- a/themes/ee/asset/javascript/src/common.js
+++ b/themes/ee/asset/javascript/src/common.js
@@ -713,7 +713,7 @@ $(document).ready(function(){
 		$('body').on('modal:close', '.modal-wrap, .modal-form-wrap, .app-modal', function(e) {
 			var modal = $(this)
 
-			if (modal.is(":visible")) {
+			if (modal.is(":visible") && !modal.hasClass('must-interact')) {
 				// fade out the overlay
 				$('.overlay').fadeOut('slow');
 


### PR DESCRIPTION
This adds some restrictions to the way modals can be closed in order to require some interaction.

This can be useful for instances where you need the user to make a decision about something before proceeding - something different than the "confirm or cancel the action" behavior that a modal has by default. The example that we built this for was to allow the user to select one of two URL Title values before proceeding to edit the entry.

This additional logic ensures that the user makes a choice instead of just dismisses the action.

<img width="730" alt="image" src="https://github.com/user-attachments/assets/0037916b-8729-4f68-8672-e9658d8787c7" />



User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/944