### PR TITLE
Enabled cropping images around selected focal point; #4850

### DIFF
--- a/build-tools/build.json
+++ b/build-tools/build.json
@@ -1,5 +1,5 @@
 {
-    "tag": "7.5.12",
+    "tag": "7.6.0",
 
     "repositories": {
         "app": "git@github.com:ExpressionEngine/ExpressionEngine",

--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -529,6 +529,11 @@ JSC;
             return false;
         }
 
+        // if the crop position is focal, get actual numbers so that image will be updated when those change
+        if ($function == 'crop' && isset($params['position']) && $params['position'] == 'focal') {
+            $params['position'] = ($data['model_object']->focal_x / 100) . '|' . ($data['model_object']->focal_y / 100);
+        }
+
         ee()->load->library('image_lib');
         $filename = ee()->image_lib->explode_name($data['fs_filename']);
         if ($function == 'webp') {
@@ -598,11 +603,48 @@ JSC;
             // if position parameter is provided, use it to calculate x and y
             if ($function == 'crop' && isset($params['position'])) {
                 $props = ee()->image_lib->get_image_properties($source['path'], true);
+                $positions = explode('|', $params['position']);
+                if (count($positions) == 1) {
+                    $positions[1] = $positions[0];
+                }
+                foreach ($positions as $key => $value) {
+                    if (is_numeric($value)) {
+                        $positions[$key] = (float) $value;
+                    } else {
+                        switch ($value) {
+                            case 'left':
+                                $positions[$key] = 0;
+                                break;
+                            case 'right':
+                                $positions[$key] = 1;
+                                break;
+                            case 'top':
+                                $positions[$key] = 0;
+                                break;
+                            case 'bottom':
+                                $positions[$key] = 1;
+                                break;
+                            case 'center':
+                            default:
+                                $positions[$key] = 0.5;
+                        }
+                    }
+                }
+                $focalX = $positions[0];
+                $focalY = $positions[1];
+
+                if (!isset($params['width']) && isset($params['height'])) {
+                    $params['width'] = $props['width'] * $params['height'] / $props['height'];
+                }
+                if (!isset($params['height']) && isset($params['width'])) {
+                    $params['height'] = $props['height'] * $params['width'] / $props['width'];
+                }
+
                 if (isset($params['width'])) {
-                    $imageLibConfig['x_axis'] += floor(($props['width'] - (int) $params['width']) / 2);
+                    $imageLibConfig['x_axis'] += floor($props['width'] * $focalX - (int) $params['width'] * $focalX);
                 }
                 if (isset($params['height'])) {
-                    $imageLibConfig['y_axis'] += floor(($props['height'] - (int) $params['height']) / 2);
+                    $imageLibConfig['y_axis'] += floor($props['height'] * $focalY - (int) $params['height'] * $focalY);
                 }
             }
 

--- a/system/ee/ExpressionEngine/Model/File/FileDimension.php
+++ b/system/ee/ExpressionEngine/Model/File/FileDimension.php
@@ -210,8 +210,11 @@ class FileDimension extends Model
 
             ee()->image_lib->initialize($config);
 
-            $config['x_axis'] = ((ee()->image_lib->width / 2) - ($width / 2));
-            $config['y_axis'] = ((ee()->image_lib->height / 2) - ($height / 2));
+            $focalX = $file->focal_x / 100;
+            $focalY = $file->focal_y / 100;
+
+            $config['x_axis'] = ((ee()->image_lib->width * $focalX) - ($width * $focalX));
+            $config['y_axis'] = ((ee()->image_lib->height * $focalY) - ($height * $focalY));
             $config['maintain_ratio'] = false;
             $config['width'] = $width;
             $config['height'] = $height;

--- a/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
+++ b/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
@@ -94,6 +94,8 @@ class FileSystemEntity extends ContentModel
         'description' => 'xss',
         'credit' => 'xss',
         'location' => 'xss',
+        'focal_x' => 'integer|greaterOrEqualThan[0]|lessOrEqualThan[100]',
+        'focal_y' => 'integer|greaterOrEqualThan[0]|lessOrEqualThan[100]',
     );
 
     protected $file_id;
@@ -115,6 +117,8 @@ class FileSystemEntity extends ContentModel
     protected $modified_date;
     protected $file_hw_original;
     protected $total_records;
+    protected $focal_x;
+    protected $focal_y;
 
     protected $_baseServerPath;
     protected $_subfolderPath;

--- a/system/ee/ExpressionEngine/Service/File/Upload.php
+++ b/system/ee/ExpressionEngine/Service/File/Upload.php
@@ -108,6 +108,25 @@ class Upload
             )
         );
 
+        if ($file->isEditableImage()) {
+            $sections[0][] = array(
+                'title' => 'focal_point',
+                'desc' => 'focal_point_desc',
+                'fields' => [
+                    'focal_x' => [
+                        'type' => 'short-text',
+                        'label' => 'x-axis',
+                        'value' => $file->focal_x
+                    ],
+                    'focal_y' => [
+                        'type' => 'short-text',
+                        'label' => 'y-axis',
+                        'value' => $file->focal_y
+                    ]
+                ]
+            );
+        }
+
         // Remove the file field when we are editing
         if (! $file->isNew()) {
             unset($sections[0][0]);
@@ -553,7 +572,7 @@ class Upload
         $action = ($file->isNew()) ? 'upload_filedata' : 'edit_file_metadata';
 
         $file->set(array_intersect_key($_POST, array_flip([
-            'title', 'description', 'credit', 'location', 'categories',
+            'title', 'description', 'credit', 'location', 'categories', 'focal_x', 'focal_y',
             'crop_width', 'crop_height', 'crop_x', 'crop_y',
             'rotate', 'resize_width', 'resize_height'
         ])));

--- a/system/ee/ExpressionEngine/Tests/bootstrap.php
+++ b/system/ee/ExpressionEngine/Tests/bootstrap.php
@@ -11,7 +11,7 @@ define('SYSPATH', $project_base);
 define('BASEPATH', SYSPATH . 'ee/legacy/');
 define('PATH_CACHE', SYSPATH . 'user/cache/');
 define('APPPATH', BASEPATH);
-define('APP_VER', '7.5.12');
+define('APP_VER', '7.6.0');
 define('PATH_THEMES', realpath(SYSPATH . '/../themes') . '/');
 define('DOC_URL', 'http://our.doc.url/');
 define('PATH_THIRD', SYSPATH . 'user/addons/');

--- a/system/ee/installer/controllers/wizard.php
+++ b/system/ee/installer/controllers/wizard.php
@@ -13,7 +13,7 @@
  */
 class Wizard extends CI_Controller
 {
-    public $version = '7.5.12'; // The version being installed
+    public $version = '7.6.0'; // The version being installed
     public $installed_version = '';  // The version the user is currently running (assuming they are running EE)
     public $schema = null; // This will contain the schema object with our queries
     public $languages = array(); // Available languages the installer supports (set dynamically based on what is in the "languages" folder)

--- a/system/ee/installer/schema/mysql_schema.php
+++ b/system/ee/installer/schema/mysql_schema.php
@@ -1472,6 +1472,8 @@ class EE_Schema
 			`modified_date` bigint(10) DEFAULT NULL,
 			`file_hw_original` varchar(20) NOT NULL DEFAULT '',
 			`total_records` int(10) unsigned DEFAULT '0',
+			`focal_x` TINYINT(1) unsigned DEFAULT '50',
+			`focal_y` TINYINT(1) unsigned DEFAULT '50',
 			PRIMARY KEY (`file_id`),
 			KEY `model_type` (`model_type`),
 			KEY `upload_location_id` (`upload_location_id`),

--- a/system/ee/installer/updates/ud_7_06_00.php
+++ b/system/ee/installer/updates/ud_7_06_00.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Updater\Version_7_6_0;
+
+/**
+ * Update
+ */
+class Updater
+{
+    public $version_suffix = '';
+
+    /**
+     * Do Update
+     *
+     * @return TRUE
+     */
+    public function do_update()
+    {
+        $steps = new \ProgressIterator(
+            [
+                'addFilesTableColumns'
+            ]
+        );
+
+        foreach ($steps as $k => $v) {
+            $this->$v();
+        }
+
+        return true;
+    }
+
+    private function addFilesTableColumns()
+    {
+        if (! ee()->db->field_exists('focal_x', 'files')) {
+            ee()->smartforge->add_column(
+                'files',
+                [
+                    'focal_x' => [
+                        'type' => 'tinyint',
+                        'constraint' => 1,
+                        'default' => 50,
+                        'unsigned' => true
+                    ]
+                ]
+            );
+        }
+        if (! ee()->db->field_exists('focal_y', 'files')) {
+            ee()->smartforge->add_column(
+                'files',
+                [
+                    'focal_y' => [
+                        'type' => 'tinyint',
+                        'constraint' => 1,
+                        'default' => 50,
+                        'unsigned' => true
+                    ]
+                ]
+            );
+        }
+    }
+}
+
+// EOF

--- a/system/ee/language/english/filemanager_lang.php
+++ b/system/ee/language/english/filemanager_lang.php
@@ -204,6 +204,10 @@ $lang = array(
 
     'check_upload_settings' => 'Check the <a href="%s">settings</a> for this upload directory.',
 
+    'focal_point' => 'Focal Point',
+
+    'focal_point_desc' => 'This is center point to be used when cropping image on front-end. From top left, 0 &mdash; 100 %',
+
     'constraints' => 'Constraints',
 
     'coordiantes_desc' => 'x (horizontal) and y (vertical) axis coordinates to start the crop from.',

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -74,8 +74,8 @@ class EE_Core
 
         // application constants
         define('APP_NAME', 'ExpressionEngine');
-        define('APP_BUILD', '20250514');
-        define('APP_VER', '7.5.12');
+        define('APP_BUILD', '20250518');
+        define('APP_VER', '7.6.0');
         define('APP_VER_ID', '');
         define('SLASH', '&#47;');
         define('LD', '{');

--- a/tests/cypress/support/config/config.php
+++ b/tests/cypress/support/config/config.php
@@ -13,7 +13,7 @@ $config['legacy_member_templates'] = 'y';
 
 $config['log_date_format'] = 'Y-m-d H:i:s';
 $config['log_threshold'] = '1';
-$config['app_version'] = '7.5.12';
+$config['app_version'] = '7.6.0';
 $config['encryption_key'] = '4b9e521eb02751d8466a3e9b764524aff14b91ad';
 $config['session_crypt_key'] = '1f307a8afe66e692c2689508a5d9f783606379a8';
 $config['base_path'] = $_SERVER['DOCUMENT_ROOT'];


### PR DESCRIPTION
Enabled cropping images around selected focal point; #4850

The PR does not include any graphical UI (like a JS library) to select a focal point. Instead, you are just asked to enter the numbers, which is mostly fine I guess.

The focal point is only getting applied to manipulations on front-end with `:crop` modifier; it does not apply to pre-defined manipulation in CP, because those happen purely on the file system, without touching (or asking) the DB

User guide: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/991