### PR TITLE
Renamed hook and now low reorder extension not working....

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro_search/mod.pro_search.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/mod.pro_search.php
@@ -834,9 +834,9 @@ class Pro_search
         //  - Do something just after the search is executed
         // -------------------------------------
 
-        if (ee()->extensions->active_hook('pro_search_post_search') === true) {
+        if (ee()->extensions->active_hook('low_search_post_search') === true) {
             $params = $this->params->get();
-            $params = ee()->extensions->call('pro_search_post_search', $params);
+            $params = ee()->extensions->call('low_search_post_search', $params);
             if (ee()->extensions->end_script === true) {
                 return ee()->TMPL->tagdata;
             }


### PR DESCRIPTION
Low reorder has an extension calling 'low_search_post_search' that can be called to alter pro search ordering. But... we renamed it pro search and now Low Reorder doesn't find it because the name changed.

This renames it back- but now I'm wondering if this is the right fix.  Do we need to keep old name and new name- for like all the hooks? Kind of surprised this is the first time I ran into this.