### PR TITLE
Resolved #4339 where it was not possible to validate custom field names outside of CP

### DIFF
--- a/system/ee/ExpressionEngine/Config/reserved_field_names.php
+++ b/system/ee/ExpressionEngine/Config/reserved_field_names.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2025, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+/**
+ * Resevrved Field Names
+ *
+ * Reserved keywords that cannot be used as custom field names.
+ * To avoid conflicts with ExpressionEngine's built-in variables, etc.
+ *
+ */
+return array(
+    // channel variables
+    'author',
+    'author_id',
+    'avatar_image_height',
+    'avatar_image_width',
+    'avatar_url',
+    'comment_auto_path',
+    'comment_entry_id_auto_path',
+    'comment_total',
+    'comment_url_title_path',
+    'count',
+    'edit_date',
+    'email',
+    'entry_date',
+    'entry_id',
+    'entry_id_path',
+    'expiration_date',
+    'forum_topic_id',
+    'gmt_edit_date',
+    'gmt_entry_date',
+    'ip_address',
+    'member_search_path',
+    'month',
+    'permalink',
+    'photo_image_height',
+    'photo_image_width',
+    'photo_url',
+    'profile_path',
+    'recent_comment_date',
+    'relative_date',
+    'relative_url',
+    'screen_name',
+    'signature',
+    'signature_image_height',
+    'signature_image_url',
+    'signature_image_width',
+    'status',
+    'switch',
+    'title',
+    'title_permalink',
+    'total_results',
+    'trimmed_url',
+    'url_as_email_as_link',
+    'url_or_email',
+    'url_or_email_as_author',
+    'url_title',
+    'url_title_path',
+    'username',
+    'channel',
+    'channel_id',
+    'year',
+    'content',
+    // global variables
+    'app_version',
+    'captcha',
+    'charset',
+    'current_time',
+    'debug_mode',
+    'elapsed_time',
+    'email',
+    'embed',
+    'encode',
+    'group_description',
+    'group_id',
+    'gzip_mode',
+    'hits',
+    'homepage',
+    'ip_address',
+    'ip_hostname',
+    'lang',
+    'member_group',
+    'member_id',
+    'member_profile_link',
+    'path',
+    'private_messages',
+    'screen_name',
+    'site_index',
+    'site_name',
+    'site_url',
+    'stylesheet',
+    'total_comments',
+    'total_entries',
+    'total_forum_posts',
+    'total_forum_topics',
+    'total_queries',
+    'username',
+    'webmaster_email',
+    'version',
+    // orderby variables
+    'comment_total',
+    'date',
+    'edit_date',
+    'expiration_date',
+    'most_recent_comment',
+    'random',
+    'screen_name',
+    'title',
+    'url_title',
+    'username',
+    'view_count_four',
+    'view_count_one',
+    'view_count_three',
+    'view_count_two',
+    // prefixes
+    'parents',
+    'siblings',
+    'file',
+    // control structures
+    'if',
+    'else',
+    'elseif'
+);
+
+// EOF

--- a/system/ee/ExpressionEngine/Model/Content/FieldModel.php
+++ b/system/ee/ExpressionEngine/Model/Content/FieldModel.php
@@ -564,7 +564,7 @@ abstract class FieldModel extends Model
      */
     public function validateNameIsNotReserved($key, $value, $params, $rule)
     {
-        if (in_array($value, ee()->cp->invalid_custom_field_names())) {
+        if (in_array($value, ee()->config->loadFile('reserved_field_names'))) {
             return lang('reserved_word');
         }
 

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -1052,7 +1052,7 @@ class Cp
             return $invalid_fields;
         }
 
-        return $invalid_fields = array_uninue(ee()->config->loadFile('reserved_field_names'));
+        return $invalid_fields = array_unique(ee()->config->loadFile('reserved_field_names'));
     }
 
     /**

--- a/system/ee/legacy/libraries/Cp.php
+++ b/system/ee/legacy/libraries/Cp.php
@@ -1052,59 +1052,7 @@ class Cp
             return $invalid_fields;
         }
 
-        $channel_vars = array(
-            'author', 'author_id', 'avatar_image_height',
-            'avatar_image_width', 'avatar_url', 'comment_auto_path',
-            'comment_entry_id_auto_path', 'comment_total', 'comment_url_title_path', 'count',
-            'edit_date', 'email', 'entry_date', 'entry_id',
-            'entry_id_path', 'expiration_date', 'forum_topic_id',
-            'gmt_edit_date', 'gmt_entry_date',
-            'ip_address', 'member_search_path', 'month',
-            'permalink', 'photo_image_height',
-            'photo_image_width', 'photo_url', 'profile_path',
-            'recent_comment_date', 'relative_date', 'relative_url',
-            'screen_name', 'signature', 'signature_image_height',
-            'signature_image_url', 'signature_image_width', 'status',
-            'switch', 'title', 'title_permalink', 'total_results',
-            'trimmed_url', 'url_as_email_as_link', 'url_or_email',
-            'url_or_email_as_author', 'url_title', 'url_title_path',
-            'username', 'channel', 'channel_id', 'year', 'content'
-        );
-
-        $global_vars = array(
-            'app_version', 'captcha', 'charset', 'current_time',
-            'debug_mode', 'elapsed_time', 'email', 'embed', 'encode',
-            'group_description', 'group_id', 'gzip_mode', 'hits',
-            'homepage', 'ip_address', 'ip_hostname', 'lang',
-            'member_group', 'member_id', 'member_profile_link', 'path',
-            'private_messages', 'screen_name', 'site_index', 'site_name',
-            'site_url', 'stylesheet', 'total_comments', 'total_entries',
-            'total_forum_posts', 'total_forum_topics', 'total_queries',
-            'username', 'webmaster_email', 'version'
-        );
-
-        $orderby_vars = array(
-            'comment_total', 'date', 'edit_date', 'expiration_date',
-            'most_recent_comment', 'random', 'screen_name', 'title',
-            'url_title', 'username', 'view_count_four', 'view_count_one',
-            'view_count_three', 'view_count_two'
-        );
-
-        $prefixes = array(
-            'parents', 'siblings', 'file'
-        );
-
-        $control_structures = array(
-            'if', 'else', 'elseif'
-        );
-
-        return $invalid_fields = array_unique(array_merge(
-            $channel_vars,
-            $global_vars,
-            $orderby_vars,
-            $prefixes,
-            $control_structures
-        ));
+        return $invalid_fields = array_uninue(ee()->config->loadFile('reserved_field_names'));
     }
 
     /**


### PR DESCRIPTION
Resolved #4339 where it was not possible to validate custom field names outside of CP

Adds `reserved_field_names` config file, which also enabled adding own reserve words

User Guide: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/998

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
