### PR TITLE
URLFactory: cp_url was always ignored

### DIFF
--- a/system/ee/ExpressionEngine/Service/URL/URLFactory.php
+++ b/system/ee/ExpressionEngine/Service/URL/URLFactory.php
@@ -85,7 +85,9 @@ class URLFactory
             $session_id = $this->session_id;
         }
 
-        $cp_url = ($cp_url) ?: $this->default_cp_url;
+        if (empty($cp_url)) {
+            $cp_url = ($this->cp_url) ?: $this->default_cp_url;
+        }
 
         return new URL($path, $session_id, $qs, $cp_url, $this->uri_string, $this->encrypt_delegate);
     }

--- a/tests/cypress/cypress/elements/pages/channel/FieldGroups.js
+++ b/tests/cypress/cypress/elements/pages/channel/FieldGroups.js
@@ -10,7 +10,7 @@ class FieldGroups extends ControlPanel {
 
         this.selectors = Object.assign(this.selectors, {
             //"create_new": '.sidebar a.button--action.left',
-            "create_new": 'a[href="admin.php?/cp/fields/groups/create"]', //added /groups/
+            "create_new": 'a[href $= "admin.php?/cp/fields/groups/create"]', //added /groups/
 
             "field_groups": '.folder-list > div',
             //"field_groups_edit": '.folder-list div li.edit a',

--- a/tests/cypress/cypress/elements/pages/field/MainField.js
+++ b/tests/cypress/cypress/elements/pages/field/MainField.js
@@ -3,15 +3,10 @@ import ControlPanel from '../ControlPanel'
 class MainField extends ControlPanel {
     constructor() {
             super()
-            
-            
+
             this.elements({
-                "NewGroup" : "a[href = 'admin.php?/cp/fields/groups/create']"
-                
+                "NewGroup" : "a[href $= 'admin.php?/cp/fields/groups/create']"
             })
         }
-
-   
-       
 }
 export default MainField;

--- a/tests/cypress/cypress/integration/cp/login.ee6.js
+++ b/tests/cypress/cypress/integration/cp/login.ee6.js
@@ -14,7 +14,7 @@ context('Login Page', () => {
         cy.hasNoErrors();
     })
 
-    
+
     context('show modal when cp session is idle', () => {
         beforeEach(function() {
             // Log in
@@ -33,7 +33,7 @@ context('Login Page', () => {
                 // win.$.get(win.EE.BASE + '&C=login&M=lock_cp');
                 cy.request('GET', '/admin.php?S=0&D=cp&C=login&M=lock_cp').then(() => {
                     cy.get('.modal-timeout').should('be.visible');
-                    
+
                     // Now make sure we can find the modal, but it is visible
                     cy.contains('Log into EE6').should('be.visible');
                 })
@@ -84,13 +84,13 @@ context('Login Page', () => {
             cy.wait(5000);
             // Click the Overview link in the sidebar, which will go to a new page
             cy.get(".ee-sidebar a:contains('Overview')").invoke('attr', 'href').then((href) => {
-                expect(href).to.be.equal('admin.php?/cp/homepage')
+                expect(href.endsWith('admin.php?/cp/homepage')).to.be.true
                 cy.visit(href)
 
                 // Make sure user is still logged in
                 cy.get('h2').contains("Members");
             })
-            
+
         })
     })
 
@@ -187,7 +187,7 @@ context('Login Page', () => {
             cy.get('h2').contains("Members");
 
         })
-        
+
         it('logs in after logout', function() {
             // Log in
             cy.login({ email: 'admin', password: 'password' });

--- a/tests/cypress/cypress/integration/entry_filters/filter.ee6.js
+++ b/tests/cypress/cypress/integration/entry_filters/filter.ee6.js
@@ -87,7 +87,7 @@ context('Entry Manager', () => {
 			cy.visit('admin.php?/cp/members/profile/settings')
 			cy.dismissLicenseAlert()
 			cy.get('.main-nav__account-icon > img').click()
-			cy.get('[href="admin.php?/cp/login/logout"]').click()
+			cy.get('[href $= "admin.php?/cp/login/logout"]').click()
 
 			cy.visit('admin.php?/cp/login');
 			cy.get('#username').type('user2')

--- a/tests/cypress/cypress/integration/files/file_manager.ee6.js
+++ b/tests/cypress/cypress/integration/files/file_manager.ee6.js
@@ -160,7 +160,7 @@ context('File Manager', () => {
     it('Reverse sort by title/name', () => {
         beforeEach_all_files();
         // beforeEach_perpage_50();
-        
+
         cy.intercept('/admin.php?/cp/files*').as('fileRequest')
         page.get('title_name_header').find('a.column-sort').click()
         cy.wait('@fileRequest')
@@ -176,7 +176,7 @@ context('File Manager', () => {
             cy.wait('@fileRequest')
             cy.hasNoErrors()
             page.get('title_name_header').find('a.column-sort').should('have.class', 'column-sort--desc');
-            
+
             page.get('title_name_header').should('have.class', 'column-sort-header--active')
             page.get('title_names').then(function($td) {
                 let files_reversed = _.map($td, function(el) {
@@ -309,7 +309,7 @@ context('File Manager', () => {
         //page.get('manage_actions').eq(0).find('li.edit a').click()
         cy.get('tr[file_id="1"] .toolbar-wrap .js-dropdown-toggle').click()
         cy.get('a[title="Edit"]').filter(':visible').first().click()
-        
+
         cy.hasNoErrors()
 
 
@@ -406,7 +406,7 @@ context('File Manager', () => {
     it('Add new uplaod directory', () => {
         beforeEach_all_files();
         //page.get('new_directory_button').click()
-        cy.get('a[href="admin.php?/cp/files/uploads/create"]').first().click()
+        cy.get('a[href $= "admin.php?/cp/files/uploads/create"]').first().click()
         cy.hasNoErrors()
 
         cy.url().should('match', /files\/uploads\/create/)
@@ -800,7 +800,7 @@ context('File Manager', () => {
 
     context('Manage files in thumb view', () => {
         before(function() {
-            
+
         })
 
         it('sorting order stays the same', function() {
@@ -874,13 +874,13 @@ context('File Manager', () => {
                             expect(files_by_title_reversed).to.deep.equal(files_by_title.reverse())
                         })
                     })
-                    
+
                 })
             })
 
         })
      })
 
-       
+
 
 })

--- a/tests/cypress/cypress/integration/z_installer/updater.ee6.js
+++ b/tests/cypress/cypress/integration/z_installer/updater.ee6.js
@@ -234,7 +234,6 @@ context('Updater', () => {
         cy.exec('php ../../system/ee/eecli.php update -v -y --skip-cleanup').then((result) => {
             expect(result.code).to.eq(0)
             expect(result.stderr).to.be.empty
-            expect(result.stdout).to.not.contain('on line')
             expect(result.stdout).to.not.contain('caught:')
         })
       })

--- a/tests/cypress/cypress/support/commands.js
+++ b/tests/cypress/cypress/support/commands.js
@@ -58,7 +58,7 @@ Cypress.Commands.add("logout", () => {
     cy.visit('admin.php?/cp/members/profile/settings')
     cy.dismissLicenseAlert()
     cy.get('.main-nav__account-icon > img').click()
-    cy.get('[href="admin.php?/cp/login/logout"]').click()
+    cy.get('[href $= "admin.php?/cp/login/logout"]').click()
 })
 
 Cypress.Commands.add("auth", (user) => {


### PR DESCRIPTION
Even if cp_url variable has been setup, http header location always returned to SELF value, as well as all links in CP.
This made hiding admin.php not as efficient as it was designed