### PR TITLE
Allow sending array variables to {embed} tags

### DIFF
--- a/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/LegacyParser.php
@@ -153,7 +153,21 @@ class LegacyParser
             $result = array();
 
             foreach ($matches as $match) {
-                $result[$match[1]] = (trim($match[4]) == '') ? $match[4] : trim($match[4]);
+                $separator = '.';
+                // Handle array data with nested keys separated by $separator
+                if(strpos($match[1], $separator)) {
+                    $pieces = explode($separator, $match[1]);
+                    $current = &$result;
+                    foreach($pieces as $piece) {
+                        if(!is_array($current[$piece] ?? null)) {
+                            $current[$piece] = [];
+                        }
+                        $current = &$current[$piece];
+                    }
+                    $current = (trim($match[4]) == '') ? $match[4] : trim($match[4]);
+                }else{
+                    $result[$match[1]] = (trim($match[4]) == '') ? $match[4] : trim($match[4]);
+                }
             }
 
             foreach ($defaults as $name => $default_value) {

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -454,7 +454,9 @@ class EE_Template
                 // add 'embed:' to the key for replacement and so these variables work in conditionals
                 $this->embed_vars['embed:' . $key] = $val;
                 unset($this->embed_vars[$key]);
-                $this->template = $this->_parse_var_single('embed:' . $key, $val, $this->template);
+                $this->template = (is_array($val)) ?
+                    $this->_parse_var_pair('embed:' . $key, $val, $this->template) :
+                    $this->_parse_var_single('embed:' . $key, $val, $this->template);
             }
         }
 


### PR DESCRIPTION
This change would allow passing array variables into an {embed} tag.

Here's an example of passing data from grid field into an embed:

```
{embed="group/_template"
    section_title="{title}"
    {my_grid_field}
        grid.{my_grid_field:index}.question="{my_grid_field:question}"
        grid.{my_grid_field:index}.answer="{my_grid_field:answer}"
    {/my_grid_field}
}
```

And accessing the variable inside the embed:

```
<h2>{embed:section_title}</h2>
<dl>
  {embed:grid}
    <dt>{question}</dt>
    <dd>{answer}</dd>
  {/embed:grid}
</dl>
```