### PR TITLE
Resolved #4900 where `maxlength` for text field in Channel Form could have been set to 0

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/libraries/channel_form/Channel_form_lib.php
+++ b/system/ee/ExpressionEngine/Addons/channel/libraries/channel_form/Channel_form_lib.php
@@ -1040,7 +1040,7 @@ GRID_FALLBACK;
                 'text_direction' => $field->getSetting('field_text_direction'),
                 'field_data' => $this->entry($field->getName()),
                 'rows' => $field->getSetting('field_ta_rows'),
-                'maxlength' => $field->getSetting('field_maxl'),
+                'maxlength' => $field->getSetting('field_maxl') ?: '',
                 'formatting_buttons' => '',
                 'field_show_formatting_btns' => ($field->getSetting('field_show_formatting_btns') == 'y') ? 1 : 0,
                 'textinput' => 0,


### PR DESCRIPTION
Resolved #4900 where `maxlength` for text field in Channel Form could have been set to 0