### PR TITLE
Resolved #4811 where error messages when uploading attachments on Communicate page were not clear

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Utilities/Communicate.php
+++ b/system/ee/ExpressionEngine/Controller/Utilities/Communicate.php
@@ -907,7 +907,7 @@ class Communicate extends Utilities
         ));
 
         if (! ee()->upload->do_upload('attachment')) {
-            ee()->form_validation->set_message('_attachment_handler', lang('attachment_problem'));
+            ee()->form_validation->set_message('_attachment_handler', ee()->upload->display_errors());
 
             return false;
         }


### PR DESCRIPTION
Resolved #4811 where error messages when uploading attachments on Communicate page were not clear