### PR TITLE
Resolved #4762 where in some cases it was not possible to change site 404 template

### DIFF
--- a/system/ee/legacy/libraries/Form_validation.php
+++ b/system/ee/legacy/libraries/Form_validation.php
@@ -163,7 +163,8 @@ class EE_Form_validation
             if (is_array($setting)) {
                 foreach ($setting['fields'] as $field_name => $field) {
                     // For ajaxified fields with options not currently showing, we skip
-                    if (isset($field['filter_url']) && isset($field['choices']) && count($field['choices']) == 100) {
+                    $choicesLimit = isset($field['limit']) ? $field['limit'] : 100;
+                    if (isset($field['filter_url']) && isset($field['choices']) && count($field['choices']) >= $choicesLimit) {
                         continue;
                     }
 


### PR DESCRIPTION
Resolved #4762 where in some cases it was not possible to change site 404 template

Note: I'm not fan how the validation was / is currently working for ajax selects (essentially it might get skipped), but altering that would be rather a global change and new feature request. This PR is focusing on pushing the fix for the reported issue