### PR TITLE
Resolved #4826 where PHP Warning could be shown when referencing non-existing JavaScript template in CP

### DIFF
--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -744,7 +744,7 @@ class Cp
                     return $templateModel->edit_date;
                 }
 
-                break;
+                return 0;
 
             default:
                 return 0;


### PR DESCRIPTION
Resolved #4826 where PHP Warning could be shown when referencing non-existing JavaScript template in CP