### PR TITLE
Fixed a bug where using entry_status in comment form threw php error

### DIFF
--- a/system/ee/ExpressionEngine/Addons/comment/mod.comment.php
+++ b/system/ee/ExpressionEngine/Addons/comment/mod.comment.php
@@ -734,12 +734,13 @@ class Comment
         if ($e_status = ee()->TMPL->fetch_param('entry_status')) {
             $e_status = str_replace('Open', 'open', $e_status);
             $e_status = str_replace('Closed', 'closed', $e_status);
-
-            ee()->functions->ar_andor_string($e_status, 'status');
-
-            if (stristr($sql, "'closed'") === false) {
+			
+            // If they don't specify closed, it defaults to it
+            if (! in_array('closed', explode('|', $e_status))) {
                 ee()->db->where('status !=', 'closed');
             }
+
+            ee()->functions->ar_andor_string($e_status, 'status');			
         } else {
             ee()->db->where('status !=', 'closed');
         }


### PR DESCRIPTION
The parameter isn't currently documented for the comment form, but code was there but a bit broken.  Fixing both issues.

Doc additions pr: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1069

