### PR TITLE
Minigrid settings

### DIFF
--- a/themes/ee/asset/javascript/src/cp/grid.js
+++ b/themes/ee/asset/javascript/src/cp/grid.js
@@ -229,7 +229,7 @@ Grid.Publish.prototype = Grid.MiniField.prototype = {
 		var rowsCount = this._getRows().length,
 			neededRows = 0;
 
-		if (typeof(this.settings) !== 'undefined' && typeof(this.settings.grid_min_rows) !== 'undefined')
+		if (typeof(this.settings.grid_min_rows) !== 'undefined')
 		{
 			neededRows = this.settings.grid_min_rows - rowsCount;
 		}

--- a/themes/ee/asset/javascript/src/cp/grid.js
+++ b/themes/ee/asset/javascript/src/cp/grid.js
@@ -229,7 +229,7 @@ Grid.Publish.prototype = Grid.MiniField.prototype = {
 		var rowsCount = this._getRows().length,
 			neededRows = 0;
 
-		if (typeof(this.settings)!=='undefined')
+		if (typeof(this.settings) !== 'undefined' && typeof(this.settings.grid_min_rows) !== 'undefined')
 		{
 			neededRows = this.settings.grid_min_rows - rowsCount;
 		}

--- a/themes/ee/asset/javascript/src/cp/grid.js
+++ b/themes/ee/asset/javascript/src/cp/grid.js
@@ -229,7 +229,7 @@ Grid.Publish.prototype = Grid.MiniField.prototype = {
 		var rowsCount = this._getRows().length,
 			neededRows = 0;
 
-		if (typeof(this.settings.grid_min_rows) !== 'undefined')
+		if (typeof(this.settings)!=='undefined' && typeof(this.settings.grid_min_rows) !== 'undefined')
 		{
 			neededRows = this.settings.grid_min_rows - rowsCount;
 		}

--- a/themes/ee/asset/javascript/src/cp/grid.js
+++ b/themes/ee/asset/javascript/src/cp/grid.js
@@ -1080,7 +1080,7 @@ $(document).ready(function () {
 	});
 });
 
-function checkGrigWidthForResize() {
+function checkGridWidthForResize() {
 	var gridTables = $('.grid-field:not(.horizontal-layout)');
 
 	gridTables.each(function(el) {
@@ -1106,7 +1106,7 @@ function checkGrigWidthForResize() {
 	});
 }
 
-function checkGrigWidth() {
+function checkGridWidth() {
 	var gridTables = $('.grid-field:not(.horizontal-layout)');
 
 	gridTables.each(function(el) {
@@ -1146,11 +1146,11 @@ function addHorizontalClassToFluid() {
 
 $(window).on('load', function() {
 	addHorizontalClassToFluid();
-	checkGrigWidth();
+	checkGridWidth();
 });
 
 $(window).on('resize', function() {
-	checkGrigWidthForResize();
+	checkGridWidthForResize();
 });
 
 })(jQuery);


### PR DESCRIPTION
Fixed issue where if minigrid settings was missing `grid_min_rows`, it would calculate `neededRows` to `NaN` and would cause the initial "Add" button to not appear.

This also fixes a typo with 2 function names: Grig -> Grid