### PR TITLE
Hide the text and show inly icons for default HTML buttons

### DIFF
--- a/cp-styles/app/styles/vendor/_markItUp.scss
+++ b/cp-styles/app/styles/vendor/_markItUp.scss
@@ -169,7 +169,8 @@
     content: fa-content($fa-var-list-ol);
   }
 }
-.markItUp .html-underline a {
+.markItUp .html-underline a,
+.markItUp .html-ins a {
   &:before{
     content: fa-content($fa-var-underline);
   }

--- a/themes/ee/asset/javascript/src/jquery/plugins/markitup.js
+++ b/themes/ee/asset/javascript/src/jquery/plugins/markitup.js
@@ -80,6 +80,8 @@
 			'html-link',
 			'html-upload',
 			'html-quote',
+			'html-strike',
+			'html-ins'
 		];
 
 		options = {	id:						'',

--- a/themes/ee/cp/css/common.min.css
+++ b/themes/ee/cp/css/common.min.css
@@ -21350,7 +21350,8 @@ body[data-theme=dark] .hljs .apache .hljs-attribute {
   content: "\f0cb";
 }
 
-.markItUp .html-underline a:before {
+.markItUp .html-underline a:before,
+.markItUp .html-ins a:before {
   content: "\f0cd";
 }
 


### PR DESCRIPTION
Request from 10.09.2025 (general chat):

<img width="639" height="319" alt="Screenshot 2025-09-15 at 20 40 34" src="https://github.com/user-attachments/assets/bc95ae49-aa0e-48a5-bf8f-21c395a5398a" />

Changes:
Hide text for default HTML buttons.
<img width="680" height="120" alt="Screenshot 2025-09-15 at 20 41 24" src="https://github.com/user-attachments/assets/08638054-f42d-4064-8b0b-b52aeb61f20f" />
