### PR TITLE
Add the backspace param to entries tag

### DIFF
--- a/system/ee/ExpressionEngine/Addons/comment/mod.comment.php
+++ b/system/ee/ExpressionEngine/Addons/comment/mod.comment.php
@@ -551,6 +551,10 @@ class Comment
             }
             $return .= ee()->TMPL->parse_variables_row($tagdata, $variables);
         }
+		
+        if (!empty(ee()->TMPL->fetch_param('backspace'))) {
+            $return = substr($return, 0, - (int) ee()->TMPL->fetch_param('backspace'));
+        }		
 
         if ($enabled['pagination']) {
             return $pagination->render($return);


### PR DESCRIPTION
I really thought this already existed.  It... did not.

Docs pr: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1050

