### PR TITLE
Fixed default HTML buttons

### DIFF
--- a/build-tools/build.json
+++ b/build-tools/build.json
@@ -1,5 +1,5 @@
 {
-    "tag": "7.5.16",
+    "tag": "7.5.17",
 
     "repositories": {
         "app": "git@github.com:ExpressionEngine/ExpressionEngine",

--- a/cp-styles/app/styles/vendor/_markItUp.scss
+++ b/cp-styles/app/styles/vendor/_markItUp.scss
@@ -63,9 +63,11 @@
   display: inline-block;
 	position:relative;
 }
+
 .markItUpHeader ul li:hover > ul{
 	display:block;
 }
+.markItUpHeader ul li a i { font-weight: 400;}
 .markItUpHeader ul .markItUpDropMenu {
 	background:transparent url(images/menu.png) no-repeat 115% 50%;
 	margin-right:5px;
@@ -169,7 +171,8 @@
     content: fa-content($fa-var-list-ol);
   }
 }
-.markItUp .html-underline a {
+.markItUp .html-underline a, 
+.markItUp .html-ins a {
   &:before{
     content: fa-content($fa-var-underline);
   }

--- a/system/ee/ExpressionEngine/Controller/Members/Profile/Buttons.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Profile/Buttons.php
@@ -295,13 +295,15 @@ class Buttons extends Settings
      */
     private function form($vars, $values = array())
     {
+        $specialButtons = ['html-bold','html-italic','html-order-list','html-list','html-link','html-upload','html-quote','html-strike','html-ins'];
         $name = isset($values['tag_name']) ? $values['tag_name'] : '';
         $open = isset($values['tag_open']) ? $values['tag_open'] : '';
         $close = isset($values['tag_close']) ? $values['tag_close'] : '';
         $shortcut = isset($values['accesskey']) ? $values['accesskey'] : '';
         $class = isset($values['classname']) ? $values['classname'] : '';
         $readonly = isset($values['classname']) && $values['classname'] == 'html-upload' ? true : false;
-        $icon = isset($values['icon']) ? $values['icon'] : '';
+        $icon = isset($values['tag_icon']) ? $values['tag_icon'] : '';
+        $readonly_icon = in_array(isset($values['classname']) && $values['classname'], $specialButtons);
 
         $vars['sections'] = array(
             array(
@@ -337,7 +339,7 @@ class Buttons extends Settings
                     'title' => 'tag_icon',
                     'desc' => 'tag_icon_desc',
                     'fields' => array(
-                        'tag_icon' => array('type' => 'text', 'value' => $icon, 'attrs' => ($readonly ? 'readonly="readonly"' : ''))
+                        'tag_icon' => array('type' => 'text', 'value' => $icon, 'attrs' => ($readonly_icon ? 'readonly="readonly"' : ''))
                     )
                 )
 

--- a/system/ee/ExpressionEngine/Controller/Members/Profile/Buttons.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Profile/Buttons.php
@@ -301,6 +301,7 @@ class Buttons extends Settings
         $shortcut = isset($values['accesskey']) ? $values['accesskey'] : '';
         $class = isset($values['classname']) ? $values['classname'] : '';
         $readonly = isset($values['classname']) && $values['classname'] == 'html-upload' ? true : false;
+        $icon = isset($values['icon']) ? $values['icon'] : '';
 
         $vars['sections'] = array(
             array(
@@ -331,7 +332,15 @@ class Buttons extends Settings
                         'accesskey' => array('type' => 'text', 'value' => $shortcut, 'attrs' => ($readonly ? 'readonly="readonly"' : '')),
                         'classname' => array('type' => 'hidden', 'value' => $class)
                     )
+                ),
+                array(
+                    'title' => 'tag_icon',
+                    'desc' => 'tag_icon_desc',
+                    'fields' => array(
+                        'tag_icon' => array('type' => 'text', 'value' => $icon, 'attrs' => ($readonly ? 'readonly="readonly"' : ''))
+                    )
                 )
+
             )
         );
 

--- a/system/ee/ExpressionEngine/Controller/Settings/Buttons.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Buttons.php
@@ -65,6 +65,7 @@ class Buttons extends Settings
                     'content' => $name . form_hidden('order[]', $button->id)
                 )
             ));
+
             $toolbar = array('toolbar_items' => array(
                 'edit' => array(
                     'href' => ee('CP/URL')->make('settings/buttons/edit/' . $button->id),
@@ -289,12 +290,24 @@ class Buttons extends Settings
      */
     private function form($vars, $values = array())
     {
+        $specialButtons = [
+            'html-bold',
+            'html-italic',
+            'html-order-list',
+            'html-list',
+            'html-link',
+            'html-upload',
+            'html-quote',
+            'html-strike',
+            'html-ins'
+        ];
         $name = isset($values['tag_name']) ? $values['tag_name'] : '';
         $open = isset($values['tag_open']) ? $values['tag_open'] : '';
         $close = isset($values['tag_close']) ? $values['tag_close'] : '';
         $shortcut = isset($values['accesskey']) ? $values['accesskey'] : '';
         $readonly = isset($values['classname']) && $values['classname'] == 'html-upload' ? true : false;
-        $icon = isset($values['icon']) ? $values['icon'] : '';
+        $icon = isset($values['tag_icon']) ? $values['tag_icon'] : '';
+        $readonly_icon = in_array(isset($values['classname']) && $values['classname'], $specialButtons);
 
         $vars['sections'] = array(
             array(
@@ -329,7 +342,7 @@ class Buttons extends Settings
                     'title' => 'tag_icon',
                     'desc' => 'tag_icon_desc',
                     'fields' => array(
-                        'tag_icon' => array('type' => 'text', 'value' => $icon, 'attrs' => ($readonly ? 'readonly="readonly"' : ''))
+                        'tag_icon' => array('type' => 'text', 'value' => $icon, 'attrs' => ($readonly_icon ? 'readonly="readonly"' : ''))
                     )
                 )
             )

--- a/system/ee/ExpressionEngine/Controller/Settings/Buttons.php
+++ b/system/ee/ExpressionEngine/Controller/Settings/Buttons.php
@@ -294,6 +294,7 @@ class Buttons extends Settings
         $close = isset($values['tag_close']) ? $values['tag_close'] : '';
         $shortcut = isset($values['accesskey']) ? $values['accesskey'] : '';
         $readonly = isset($values['classname']) && $values['classname'] == 'html-upload' ? true : false;
+        $icon = isset($values['icon']) ? $values['icon'] : '';
 
         $vars['sections'] = array(
             array(
@@ -322,6 +323,13 @@ class Buttons extends Settings
                     'desc' => 'accesskey_desc',
                     'fields' => array(
                         'accesskey' => array('type' => 'text', 'value' => $shortcut, 'attrs' => ($readonly ? 'readonly="readonly"' : ''))
+                    )
+                ),
+                array(
+                    'title' => 'tag_icon',
+                    'desc' => 'tag_icon_desc',
+                    'fields' => array(
+                        'tag_icon' => array('type' => 'text', 'value' => $icon, 'attrs' => ($readonly ? 'readonly="readonly"' : ''))
                     )
                 )
             )

--- a/system/ee/ExpressionEngine/Model/Member/HTMLButton.php
+++ b/system/ee/ExpressionEngine/Model/Member/HTMLButton.php
@@ -43,6 +43,7 @@ class HTMLButton extends Model
         'tag_close' => 'required',
         'accesskey' => 'required',
         'tag_order' => 'required|isNatural',
+        'tag_icon' => 'required'
     );
 
     // Properties
@@ -56,6 +57,7 @@ class HTMLButton extends Model
     protected $tag_order;
     protected $tag_row;
     protected $classname;
+    protected $tag_icon;
 
     public function prepForJSON()
     {
@@ -68,7 +70,8 @@ class HTMLButton extends Model
                 'key' => strtoupper($this->accesskey),
                 'openWith' => $this->tag_open,
                 'closeWith' => $this->tag_close,
-                'className' => $this->classname . ' id' . $this->id
+                'className' => $this->classname . ' id' . $this->id,
+                'icon' => $this->tag_icon,
             );
         }
 

--- a/system/ee/ExpressionEngine/Tests/bootstrap.php
+++ b/system/ee/ExpressionEngine/Tests/bootstrap.php
@@ -11,7 +11,7 @@ define('SYSPATH', $project_base);
 define('BASEPATH', SYSPATH . 'ee/legacy/');
 define('PATH_CACHE', SYSPATH . 'user/cache/');
 define('APPPATH', BASEPATH);
-define('APP_VER', '7.5.16');
+define('APP_VER', '7.5.17');
 define('PATH_THEMES', realpath(SYSPATH . '/../themes') . '/');
 define('DOC_URL', 'http://our.doc.url/');
 define('PATH_THIRD', SYSPATH . 'user/addons/');

--- a/system/ee/installer/controllers/wizard.php
+++ b/system/ee/installer/controllers/wizard.php
@@ -13,7 +13,7 @@
  */
 class Wizard extends CI_Controller
 {
-    public $version = '7.5.16'; // The version being installed
+    public $version = '7.5.17'; // The version being installed
     public $installed_version = '';  // The version the user is currently running (assuming they are running EE)
     public $schema = null; // This will contain the schema object with our queries
     public $languages = array(); // Available languages the installer supports (set dynamically based on what is in the "languages" folder)

--- a/system/ee/installer/updates/ud_7_05_17.php
+++ b/system/ee/installer/updates/ud_7_05_17.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Updater\Version_7_5_17;
+
+/**
+ * Update
+ */
+class Updater
+{
+    public $version_suffix = '';
+
+    /**
+     * Do Update
+     *
+     * @return TRUE
+     */
+    public function do_update()
+    {
+        $steps = new \ProgressIterator(
+            [
+                'addHtmlButtonsTagIcon'
+            ]
+        );
+
+        foreach ($steps as $k => $v) {
+            $this->$v();
+        }
+
+        return true;
+    }
+
+    private function addHtmlButtonsTagIcon()
+    {
+        if (!ee()->db->field_exists('tag_icon', 'html_buttons')) {
+            ee()->smartforge->add_column(
+                'html_buttons',
+                [
+                    'tag_icon' => [
+                        'type' => 'varchar',
+                        'constraint' => 254,
+                        'default' => null,
+                        'null' => true
+                    ]
+                ]
+            );
+        }
+    }
+}
+
+// EOF

--- a/system/ee/language/english/admin_content_lang.php
+++ b/system/ee/language/english/admin_content_lang.php
@@ -458,6 +458,10 @@ $lang = array(
 
     'tag_close_desc' => 'Closing output of this button. i.e. <b><code>&lt;/b&gt;</code></b>',
 
+    'tag_icon' => 'Tag Icon',
+
+    'tag_icon_desc' => 'Add your custom Font Awesome 6 Pro icon. Insert it as HTML using the <i> tag with classes. i.e. &lt;i class="fa-solid fa-newspaper"&gt;&lt;/i&gt;',
+
     'tag_name' => 'Name',
 
     'tag_open' => 'Opening Tag',

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -74,8 +74,8 @@ class EE_Core
 
         // application constants
         define('APP_NAME', 'ExpressionEngine');
-        define('APP_BUILD', '20250909');
-        define('APP_VER', '7.5.16');
+        define('APP_BUILD', '20250912');
+        define('APP_VER', '7.5.17');
         define('APP_VER_ID', '');
         define('SLASH', '&#47;');
         define('LD', '{');

--- a/tests/cypress/support/config/config.php
+++ b/tests/cypress/support/config/config.php
@@ -13,7 +13,7 @@ $config['legacy_member_templates'] = 'y';
 
 $config['log_date_format'] = 'Y-m-d H:i:s';
 $config['log_threshold'] = '1';
-$config['app_version'] = '7.5.16';
+$config['app_version'] = '7.5.17';
 $config['encryption_key'] = '4b9e521eb02751d8466a3e9b764524aff14b91ad';
 $config['session_crypt_key'] = '1f307a8afe66e692c2689508a5d9f783606379a8';
 $config['base_path'] = $_SERVER['DOCUMENT_ROOT'];

--- a/themes/ee/asset/javascript/src/jquery/plugins/markitup.js
+++ b/themes/ee/asset/javascript/src/jquery/plugins/markitup.js
@@ -80,6 +80,8 @@
 			'html-link',
 			'html-upload',
 			'html-quote',
+			'html-strike',
+			'html-ins'
 		];
 
 		options = {	id:						'',
@@ -213,6 +215,8 @@
 
 						if (specialButtons.indexOf(button.className.split(' ')[0]) > -1) {
 							name = '';
+						} else if (button.icon) {
+							name = button.icon || '';
 						} else {
 							name = button.name||'';
 						}

--- a/themes/ee/cp/css/common.min.css
+++ b/themes/ee/cp/css/common.min.css
@@ -21251,6 +21251,10 @@ body[data-theme=dark] .hljs .apache .hljs-attribute {
   display: block;
 }
 
+.markItUpHeader ul li a i {
+  font-weight: 400;
+}
+
 .markItUpHeader ul .markItUpDropMenu {
   background: transparent url(images/menu.png) no-repeat 115% 50%;
   margin-right: 5px;
@@ -21350,7 +21354,8 @@ body[data-theme=dark] .hljs .apache .hljs-attribute {
   content: "\f0cb";
 }
 
-.markItUp .html-underline a:before {
+.markItUp .html-underline a:before,
+.markItUp .html-ins a:before {
   content: "\f0cd";
 }
 


### PR DESCRIPTION
**Request** from 10.09.2025 (general chat)
<img width="624" height="329" alt="Screenshot 2025-09-14 at 10 03 18" src="https://github.com/user-attachments/assets/73ff8dbf-b263-4bd1-b618-6749ca4d0f35" />

**Changes**:
1. Hide text for default HTML buttons.
<img width="1167" height="169" alt="Screenshot 2025-09-14 at 10 06 04" src="https://github.com/user-attachments/assets/c4492436-2bb3-4328-ab95-303d95a9a9f7" />
2. Added field for New HTML button for adding custom font Awesome icon (optional)

<img width="916" height="651" alt="Screenshot 2025-09-14 at 10 07 06" src="https://github.com/user-attachments/assets/ff80be1c-fa51-48f2-ba09-0a92de80be60" />
3. use this icon instead of text (if icon is present) or button title (if icon field is empty)
<img width="745" height="166" alt="Screenshot 2025-09-14 at 10 08 31" src="https://github.com/user-attachments/assets/210b1e63-2614-4281-8c40-c52f11b5dc40" />
