### PR TITLE
Resolved a performance issue with the category filter on entry listing

### DIFF
--- a/system/ee/ExpressionEngine/Model/Category/CategoryGroup.php
+++ b/system/ee/ExpressionEngine/Model/Category/CategoryGroup.php
@@ -128,7 +128,7 @@ class CategoryGroup extends StructureModel
         $sort_column = ($this->sort_order == 'a') ? 'cat_name' : 'cat_order';
 
         $categories = ee()->db
-            ->select('cat_id, parent_id, cat_name')
+            ->select('cat_id, parent_id, group_id, cat_name, cat_url_title')
             ->from('categories')
             ->where('group_id', $this->getId())
             ->order_by($sort_column, 'asc')

--- a/system/ee/ExpressionEngine/Model/Category/CategoryGroup.php
+++ b/system/ee/ExpressionEngine/Model/Category/CategoryGroup.php
@@ -127,10 +127,15 @@ class CategoryGroup extends StructureModel
     {
         $sort_column = ($this->sort_order == 'a') ? 'cat_name' : 'cat_order';
 
-        return $tree->from_list(
-            $this->getCategories()->sortBy($sort_column),
-            array('id' => 'cat_id')
-        );
+        $categories = ee()->db
+            ->select('cat_id, parent_id, cat_name')
+            ->from('categories')
+            ->where('group_id', $this->getId())
+            ->order_by($sort_column, 'asc')
+            ->get()
+            ->result_object();
+
+        return $tree->from_list($categories, array('id' => 'cat_id'));
     }
 
     /**

--- a/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
+++ b/system/ee/ExpressionEngine/Service/EntryListing/EntryListing.php
@@ -472,7 +472,6 @@ class EntryListing
 
         if (is_null($channel)) {
             $category_groups = ee('Model')->get('CategoryGroup')
-                ->with('Categories')
                 ->filter('site_id', ee()->config->item('site_id'))
                 ->filter('exclude_group', '!=', 1)
                 ->order('group_name', 'asc')


### PR DESCRIPTION
For sites with a large number of categories rendering the category filter would consume an excessive amount of memory.
