### PR TITLE
Resolved #4745 where using `edit_date` variable in Structure navigation was giving PHP error

### DIFF
--- a/system/ee/ExpressionEngine/Addons/structure/libraries/Structure_nav_parser.php
+++ b/system/ee/ExpressionEngine/Addons/structure/libraries/Structure_nav_parser.php
@@ -231,6 +231,12 @@ class Structure_core_nav_parser
                     $variable_row[$prefix . $field_name] = $channelEntry->$field_name;
                 }
 
+                // edit date is special in getModChannelResultsArray, so also special here
+                // not sure why is that though...
+                if (isset($variable_row[$prefix . 'edit_date'])) {
+                    $variable_row[$prefix . 'edit_date'] = $variable_row[$prefix . 'edit_date']->format('U');
+                }
+
                 foreach ($fields[$channelEntry->Channel->getId()] as $field) {
                     // echo 'CFN: ', $prefix.$field->field_name, '<br />', "\n";
                     $property = 'field_id_' . $field->getId();


### PR DESCRIPTION
Resolved #4745 where using `edit_date` variable in Structure navigation was giving PHP error