### PR TITLE
Refactor drag-and-drop view for "Select Entries" (Pro Variable) to use Relationship field

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro_variables/css/pro_variables.css
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/css/pro_variables.css
@@ -247,12 +247,14 @@
     cursor:grab;
     -webkit-border-radius:3px;
     -moz-border-radius:3px;
-    border-radius:3px
+    border-radius:3px;
+    color: var(--ee-text-primary);
+    font-size: 14px;
 }
 
 .pro-drag-lists ul li:hover {
-    background:#eee;
-    color:#000
+    background:var(--ee-sidebar-bg-active);
+    color:var(--ee-sidebar-text-active);
 }
 
 .pro-drag-lists li.ui-sortable-helper {
@@ -286,6 +288,7 @@
     background:#fff;
     vertical-align:middle;
     margin-right:5px;
+    max-width: 50px;
 
     -webkit-border-radius:3px;
     -moz-border-radius:3px;

--- a/system/ee/ExpressionEngine/Addons/pro_variables/mcp.pro_variables.php
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/mcp.pro_variables.php
@@ -594,6 +594,7 @@ class Pro_variables_mcp
         // --------------------------------------
 
         ee()->cp->add_js_script('file', 'cp/confirm_remove');
+
         ee()->javascript->set_global('lang.remove_confirm', '### ' . lang('variables'));
 
         // -------------------------------------
@@ -2238,9 +2239,19 @@ class Pro_variables_mcp
         // -------------------------------------
 
         $version = '&amp;lv=' . (static::DEBUG ? time() : $this->version);
-
+        ee()->lang->loadfile('fieldtypes');
         ee()->cp->add_js_script('plugin', 'ui.touch.punch');
         ee()->cp->add_js_script('ui', 'sortable');
+        ee()->cp->add_js_script(array(
+            'file' => [
+                'fields/relationship/settings',
+                'vendor/react/react.min',
+                'vendor/react/react-dom.min',
+                'components/relationship',
+                'components/dropdown_button',
+                'components/select_list'
+            ],
+        ));
 
         ee()->cp->load_package_css($this->package . $version);
         ee()->cp->load_package_js($this->package . $version);

--- a/system/ee/ExpressionEngine/Addons/pro_variables/types/pro_select_entries/vt.pro_select_entries.php
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/types/pro_select_entries/vt.pro_select_entries.php
@@ -305,19 +305,118 @@ class Pro_select_entries extends Pro_variables_type
                 )
             );
         } else {
-            //  Multiple choice
-            $data = array(
-                'name' => $this->input_name(),
-                'choices' => $choices,
-                'value' => PVUI::explode($this->settings('separator'), $var_data),
-                'multiple' => true
-            );
+            if ($this->settings('multi_interface') == 'drag-list') {
+                $ids = str_replace('Array', '', $var_data);
+                $ids = array_map('intval', preg_split('/\s+/', trim($ids)));
+
+                $entries = ee('Model')
+                    ->get('ChannelEntry')
+                    ->filter('entry_id', 'IN', $ids)
+                    ->all()
+                    ->indexBy('entry_id');
+
+                $channels = ee('Model')
+                    ->get('Channel')
+                    ->filter('site_id', ee()->config->item('site_id'))
+                    ->order('channel_title')
+                    ->all();
+
+                $selected = [];
+                $items = [];
+                $channels_arr = [];
+                $allowed_channels = array_filter($this->settings('channels'));
+
+                foreach ($ids as $id) {
+                    if (isset($entries[$id])) {
+                        $entry = $entries[$id];
+                        $selected[] = [
+                            'value'        => $entry->entry_id,
+                            'label'        => $entry->title,
+                            'instructions' => $entry->Channel->channel_title,
+                            'channel_id'   => $entry->channel_id,
+                            'can_edit'     => false,
+                            'editable'     => false,
+                        ];
+                    }
+                }
+                foreach ($query as $entry) {
+                    if (in_array($entry->channel_id, $allowed_channels)) {
+                        $items[] = [
+                            'value'        => $entry->entry_id,
+                            'label'        => $entry->title,
+                            'instructions' => $entry->Channel->channel_title,
+                            'channel_id'   => $entry->channel_id,
+                            'can_edit'     => false,
+                            'editable'     => false,
+                        ];
+                    }
+                }
+
+                foreach ($channels as $channel) {
+                    if (in_array($channel->channel_id, $allowed_channels)) {
+                        $channels_arr[] = [
+                            'title' => $channel->channel_title,
+                            'id'    => $channel->channel_id,
+                        ];
+                    }
+                }
+
+                $lang = [
+                    'relateEntry' => lang('relate_entry'),
+                    'search' => lang('search'),
+                    'channel' => lang('channel'),
+                    'remove' => lang('remove'),
+                ];
+
+                $settings = array(
+                    'channels' => $this->settings['channels'],
+                    'categories' => $this->settings['categories'],
+                    'statuses' => $this->settings['statuses'],
+                    'limit' => $this->settings['limit'] ? $this->settings['limit'] : 100,
+                    'order_field' => $this->settings['orderby'],
+                    'order_dir' => $this->settings['sort'],
+                    'authors' => [],
+                    'expired' => '',
+                    'future' => '',
+                    'entry_id' => '',
+                );
+                $settings = json_encode($settings);
+                $settings = ee('Encrypt')->encode(
+                    $settings,
+                    ee()->config->item('session_crypt_key')
+                );
+
+                //  Multiple choice Relationship field
+                $data = array(
+                    'var_type' => $this->info['name'],
+                    'name' => $this->input_name(),
+                    'value' => $selected,
+                    'multiple' => true,
+                    'limit' => $this->settings('limit'),
+                    'channels' => $channels_arr,
+                    'items' => $items,
+                    'lang' => $lang,
+                    'filter_url' => ee('CP/URL')->make('publish/relationship-filter', [
+                        'settings' => $settings
+                    ])->compile(),
+                );
+            } else {
+
+                //  Multiple choice Select
+                $data = array(
+                    'name' => $this->input_name(),
+                    'choices' => $choices,
+                    'value' => PVUI::explode($this->settings('separator'), $var_data),
+                    'multiple' => true
+                );
+            }
 
             return array(array(
                 'type' => 'html',
                 'content' => PVUI::view_field($this->settings('multi_interface'), $data)
             ));
         }
+
     }
 
     // --------------------------------------------------------------------

--- a/system/ee/ExpressionEngine/Addons/pro_variables/types/pro_select_entries/vt.pro_select_entries.php
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/types/pro_select_entries/vt.pro_select_entries.php
@@ -306,8 +306,9 @@ class Pro_select_entries extends Pro_variables_type
             );
         } else {
             if ($this->settings('multi_interface') == 'drag-list') {
+
                 $ids = str_replace('Array', '', $var_data);
-                $ids = array_map('intval', preg_split('/\s+/', trim($ids)));
+                $ids = array_map('intval', preg_split('/[|,\s]+/', trim($ids)));
 
                 $entries = ee('Model')
                     ->get('ChannelEntry')

--- a/system/ee/ExpressionEngine/Addons/pro_variables/views/fields/drag-list.php
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/views/fields/drag-list.php
@@ -1,4 +1,33 @@
-<div class="pro-drag-lists<?php if (isset($thumbs) && $thumbs) :
+<?php 
+    if (isset($var_type) && $var_type == 'Select Entries'):
+        $component = [
+            'items' => $items,
+            'selected' => $value,
+            'multi' => $multiple,
+            'filter_url' => $filter_url,
+            'limit' => $limit ? $limit : 100,
+            'no_results' => lang('no_entries_found'),
+            'button_label' => null,
+            'can_add_items' => false,
+            'can_edit_items' => false,
+            'channels' => $channels,
+            'display_entry_id' => false,
+            'display_status' => false,
+            'rel_max' => 0,
+            'lang' => $lang,
+        ];
+
+        $placeholder = '<label class="field-loading">' . lang('loading') . '<span></span></label>';
+ ?>
+    <div data-relationship-react="<?=base64_encode(json_encode($component))?>" data-input-value="<?=$name?>">
+        <div class="fields-select">
+            <div class="field-inputs">
+                <?php echo $placeholder ?>
+            </div>
+        </div>
+    </div>
+<?php else: ?>
+    <div class="pro-drag-lists<?php if (isset($thumbs) && $thumbs) :
     ?> pro-thumbs<?php
 endif;?>" data-name="<?=$name?>[]">
     <ul class="pro-off">
@@ -15,4 +44,5 @@ endif;?>" data-name="<?=$name?>[]">
             <?php endif; ?>
         <?php endforeach; ?>
     </ul>
-</div>
+
+<?php endif; ?>

--- a/system/ee/ExpressionEngine/Addons/pro_variables/views/fields/select.php
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/views/fields/select.php
@@ -1,7 +1,6 @@
 <?php $multi = ! empty($multiple); ?>
 <select name="<?=$name . ($multi ? '[]' : '')?>"<?php if ($multi) :
-    ?> class="pro-select-multiple" multiple<?php
-endif; ?>>
+    ?> class="pro-select-multiple" multiple<?php endif; ?> style="max-width: 100%">
 <?php foreach ($choices as $key => $val) : ?>
     <?php if (is_array($val) && ! empty($val)) : ?>
         <optgroup label="<?=htmlspecialchars($key, ENT_QUOTES)?>">

--- a/system/ee/language/english/pro_variables_lang.php
+++ b/system/ee/language/english/pro_variables_lang.php
@@ -646,6 +646,17 @@ $lang = array(
     'Settings saved',
 
     //----------------------------------------
+    // Lang for new Relationship field 
+    // for drag nad drops view
+    //----------------------------------------
+
+    'relate_entry' => 'Relate Entry',
+
+    'channel' => 'Channel',
+
+    'no_entries_found' => 'No Entries Found',
+
+    //----------------------------------------
     // Required for FIELDTYPE page
     //----------------------------------------
 


### PR DESCRIPTION
Request:
<img width="398" height="598" alt="Screenshot 2025-09-29 at 11 55 01" src="https://github.com/user-attachments/assets/e29779da-c7fd-453f-84fa-b44f7a44dd50" />

Replaced the custom drag-and-drop view implementation for the "Select Entries" (Pro) variable  
Now it uses the built-in Relationship field instead  
