### PR TITLE
Re-added `{index}` and `{absolute_index}` variables to `{exp:channel:entries}` tag; #3768

### DIFF
--- a/system/ee/legacy/libraries/channel_entries_parser/Parser.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/Parser.php
@@ -203,11 +203,13 @@ class EE_Channel_data_parser
 
             $this->_count = $count;
 
+            $row['index'] = $count;
             $row['count'] = $count + 1;
             $row['reverse_count'] = $total_results - $row['count'] + 1;
             $row['page_uri'] = '';
             $row['page_url'] = '';
             $row['total_results'] = $total_results;
+            $row['absolute_index'] = $absolute_offset + $row['index'];
             $row['absolute_count'] = $absolute_offset + $row['count'];
             $row['absolute_results'] = ($absolute_results === null) ? $total_results : $absolute_results;
             $row['absolute_reverse_count'] = $row['absolute_results'] - $row['absolute_count'] + 1;

--- a/tests/cypress/cypress/integration/content/entry_listing.ee6.js
+++ b/tests/cypress/cypress/integration/content/entry_listing.ee6.js
@@ -1,0 +1,42 @@
+
+/// <reference types="Cypress" />
+
+
+context('Entry Listing Page', () => {
+
+    before(function () {
+        cy.task('db:seed')
+        cy.eeConfig({ item: 'save_tmpl_files', value: 'y' })
+
+        //copy templates
+        cy.task('filesystem:copy', { from: 'support/templates/*', to: '../../system/user/templates/' }).then(() => {
+            cy.authVisit('admin.php?/cp/design')
+        })
+    })
+
+    it('index and count are correct when paginating', () => {
+        cy.visit('/index.php/entries/index')
+
+        cy.hasNoErrors()
+
+        cy.get('.entry').first().find('.count').invoke('text').should('eq', '1')
+        cy.get('.entry').first().find('.index').invoke('text').should('eq', '0')
+        cy.get('.entry').first().find('.absolute_count').invoke('text').should('eq', '1')
+        cy.get('.entry').first().find('.absolute_index').invoke('text').should('eq', '0')
+
+        cy.get('.entry').last().find('.count').invoke('text').should('eq', '5')
+        cy.get('.entry').last().find('.index').invoke('text').should('eq', '4')
+        cy.get('.entry').last().find('.absolute_count').invoke('text').should('eq', '5')
+        cy.get('.entry').last().find('.absolute_index').invoke('text').should('eq', '4')
+
+        cy.get('.pagination .next').click()
+
+        cy.hasNoErrors()
+
+        cy.get('.entry').first().find('.count').invoke('text').should('eq', '1')
+        cy.get('.entry').first().find('.index').invoke('text').should('eq', '0')
+        cy.get('.entry').first().find('.absolute_count').invoke('text').should('eq', '6')
+        cy.get('.entry').first().find('.absolute_index').invoke('text').should('eq', '5')
+    })
+
+})

--- a/tests/cypress/support/templates/default_site/entries.group/index.html
+++ b/tests/cypress/support/templates/default_site/entries.group/index.html
@@ -1,0 +1,26 @@
+{layout="cypress/layout"}
+{exp:channel:entries channel="about" limit="5" paginate="bottom"}
+<div id="entry-{entry_id}" class="entry">
+    <h4>{title}</h4>
+    <p>
+        <span class="count">{count}</span> /
+        <span class="index">{index}</span>
+    </p>
+    <p>
+        <span class="absolute_count">{absolute_count}</span> /
+        <span class="absolute_index">{absolute_index}</span>
+    </p>
+</div>
+
+{paginate}
+<div class="pagination">
+    {if previous_page}
+        <a href="{auto_path}" class="prev">Previous Page</a> &nbsp;
+    {/if}
+    {if next_page}
+        <a href="{auto_path}" class="next">Next Page</a>
+    {/if}
+</div>
+{/paginate}
+
+{/exp:channel:entries}


### PR DESCRIPTION
Re-added `{index}` and `{absolute_index}` variables to `{exp:channel:entries}` tag; #3768

Closes #4770

Initially this was included and merged into `release/7.5.0` but somehow at some point got wiped out