### PR TITLE
Remove extra revision from Revisions table

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -184,10 +184,10 @@ abstract class AbstractPublish extends CP_Controller
             if ($index === 0) {
                 $toolbar_items['current-revision'] = array(
                     'button' => false,
-                    'html_tag' => 'span',
+                    'href' => ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id),
                     'class' => 'st-open',
                     'content' => lang('current'),
-                    'style' => 'margin-left: 2px',
+                    'style' => 'margin-left: 4px',
                 );
             }
 

--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -160,11 +160,10 @@ abstract class AbstractPublish extends CP_Controller
 
         $data = array();
         $authors = array();
-        $i = $entry->Versions->count();
+        $count = $entry->Versions->count();
         $current_author_id = false;
-        $current_id = $i + 1;
 
-        foreach ($entry->Versions->sortBy('version_date')->reverse() as $version) {
+        foreach ($entry->Versions->sortBy('version_date')->reverse() as $index => $version) {
             if (! isset($authors[$version->author_id])) {
                 $authors[$version->author_id] = $version->getAuthorName();
             }
@@ -173,52 +172,44 @@ abstract class AbstractPublish extends CP_Controller
                 $current_author_id = $authors[$version->author_id];
             }
 
-            $toolbar = ee('View')->make('_shared/toolbar')->render(
-                array(
-                    'toolbar_items' => array(
-                        'txt-only' => array(
-                            'href' => ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id, array('version' => $version->version_id)),
-                            'title' => lang('load_revision'),
-                            'content' => lang('view')
-                        ),
-                    )
+            $toolbar_items = array(
+                'txt-only' => array(
+                    'href' => ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id, array('version' => $version->version_id)),
+                    'title' => lang('load_revision'),
+                    'content' => lang('view')
                 )
             );
 
-            $attrs = ($version->version_id == $version_id) ? array('class' => 'selected') : array();
+            // add the Current tag to the first revision
+            if ($index === 0) {
+                $toolbar_items['current-revision'] = array(
+                    'button' => false,
+                    'html_tag' => 'span',
+                    'class' => 'st-open',
+                    'content' => lang('current'),
+                    'style' => 'margin-left: 2px',
+                );
+            }
+
+            $toolbar = ee('View')->make('_shared/toolbar')->render(
+                array(
+                    'toolbar_items' => $toolbar_items
+                )
+            );
+
+            $attrs = [];
+            if (($version_id === false && $index === 0) || $version->version_id == $version_id) {
+                $attrs['class'] = 'selected';
+            }
 
             $data[] = array(
                 'attrs' => $attrs,
                 'columns' => array(
-                    $i,
+                    $count - $index,
                     ee()->localize->human_time($version->version_date->format('U'), true, true),
                     $authors[$version->author_id],
                     $toolbar
                 )
-            );
-            $i--;
-        }
-
-        if (! $entry->isNew()) {
-            $attrs = (!$version_id) ? array('class' => 'selected') : array();
-
-            $current_author_id = (!$current_author_id) ? $entry->getAuthorName() : $current_author_id;
-
-            // Current
-            $edit_date = ($entry->edit_date)
-                ? ee()->localize->human_time($entry->edit_date->format('U'), true, true)
-                : null;
-
-            array_unshift(
-                $data,
-                array(
-                    'attrs' => $attrs,
-                    'columns' => array(
-                        $current_id,
-                        $edit_date,
-                        $current_author_id,
-                        '<a href="' . ee('CP/URL')->make('publish/edit/entry/' . $entry->entry_id) . '"><span class="st-open">' . lang('current') . '</span></a>'
-                    ))
             );
         }
 

--- a/system/ee/ExpressionEngine/View/_shared/toolbar.php
+++ b/system/ee/ExpressionEngine/View/_shared/toolbar.php
@@ -68,13 +68,8 @@
                     if (isset($attributes['button']) && $attributes['button'] === false) {
                         $button_classes = '';
                     }
-
-                    $html_tag = 'a';
-                    if (isset($attributes['html_tag'])) {
-                        $html_tag = $attributes['html_tag'];
-                    }
                     ?>
-                    <<?=$html_tag?> class="<?=$class?> <?=$button_classes?>" <?=$attr?>><?=$content?></<?=$html_tag?>>
+                    <a class="<?=$class?> <?=$button_classes?>" <?=$attr?>><?=$content?></a>
                 <?php endforeach ?>
           </div>
         </div>

--- a/system/ee/ExpressionEngine/View/_shared/toolbar.php
+++ b/system/ee/ExpressionEngine/View/_shared/toolbar.php
@@ -63,8 +63,18 @@
                     if (isset($attributes['title'])) {
                         $content .= '<span class="hidden">' . $attributes['title'] . '</span>';
                     }
+
+                    $button_classes = 'button button--default';
+                    if (isset($attributes['button']) && $attributes['button'] === false) {
+                        $button_classes = '';
+                    }
+
+                    $html_tag = 'a';
+                    if (isset($attributes['html_tag'])) {
+                        $html_tag = $attributes['html_tag'];
+                    }
                     ?>
-                    <a class="<?=$class?> button button--default" <?=$attr?>><?=$content?></a>
+                    <<?=$html_tag?> class="<?=$class?> <?=$button_classes?>" <?=$attr?>><?=$content?></<?=$html_tag?>>
                 <?php endforeach ?>
           </div>
         </div>


### PR DESCRIPTION
This PR removes the the first "dummy" row in the revisions table and adds the "Current" tag to the top revision to indicate that it's the most recent content. This also updates some toolbar config options to allow adding an inline "Current" tag.

This is something that's always been confusing to me, because it adds an extra "revision" to the top, so the table view didn't match the database contents in the `entry_versioning` table.

### After creating a new entry

Previous functionality:
<img width="1840" height="1132" alt="image" src="https://github.com/user-attachments/assets/168e6eff-c9d9-4a4a-8fb4-633c47eabb17" />

New functionality:
<img width="1840" height="1132" alt="image" src="https://github.com/user-attachments/assets/e713aa56-39df-403d-a131-0499039eefde" />

### After creating a new entry (not viewing a specific revision)

Previous functionality:
<img width="1840" height="1132" alt="image" src="https://github.com/user-attachments/assets/e79407ab-1b4e-4fb6-829f-e142b010bb0c" />

New functionality:
<img width="1840" height="1132" alt="image" src="https://github.com/user-attachments/assets/0bad8006-814e-44cf-8577-43cf63bcfbd6" />

### Viewing a previous revision

Previous functionality:
<img width="1840" height="1132" alt="image" src="https://github.com/user-attachments/assets/4b353a96-1c0d-441c-9e8f-77d96bad50bd" />

New functionality:
<img width="1840" height="1132" alt="image" src="https://github.com/user-attachments/assets/40258afd-361a-4168-b5ea-511935914648" />
