### PR TITLE
Ability to add headers to ajax response. #4973

### DIFF
--- a/system/ee/legacy/core/Output.php
+++ b/system/ee/legacy/core/Output.php
@@ -791,6 +791,13 @@ class EE_Output
             header("Content-Type: application/json; charset=" . ee()->config->item('charset'));
         }
 
+        // Are there any server headers to send?
+        if (count($this->headers) > 0) {
+            foreach ($this->headers as $header) {
+                @header($header[0], $header[1]);
+            }
+        }
+
         exit(json_encode($msg));
     }
 


### PR DESCRIPTION
Addresses: [#4973](#4973)

Ability to set headers on Ajax responses(`send_ajax_response` as per `_display`)

Example:
```
ee()->output->set_header("Cache-Control: public, max-age={$max_age}");
ee()->output->set_header('Expires: ' . $expires);
ee()->output->send_ajax_response($data);
```
