### PR TITLE
Make no_results work in rss parser add-on

### DIFF
--- a/system/ee/ExpressionEngine/Addons/rss_parser/pi.rss_parser.php
+++ b/system/ee/ExpressionEngine/Addons/rss_parser/pi.rss_parser.php
@@ -43,6 +43,7 @@ class Rss_parser
         // Make sure there's at least one item
         if ($feed->get_item_quantity() <= 0) {
             $this->return_data = ee()->TMPL->no_results();
+            return;
         }
 
         $content = array(


### PR DESCRIPTION
The docs say that {if no_results} works, but it didn't. If there were no items, it still showed the feed meta data and just nothing for the missing items.  If the tag was present, it and the contents were removed.

I'd personally like a way to show the feed meta data and a no results type tag for the items, but that's not consistent with what docs say or what user needed and given I haven't had any request for that, I'm overthinking it.

Hence- this simple 'Make no results work like normal' pr.

