### PR TITLE
Fixed #4979 where Live preview button does not trigger when you close preview

### DIFF
--- a/themes/ee/asset/javascript/src/cp/publish/publish.js
+++ b/themes/ee/asset/javascript/src/cp/publish/publish.js
@@ -258,7 +258,7 @@ $(document).ready(function () {
 		// Show the save buttons
 		$('[data-publish] .tab-bar__right-buttons').show()
 
-		$('button[rel="live-preview"]').show();
+		$('button[rel="live-preview"]').removeAttr('style').show();
 		$(document).trigger('entry:preview-close')
 
 		// Hide the live preview modal


### PR DESCRIPTION
Fixed #4979 where Live preview button does not trigger when you close preview