### PR TITLE
Fixed a bug in updater where db connection did not include all availa…

### DIFF
--- a/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/RequirementsChecker.php
+++ b/system/ee/installer/updater/ExpressionEngine/Updater/Service/Updater/RequirementsChecker.php
@@ -147,6 +147,35 @@ class RequirementsChecker
             PDO::ATTR_STRINGIFY_FETCHES => false
         ];
 
+        // There is a limited set of PDO options that we can pass though
+        // from config.php file
+        $mysqlAttr = [
+            'MYSQL_ATTR_LOCAL_INFILE',
+            'MYSQL_ATTR_LOCAL_INFILE_DIRECTORY',
+
+            'MYSQL_ATTR_READ_DEFAULT_FILE',
+            'MYSQL_ATTR_READ_DEFAULT_GROUP',
+
+            'MYSQL_ATTR_MAX_BUFFER_SIZE',
+
+            'MYSQL_ATTR_INIT_COMMAND',
+
+            'MYSQL_ATTR_COMPRESS',
+
+            'MYSQL_ATTR_SSL_CA',
+            'MYSQL_ATTR_SSL_CAPATH',
+            'MYSQL_ATTR_SSL_CERT',
+            'MYSQL_ATTR_SSL_CIPHER',
+            'MYSQL_ATTR_SSL_KEY',
+            'MYSQL_ATTR_SSL_VERIFY_SERVER_CERT'
+        ];
+
+        foreach ($mysqlAttr as $attr) {
+            if (isset($config[$attr])) {
+                $options[constant("PDO::$attr")] = $config[$attr];
+            }
+        }
+
         return new PDO(
             $dsn,
             $username,


### PR DESCRIPTION
…ble attributes

User needs the MYSQL_ATTR_SSL_CA and MYSQL_ATTR_SSL_VERIFY_SERVER_CERT attributes set in order to connect to Azure app db.  That works fine, but then updates fail with:

Could not connect to the database using the credentials provided. ee/installer/updater/ExpressionEngine/Updater/Service/Updater/RequirementsChecker.php:65

Poking, and the db connection in the RequirementsChecker.php doesn't include those additional attributes that are in /system/ee/legacy/database/drivers/mysqli/mysqli_connection.php.  So I added them.  Aside from something about encoding for new tables which didn't seem relevant.

Might be better to abstract and share that stuff, but this is confirmed to work.  So I'm going with this.