### PR TITLE
Revert "Resolved #4772 where MFA dialog could still be shown if set required for member but disabled globally"

### DIFF
--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -418,7 +418,7 @@ class EE_Core
         }
 
         // Is MFA required?
-        if (REQ == 'PAGE' && ee()->config->item('enable_mfa') === 'y' && ee()->session->userdata('mfa_flag') != 'skip') {
+        if (REQ == 'PAGE' && ee()->session->userdata('mfa_flag') != 'skip') {
             if (ee()->session->userdata('mfa_flag') == 'show') {
                 ee('pro:Mfa')->invokeMfaDialog();
             }


### PR DESCRIPTION
Reverts ExpressionEngine/ExpressionEngine#4776