### PR TITLE
Fix file category assignments if the file is in an upload location shared across MSM sites

### DIFF
--- a/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
+++ b/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
@@ -536,11 +536,9 @@ class FileSystemEntity extends ContentModel
             if (array_key_exists('cat_group_id_' . $cat_group, $categories)) {
                 $group_cats = $categories['cat_group_id_' . $cat_group];
 
-                $cats = implode('|', $group_cats);
-
                 $group_cat_objects = $this->getModelFacade()
                     ->get('Category')
-                    ->filter('site_id', ee()->config->item('site_id'))
+                    ->filter('site_id', 'IN', [0, ee()->config->item('site_id')])
                     ->filter('cat_id', 'IN', $group_cats)
                     ->all();
 


### PR DESCRIPTION
When editing categories on a file that is in an upload location that has the "Share Upload Directory on all sites?" option enabled, the category assignments will not stick. This query fails because the file actually has a site_id value of 0.

Also removed unused $cats variable.
