### PR TITLE
Fix a missing primary key from 6.3.0 update

### DIFF
--- a/build-tools/build.json
+++ b/build-tools/build.json
@@ -1,5 +1,5 @@
 {
-    "tag": "7.5.10",
+    "tag": "7.5.11",
 
     "repositories": {
         "app": "git@github.com:ExpressionEngine/ExpressionEngine",

--- a/system/ee/ExpressionEngine/Tests/bootstrap.php
+++ b/system/ee/ExpressionEngine/Tests/bootstrap.php
@@ -11,7 +11,7 @@ define('SYSPATH', $project_base);
 define('BASEPATH', SYSPATH . 'ee/legacy/');
 define('PATH_CACHE', SYSPATH . 'user/cache/');
 define('APPPATH', BASEPATH);
-define('APP_VER', '7.5.10');
+define('APP_VER', '7.5.11');
 define('PATH_THEMES', realpath(SYSPATH . '/../themes') . '/');
 define('DOC_URL', 'http://our.doc.url/');
 define('PATH_THIRD', SYSPATH . 'user/addons/');

--- a/system/ee/installer/controllers/wizard.php
+++ b/system/ee/installer/controllers/wizard.php
@@ -13,7 +13,7 @@
  */
 class Wizard extends CI_Controller
 {
-    public $version = '7.5.10'; // The version being installed
+    public $version = '7.5.11'; // The version being installed
     public $installed_version = '';  // The version the user is currently running (assuming they are running EE)
     public $schema = null; // This will contain the schema object with our queries
     public $languages = array(); // Available languages the installer supports (set dynamically based on what is in the "languages" folder)

--- a/system/ee/installer/updates/ud_6_03_00.php
+++ b/system/ee/installer/updates/ud_6_03_00.php
@@ -140,7 +140,7 @@ class Updater
                     ]
                 ]
             );
-            ee()->dbforge->add_key(['condition_set_id', 'field_id']);
+            ee()->dbforge->add_key(['condition_set_id', 'field_id'], true);
             ee()->smartforge->create_table('field_condition_sets_channel_fields');
         }
 

--- a/system/ee/installer/updates/ud_7_05_11.php
+++ b/system/ee/installer/updates/ud_7_05_11.php
@@ -25,7 +25,41 @@ class Updater
      */
     public function do_update()
     {
+        $steps = new \ProgressIterator(
+            [
+                'updateConditionalSetsCFPrimary',
+
+            ]
+        );
+
+        foreach ($steps as $k => $v) {
+            $this->$v();
+        }
+
         return true;
+    }
+
+    // Add missing primary key which old updates missed
+    private function updateConditionalSetsCFPrimary()
+    {
+        if (! ee()->db->table_exists('field_condition_sets_channel_fields')) {
+		    return;
+		}
+
+		$query = ee()->db->query("SHOW INDEX FROM " . ee()->db->dbprefix . "field_condition_sets_channel_fields WHERE Key_name = 'Primary'");
+
+		if ($query->num_rows() !== 0) {
+		    // Primary key already exists
+			return;
+		}
+
+		// Drop the old non-primary indexes
+		// Smartforge will check that they exist
+		ee()->smartforge->drop_key('field_condition_sets_channel_fields', 'condition_set_id');
+		ee()->smartforge->drop_key('field_condition_sets_channel_fields', 'field_id');
+
+		// Add the combo primary key
+		ee()->smartforge->add_key('field_condition_sets_channel_fields', ['condition_set_id', 'field_id'], 'PRIMARY');
     }
 }
 

--- a/system/ee/installer/updates/ud_7_05_11.php
+++ b/system/ee/installer/updates/ud_7_05_11.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Updater\Version_7_5_11;
+
+/**
+ * Update
+ */
+class Updater
+{
+    public $version_suffix = '';
+
+    /**
+     * Do Update
+     *
+     * @return TRUE
+     */
+    public function do_update()
+    {
+        return true;
+    }
+}
+
+// EOF

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -74,8 +74,8 @@ class EE_Core
 
         // application constants
         define('APP_NAME', 'ExpressionEngine');
-        define('APP_BUILD', '20250331');
-        define('APP_VER', '7.5.10');
+        define('APP_BUILD', '20250430');
+        define('APP_VER', '7.5.11');
         define('APP_VER_ID', '');
         define('SLASH', '&#47;');
         define('LD', '{');

--- a/tests/cypress/support/config/config.php
+++ b/tests/cypress/support/config/config.php
@@ -13,7 +13,7 @@ $config['legacy_member_templates'] = 'y';
 
 $config['log_date_format'] = 'Y-m-d H:i:s';
 $config['log_threshold'] = '1';
-$config['app_version'] = '7.5.10';
+$config['app_version'] = '7.5.11';
 $config['encryption_key'] = '4b9e521eb02751d8466a3e9b764524aff14b91ad';
 $config['session_crypt_key'] = '1f307a8afe66e692c2689508a5d9f783606379a8';
 $config['base_path'] = $_SERVER['DOCUMENT_ROOT'];


### PR DESCRIPTION
exp_field_condition_sets_channel_fields could be missing a primary key if it updated at 6.3.0

A NEW table install in 6.3.0 had the correct primary