### PR TITLE
Fixed a Pro Variable bug where date setting options did not stick

### DIFF
--- a/system/ee/ExpressionEngine/Addons/date/ft.date.php
+++ b/system/ee/ExpressionEngine/Addons/date/ft.date.php
@@ -191,7 +191,7 @@ class Date_ft extends EE_Fieldtype
         }
 
         return ee('View')->make('date:publish')->render(array(
-            'has_localize_option' => (! in_array($this->field_name, $special) && $this->content_type() != 'grid'),
+            'has_localize_option' => ((! in_array($this->field_name, $special) && $this->content_type() != 'grid') OR $this->content_type() == 'pro_variables'),
             'show_localize_options' => $show_localize_options,
             'field_name' => $this->field_name,
             'value' => $custom_date,

--- a/system/ee/ExpressionEngine/Addons/pro_variables/types/pro_date/vt.pro_date.php
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/types/pro_date/vt.pro_date.php
@@ -23,6 +23,10 @@ class Pro_date extends Pro_variables_type
             'date' => '1.0'
         )
     );
+    public $default_settings = array(
+        'localization' => 'ask',
+        'show_time' => 'y'
+    );	
     // Field type to use
     protected $ft = 'date';
     /**
@@ -40,9 +44,15 @@ class Pro_date extends Pro_variables_type
      */
     public function save_settings()
     {
-        $this->setup_ft();
+        $data = array();
+        // Get the keys
+        foreach ($this->default_settings as $key => $default) {
+            $data[$key] = ee('Request')->post($key, $default);
+        }
 
-        return $this->call_ft(__FUNCTION__, $this->settings());
+        $this->setup_ft();
+ 
+        return $this->call_ft(__FUNCTION__, $data);
     }
 
     /**
@@ -58,6 +68,7 @@ class Pro_date extends Pro_variables_type
         $field = $this->call_ft(__FUNCTION__, $var_data);
         // Replace the entry_date back
         $this->name = $this->row('variable_name');
+		
         $field = str_replace('entry_date', $this->input_name(), $field);
 
         return $field;

--- a/system/ee/ExpressionEngine/Addons/pro_variables/types/pro_date/vt.pro_date.php
+++ b/system/ee/ExpressionEngine/Addons/pro_variables/types/pro_date/vt.pro_date.php
@@ -26,7 +26,7 @@ class Pro_date extends Pro_variables_type
     public $default_settings = array(
         'localization' => 'ask',
         'show_time' => 'y'
-    );	
+    );
     // Field type to use
     protected $ft = 'date';
     /**
@@ -44,15 +44,17 @@ class Pro_date extends Pro_variables_type
      */
     public function save_settings()
     {
-        $data = array();
-        // Get the keys
+        // Start with existing saved settings (if any)
+        $settings = $this->settings() ?: array();
+
+        // Ensure defaults are present and override with posted values if provided.
         foreach ($this->default_settings as $key => $default) {
-            $data[$key] = ee('Request')->post($key, $default);
+            $settings[$key] = ee('Request')->post($key, isset($settings[$key]) ? $settings[$key] : $default);
         }
 
         $this->setup_ft();
- 
-        return $this->call_ft(__FUNCTION__, $data);
+
+        return $this->call_ft(__FUNCTION__, $settings);
     }
 
     /**
@@ -68,7 +70,7 @@ class Pro_date extends Pro_variables_type
         $field = $this->call_ft(__FUNCTION__, $var_data);
         // Replace the entry_date back
         $this->name = $this->row('variable_name');
-		
+
         $field = str_replace('entry_date', $this->input_name(), $field);
 
         return $field;


### PR DESCRIPTION
The radio settings for the pro variable date field weren't sticking:

<img width="530" height="348" alt="Screenshot 2025-09-29 at 1 29 56 PM" src="https://github.com/user-attachments/assets/834dad2c-1e87-4096-b3df-1dda5034d5c5" />

The change to the date fieldtype was required because in pro variable we're renaming the date field temporarily to entry_date so it was never showing the localization. 

There IS still a bug where if set the localization option when you populate the variable, it's not doing anything.  We should either get rid of the option entirely or we need to change things up so we save that data and then use it.  Probably go in as pipe delimited or some such.  But I'm not sure we want to keep it so making a new bug for discussion and we may just want to ditch that in the settings.