### PR TITLE
Show warning banner when editing entry that has recent autosave by other user; #4593

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -285,6 +285,7 @@ abstract class AbstractPublish extends CP_Controller
         }
 
         $currentAutosaveId = null;
+        $loopIndex = 0;
         foreach ($entry->getAutosaves()->filter('channel_id', $entry->channel_id)->sortBy('edit_date')->reverse() as $autosave) {
             if (! isset($authors[$autosave->author_id]) && $autosave->Author) {
                 $authors[$autosave->author_id] = $autosave->Author->getMemberName();
@@ -319,6 +320,21 @@ abstract class AbstractPublish extends CP_Controller
                 )
             );
             $i--;
+
+            if ($loopIndex == 0 && empty($autosave_id)) {
+                if ($autosave->edit_date > (ee()->localize->now - 3600) && $entry->author_id != $autosave->author_id) {
+                    ee('CP/Alert')->makeInline('autosave-warning')
+                        ->asWarning()
+                        ->withTitle(lang('existing_user_autosave'))
+                        ->addToBody(sprintf(
+                            lang('existing_user_autosave_desc'),
+                            isset($authors[$autosave->author_id]) ? $authors[$autosave->author_id] : lang('someone'), 
+                            ee()->localize->human_time($autosave->edit_date, true, true)
+                        ))
+                        ->now();
+                }
+                $loopIndex++;
+            }
         }
 
         if ($autosave_id && ! empty($data) && empty($currentAutosaveId)) {

--- a/system/ee/language/english/content_lang.php
+++ b/system/ee/language/english/content_lang.php
@@ -241,6 +241,10 @@ $lang = array(
 
     'autosaves' => 'Auto Saves',
 
+    'existing_user_autosave' => 'Auto-saved by other user',
+
+    'existing_user_autosave_desc' => 'There is an existing auto save of this entry by %s made on %s. Perhaps they are still editing.',
+
     'blockquote' => 'Blockquote',
 
     'bold' => 'Bold',


### PR DESCRIPTION
Show warning banner when editing entry that has recent autosave by other user; #4593

This alert is show when opening an entry if the latest autosave for it was don by another user within latest hour. This gives a chance that they are still editing it, so we're informing 

![image](https://github.com/user-attachments/assets/c2593232-dd31-4c5a-ae99-fb827898bb6e)

