### PR TITLE
4 new hooks for email and forgotten passwords

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -769,14 +769,13 @@ class Member_auth extends Member
 
         $address = strip_tags($address);
 
-          // Allow extensions to modify submitted address for frontend password reset
-          if (ee()->extensions->active_hook('member_auth_send_reset_token_start')) {
+        // // member_auth_send_reset_token_start hook allows overriding posted email address from password reset form
+        if (ee()->extensions->active_hook('member_auth_send_reset_token_start')) {
             $address = ee()->extensions->call('member_auth_send_reset_token_start', $address);
             if (ee()->extensions->end_script === true) {
                 return;
             }
         }
-        ee()->logger->developer('member_auth_send_reset_token_start'. $address);
 
         $memberQuery = ee()->db->select('member_id, username, screen_name')
             ->where('email', $address)
@@ -859,8 +858,6 @@ class Member_auth extends Member
         // $swap.  If the key doesn't exist then no swapping happens.
         $email_subject = $this->_var_swap($email_subject, $swap);
         $email_msg = $this->_var_swap($email_template, $swap);
-
-        ee()->logger->developer('address: ' . $address);
 
         // Instantiate the email class
         ee()->load->library('email');

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -882,8 +882,8 @@ class Member_auth extends Member
 
         // If we have a success return link, go to that, otherwise, output the standard message.
         ee()->output->show_message($data, true, $return_success_link);
-	}
-		
+    }
+
     /**
      * Reset Password Form Method
      *

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -713,8 +713,8 @@ class Member_auth extends Member
      *
      * @return void
      */
-    public function send_reset_token()
-    {
+	public function send_reset_token()
+	{
         // Handle our protected data if any. This contains our extra params.
         $protected = ee()->functions->handle_protected();
 
@@ -738,6 +738,7 @@ class Member_auth extends Member
         }
 
         ee()->load->helper('email');
+
         if (! valid_email($address)) {
             return ee()->output->show_form_error(['email' => lang('invalid_email_address')], 'submission');
         }
@@ -767,6 +768,15 @@ class Member_auth extends Member
         $forum_id = (ee()->input->get_post('FROM') == 'forum') ? '&r=f&board_id=' . $board_id : '';
 
         $address = strip_tags($address);
+
+          // Allow extensions to modify submitted address for frontend password reset
+          if (ee()->extensions->active_hook('member_auth_send_reset_token_start')) {
+            $address = ee()->extensions->call('member_auth_send_reset_token_start', $address);
+            if (ee()->extensions->end_script === true) {
+                return;
+            }
+        }
+        ee()->logger->developer('member_auth_send_reset_token_start'. $address);
 
         $memberQuery = ee()->db->select('member_id, username, screen_name')
             ->where('email', $address)
@@ -850,6 +860,8 @@ class Member_auth extends Member
         $email_subject = $this->_var_swap($email_subject, $swap);
         $email_msg = $this->_var_swap($email_template, $swap);
 
+        ee()->logger->developer('address: ' . $address);
+
         // Instantiate the email class
         ee()->load->library('email');
         ee()->email->wordwrap = true;
@@ -873,8 +885,8 @@ class Member_auth extends Member
 
         // If we have a success return link, go to that, otherwise, output the standard message.
         ee()->output->show_message($data, true, $return_success_link);
-    }
-
+	}
+		
     /**
      * Reset Password Form Method
      *

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -713,8 +713,8 @@ class Member_auth extends Member
      *
      * @return void
      */
-	public function send_reset_token()
-	{
+    public function send_reset_token()
+    {
         // Handle our protected data if any. This contains our extra params.
         $protected = ee()->functions->handle_protected();
 
@@ -769,7 +769,7 @@ class Member_auth extends Member
 
         $address = strip_tags($address);
 
-        // // member_auth_send_reset_token_start hook allows overriding posted email address from password reset form
+        // member_auth_send_reset_token_start hook allows overriding posted email address from password reset form
         if (ee()->extensions->active_hook('member_auth_send_reset_token_start')) {
             $address = ee()->extensions->call('member_auth_send_reset_token_start', $address);
             if (ee()->extensions->end_script === true) {

--- a/system/ee/legacy/controllers/cp/login.php
+++ b/system/ee/legacy/controllers/cp/login.php
@@ -787,9 +787,9 @@ class Login extends CP_Controller
 
         $address = strip_tags($address);
 
-        // cp_login_send_reset_token_start hook allows overriding posted email address from cp password reset form
-        if (ee()->extensions->active_hook('cp_login_send_reset_token_start')) {          
-            $address = ee()->extensions->call('cp_login_send_reset_token_start', $address);
+        // cp_member_send_reset_token_start hook allows overriding posted email address from cp password reset form
+        if (ee()->extensions->active_hook('cp_member_send_reset_token_start')) {          
+            $address = ee()->extensions->call('cp_member_send_reset_token_start', $address);
             if (ee()->extensions->end_script === true) {
                 return;
             }

--- a/system/ee/legacy/controllers/cp/login.php
+++ b/system/ee/legacy/controllers/cp/login.php
@@ -787,15 +787,13 @@ class Login extends CP_Controller
 
         $address = strip_tags($address);
 
-        // Allow extensions to modify submitted address for CP password reset
+        // cp_login_send_reset_token_start hook allows overriding posted email address from cp password reset form
         if (ee()->extensions->active_hook('cp_login_send_reset_token_start')) {          
             $address = ee()->extensions->call('cp_login_send_reset_token_start', $address);
             if (ee()->extensions->end_script === true) {
                 return;
             }
         }
-
-        ee()->logger->developer('debug Forgot password request for email: ' . $address);
 
         // Fetch user data
         $this->db->select('member_id, username, screen_name');
@@ -818,8 +816,6 @@ class Login extends CP_Controller
         $member_id = $query->row('member_id');
         $name = ($query->row('screen_name') == '') ? $query->row('username') : $query->row('screen_name');
         $username = $query->row('username');
-
-        ee()->logger->developer('debug Forgot password request for member_id: ' . $member_id);
 
         // Clean out any old reset codes.
         $a_day_ago = time() - (60 * 60 * 24);

--- a/system/ee/legacy/controllers/cp/login.php
+++ b/system/ee/legacy/controllers/cp/login.php
@@ -787,6 +787,16 @@ class Login extends CP_Controller
 
         $address = strip_tags($address);
 
+        // Allow extensions to modify submitted address for CP password reset
+        if (ee()->extensions->active_hook('cp_login_send_reset_token_start')) {          
+            $address = ee()->extensions->call('cp_login_send_reset_token_start', $address);
+            if (ee()->extensions->end_script === true) {
+                return;
+            }
+        }
+
+        ee()->logger->developer('debug Forgot password request for email: ' . $address);
+
         // Fetch user data
         $this->db->select('member_id, username, screen_name');
         $this->db->where('email', $address);
@@ -808,6 +818,8 @@ class Login extends CP_Controller
         $member_id = $query->row('member_id');
         $name = ($query->row('screen_name') == '') ? $query->row('username') : $query->row('screen_name');
         $username = $query->row('username');
+
+        ee()->logger->developer('debug Forgot password request for member_id: ' . $member_id);
 
         // Clean out any old reset codes.
         $a_day_ago = time() - (60 * 60 * 24);

--- a/system/ee/legacy/libraries/Email.php
+++ b/system/ee/legacy/libraries/Email.php
@@ -481,9 +481,14 @@ class EE_Email
      */
     public function from($from, $name = '', $return_path = null)
     {
-        // email_from_address allows overriding the from address	
+        // email_from_address allows overriding the from/name
         if (ee()->extensions->active_hook('email_from_address')) {
-            $from = ee()->extensions->call('email_from_address', $from, $name);
+            $processed_address = ee()->extensions->call('email_from_address', $from, $name);
+            $from = $processed_address['from'] ?? $from;
+            $name = $processed_address['name'] ?? $name;
+            if (ee()->extensions->end_script === true) {
+                return;
+            }
         }
         
         if (preg_match('/\<(.*)\>/', $from, $match)) {
@@ -558,6 +563,9 @@ class EE_Email
         // email_to_address hook allows overriding the to address
         if (ee()->extensions->active_hook('email_to_address')) {
             $to = ee()->extensions->call('email_to_address', $to);
+            if (ee()->extensions->end_script === true) {
+                return;
+            }			
         }
         
         $to = $this->_str_to_array($to);

--- a/system/ee/legacy/libraries/Email.php
+++ b/system/ee/legacy/libraries/Email.php
@@ -481,6 +481,10 @@ class EE_Email
      */
     public function from($from, $name = '', $return_path = null)
     {
+        if (ee()->extensions->active_hook('email_from_address')) {
+            $from = ee()->extensions->call('email_from_address', $from, $name);
+        }
+        
         if (preg_match('/\<(.*)\>/', $from, $match)) {
             $from = $match[1];
         }
@@ -509,7 +513,7 @@ class EE_Email
         $this->set_header('Return-Path', '<' . $return_path . '>');
 
         return $this;
-    }
+     }
 
     /**
      * Set Reply-to
@@ -550,6 +554,12 @@ class EE_Email
      */
     public function to($to)
     {
+        ee()->logger->developer('sending email to: '.$to);
+        if (ee()->extensions->active_hook('email_to_address')) {
+            $to = ee()->extensions->call('email_to_address', $to);
+            ee()->logger->developer('to email: '.$to);
+        }
+        
         $to = $this->_str_to_array($to);
         $to = $this->clean_email($to);
 

--- a/system/ee/legacy/libraries/Email.php
+++ b/system/ee/legacy/libraries/Email.php
@@ -481,6 +481,7 @@ class EE_Email
      */
     public function from($from, $name = '', $return_path = null)
     {
+        // email_from_address allows overriding the from address	
         if (ee()->extensions->active_hook('email_from_address')) {
             $from = ee()->extensions->call('email_from_address', $from, $name);
         }
@@ -513,7 +514,7 @@ class EE_Email
         $this->set_header('Return-Path', '<' . $return_path . '>');
 
         return $this;
-     }
+    }
 
     /**
      * Set Reply-to
@@ -554,10 +555,9 @@ class EE_Email
      */
     public function to($to)
     {
-        ee()->logger->developer('sending email to: '.$to);
+        // email_to_address hook allows overriding the to address
         if (ee()->extensions->active_hook('email_to_address')) {
             $to = ee()->extensions->call('email_to_address', $to);
-            ee()->logger->developer('to email: '.$to);
         }
         
         $to = $this->_str_to_array($to);


### PR DESCRIPTION
Also, additional developer logging. Docs https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1021

Proposed hooks:
member_auth_send_reset_token_start
cp_login_send_reset_token_start
email_from_address
email_to_address

Finalized hooks:
member_auth_send_reset_token_start
cp_member_send_reset_token_start
email_from_address
email_to_address
