### PR TITLE
Resolved #4189 where `{if logged_in}` variable was parsed late without a reason

### DIFF
--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -3466,10 +3466,6 @@ class EE_Template
 
         $data['member_group'] = $data['logged_in_member_group'] = ee()->session->userdata['role_id'];
 
-        // Logged in and logged out variables
-        $data['logged_in'] = (ee()->session->userdata['member_id'] != 0);
-        $data['logged_out'] = (ee()->session->userdata['member_id'] == 0);
-
         // current time
         $data['current_time'] = ee()->localize->now;
 
@@ -4569,6 +4565,10 @@ class EE_Template
                 $vars['has_role_' . $role->short_name] = $value;
             }
         }
+
+        // Logged in and logged out variables
+        $data['logged_in'] = (ee()->session->userdata['member_id'] != 0);
+        $data['logged_out'] = (ee()->session->userdata['member_id'] == 0);
 
         return $vars;
     }

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -4541,7 +4541,10 @@ class EE_Template
 
         if (!isset(ee()->session)) {
             //early parsing, e.g. called from code and not web request
-            return [];
+            return [
+                'logged_out' => true,
+                'logged_in' => false,
+            ];
         }
 
         if (empty($vars)) {
@@ -4567,8 +4570,8 @@ class EE_Template
         }
 
         // Logged in and logged out variables
-        $data['logged_in'] = (ee()->session->userdata['member_id'] != 0);
-        $data['logged_out'] = (ee()->session->userdata['member_id'] == 0);
+        $vars['logged_in'] = (ee()->session->userdata['member_id'] != 0);
+        $vars['logged_out'] = (ee()->session->userdata['member_id'] == 0);
 
         return $vars;
     }


### PR DESCRIPTION
Resolved #4189 where `{if logged_in}` variable was parsed late without a reason

It would not hurt if we make it parse a little earlier