### PR TITLE
Resolved an issue where base_path and theme_path could be incorrectly set when installed with system folder above web root

### DIFF
--- a/system/ee/installer/controllers/wizard.php
+++ b/system/ee/installer/controllers/wizard.php
@@ -231,7 +231,12 @@ class Wizard extends CI_Controller
         $this->load->add_theme_cascade(APPPATH . 'views/');
 
         // First try the current directory, if they are running the system with an admin.php file
-        $this->base_path = substr($_SERVER['SCRIPT_FILENAME'], 0, -strlen(EESELF));
+        if (strpos($_SERVER['SCRIPT_FILENAME'], EESELF) !== false) {
+            $this->base_path = substr($_SERVER['SCRIPT_FILENAME'], 0, -strlen(EESELF));
+        } else {
+            $this->base_path = realpath(SYSPATH . '/../');
+        }
+        $this->base_path = rtrim($this->base_path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
 
         if (is_dir($this->base_path . 'themes')) {
             $this->theme_path = $this->base_path . 'themes/';


### PR DESCRIPTION
This could possibly be related to #4458 though I wasn't seeing the behavior reported there.