### PR TITLE
Resolved #4623 where autosaves for new entry could be overwritten by another member

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/Publish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Publish.php
@@ -159,11 +159,15 @@ class Publish extends AbstractPublishController
 
         $site_id = ee()->config->item('site_id');
 
-        $autosave = ee('Model')->get('ChannelEntryAutosave')
+        $autosaveQuery = ee('Model')->get('ChannelEntryAutosave')
             ->filter('original_entry_id', $entry_id)
             ->filter('site_id', $site_id)
-            ->filter('channel_id', $channel_id)
-            ->first();
+            ->filter('channel_id', $channel_id);
+        // for new entries, use author as extra identifier
+        if (empty($entry_id)) {
+            $autosaveQuery->filter('author_id', ee()->input->post('author_id', ee()->session->userdata('member_id')));
+        }
+        $autosave = $autosaveQuery->first();
 
         if (! $autosave) {
             $autosave = ee('Model')->make('ChannelEntryAutosave');

--- a/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
+++ b/system/ee/ExpressionEngine/Model/Channel/ChannelEntry.php
@@ -1615,6 +1615,23 @@ class ChannelEntry extends ContentModel
 
         return false;
     }
+
+    public function getAutosaves()
+    {
+        if ($this->isNew()) {
+            return ee('Model')->get('ChannelEntryAutosave')
+                ->filter('original_entry_id', 0)
+                ->filter('site_id', $this->site_id)
+                ->filter('channel_id', $this->channel_id)
+                ->filterGroup()
+                    ->filter('author_id', $this->author_id)
+                    ->orFilter('author_id', ee()->session->userdata('member_id'))
+                ->endFilterGroup()
+                ->all();
+        }
+
+        return $this->Autosaves;
+    }
 }
 
 // EOF


### PR DESCRIPTION
Resolved #4623 where autosaves for new entry could be overwritten by another member

Note: OP suggests that autosaves should not be author-specific at all, however I think some people might be using existing behaviour to pass unpublished work between editors, so we should not change that. This PR is only adding author check for new entries