### PR TITLE
Bug fix #4723

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
@@ -781,11 +781,9 @@ class Member_settings extends Member
         ee()->api_channel_fields->custom_fields = array();
 
         $hasFileField = false;
-
+        $fields = [];
         if (strpos($template, '{/custom_profile_fields}') !== false || !is_null(ee()->TMPL->template_engine)) {
             if ($query->num_rows() > 0) {
-                $fields = [];
-
                 foreach ($member->getDisplay()->getFields() as $field) {
                     if (! ee('Permission')->isSuperAdmin() && $field->get('field_public') != 'y') {
                         continue;


### PR DESCRIPTION
Warning
Undefined variable $fields
ee/ExpressionEngine/Addons/member/mod.member_settings.php, line 936

When {custom_profile_fields} tag pair not present.

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
