### PR TITLE
Resolved issue where the file info was not cached

### DIFF
--- a/system/ee/legacy/libraries/File_field.php
+++ b/system/ee/legacy/libraries/File_field.php
@@ -543,7 +543,7 @@ class File_field
 
         // Query for files based on file ID
         if (! empty($file_ids)) {
-            $file_ids = ee()->file_model->get_files_by_id($data)->result_array();
+            $file_ids = ee()->file_model->get_files_by_id($file_ids)->result_array();
         }
 
         // Merge our results into our cached array

--- a/system/ee/legacy/libraries/File_field.php
+++ b/system/ee/legacy/libraries/File_field.php
@@ -543,7 +543,15 @@ class File_field
 
         // Query for files based on file ID
         if (! empty($file_ids)) {
-            $file_ids = ee()->file_model->get_files_by_id($file_ids)->result_array();
+            $files = ee('Model')->get('File')
+                ->with('UploadDestination')
+                ->filter('file_id', 'IN', $file_ids)
+                ->all();
+            $files_as_array = array();
+            foreach ($files as $file) {
+                $files_as_array[] = array_merge($file->toArray(), array('model_object' => $file));
+            }
+            $file_ids = $files_as_array;
         }
 
         // Merge our results into our cached array


### PR DESCRIPTION
This is likely a typo; the code is intended to get the files info (to be cached and reused by parser) based on ID we have pre-parsed before - however the function was receiving different piece of data so this was actually never working if "new" file format is used