### PR TITLE
Resolved #4793 where member password reset email could have repeated / in the reset_url

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -814,7 +814,7 @@ class Member_auth extends Member
 
             // Make sure it's an actual URL.
             if (substr($reset_url, 0, 4) !== 'http') {
-                $reset_url = ee()->functions->fetch_site_index(0, 0) . '/' . $reset_url;
+                $reset_url = reduce_double_slashes(ee()->functions->fetch_site_index(0, 0) . '/' . $reset_url);
             }
         } else {
             $reset_url = reduce_double_slashes(ee()->functions->fetch_site_index(0, 0) . '/' . ee()->config->item('profile_trigger') . '/reset_password');


### PR DESCRIPTION
Resolved #4793 where member password reset email could have repeated / in the `reset_url`
