### PR TITLE
Resolved #4989 where PHP error could be shown if same `:resize_crop` code is reused

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -476,8 +476,6 @@ JSC;
 
         $out = $this->process_image('crop', $data, $params, $tagdata);
 
-        @unlink($resized);
-
         return $out;
     }
 


### PR DESCRIPTION
Resolved #4989 where PHP error could be shown if same `:resize_crop` code is reused