### PR TITLE
Resolved #5017 where "Save and Close" button on Role edit was redirecting to non-existing page

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Members/Roles/Groups.php
+++ b/system/ee/ExpressionEngine/Controller/Members/Roles/Groups.php
@@ -83,7 +83,7 @@ class Groups extends AbstractRolesController
                 if (ee('Request')->post('submit') == 'save_and_new') {
                     ee()->functions->redirect(ee('CP/URL')->make('members/roles/groups/create'));
                 } elseif (ee('Request')->post('submit') == 'save_and_close') {
-                    ee()->functions->redirect(ee('CP/URL')->make('members/roles/groups'));
+                    ee()->functions->redirect(ee('CP/URL')->make('members/roles'));
                 } else {
                     ee()->functions->redirect(ee('CP/URL')->make('members/roles/groups/edit/' . $role_group->getId()));
                 }


### PR DESCRIPTION
Resolved #5017 where "Save and Close" button on Role edit was redirecting to non-existing page