### PR TITLE
Make credit, description, and location fields searchable in Files

### DIFF
--- a/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
+++ b/system/ee/ExpressionEngine/Library/CP/FileManager/Traits/FileManagerTrait.php
@@ -15,6 +15,15 @@ use ExpressionEngine\Library\CP\FileManager\ColumnFactory;
 
 trait FileManagerTrait
 {
+    protected $searchableFields = [
+        'credit',
+        'description',
+        'file_name',
+        'location',
+        'mime_type',
+        'title',
+    ];
+
     protected function listingsPage($uploadLocation = null, $view_type = 'list', $filepickerMode = false)
     {
         $vars = array();
@@ -126,7 +135,7 @@ trait FileManagerTrait
         $search_terms = ee()->input->get_post('filter_by_keyword');
 
         if ($search_terms) {
-            $files->search(['title', 'file_name', 'mime_type'], $search_terms);
+            $files->search($this->searchableFields, $search_terms);
             $vars['search_terms'] = htmlentities($search_terms, ENT_QUOTES, 'UTF-8');
             $needToFilterFiles = true;
         }


### PR DESCRIPTION
Related discussion: https://github.com/ExpressionEngine/ExpressionEngine/discussions/4924

Seems like an oversight to not have these fields be searchable? The description field could likely return more relevant results than the title or file_name, which in some cases might be numerically numbered files, or contain file names that just don't contain any descriptors.