### PR TITLE
Add profiler output on entry save

### DIFF
--- a/system/ee/ExpressionEngine/Service/Model/Model.php
+++ b/system/ee/ExpressionEngine/Service/Model/Model.php
@@ -382,6 +382,29 @@ class Model extends SerializableEntity implements Subscriber, ValidationAware
 
         $this->emit('afterAssociationsSave');
 
+        // Output the profiler output on channel entry save.
+        // In order to trigger this, add a hidden input field named 'profiler' with a truthy value to the edit entry form.
+        if (ee()->input->post('profiler') && $this->getMetaData('hook_id') === 'channel_entry') {
+            $performance = array(
+                'database' => number_format(ee('Database')->currentExecutionTime(), 4),
+                'benchmarks' => ee()->benchmark->getBenchmarkTimings()
+            );
+
+            $profiler = ee('Profiler')
+                ->addSection('performance', $performance)
+                ->addSection('variables', array(
+                    'server' => $_SERVER,
+                    'cookie' => $_COOKIE,
+                    'get' => $_GET,
+                    'post' => $_POST,
+                    'userdata' => ee()->session->all_userdata()
+                ))
+                ->addSection('database', array(ee('Database')));
+
+            echo $profiler->render();
+            die();
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
This PR adds some advanced functionality to allow developers to view the profiler on entry save. This was massively useful to us to help troubleshoot slow save requests with thousands of redundant queries.

It's a little bit tricky do want or need to do this outside of a development environment, because the save request _normally_ redirects back to the entry page, but this intercepts that and just outputs the raw profiler data to the page and dies. So I'm open to suggestions of alternative conditional logic to output this (i.e. a toggle in the CMS, but I thought that was more persistent than necessary when you probably just want to profile a single save, not _all saves until you toggle it off_).

For quick and easy testing, edit any entry and run:

```$('.form-standard form').prepend('<input type="hidden" name="profiler" value="1" />');```

in the browser console to add the hidden input field, and then save the entry.

I'd be happy to add documentation to the User Guide to demonstrate how to use this if the PR is accepted.

Profiler output:
Shows the usual user/server data:
<img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/7353f70f-5e4d-4151-99f7-c6da9353bd98" />

And duplicate queries:
<img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/f240a2d2-7e4a-4514-9ace-7fed0d9bd2b6" />

And a list of all queries:
<img width="2032" height="1167" alt="image" src="https://github.com/user-attachments/assets/4718ec48-7790-4f07-9a40-4816f2ed6a1d" />

