### PR TITLE
Resolved #4566 where performance was poor for filtering file models by file_name

### DIFF
--- a/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
+++ b/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
@@ -34,9 +34,8 @@ class FileSystemEntity extends ContentModel
         'beforeInsert',
         'beforeSave'
     );
-    protected static $_binary_comparisons = array(
-        'file_name'
-    );
+
+    protected static $_binary_comparisons = array();
 
     protected static $_hook_id = 'file';
 
@@ -119,6 +118,16 @@ class FileSystemEntity extends ContentModel
     protected $_baseServerPath;
     protected $_subfolderPath;
     protected $_exists;
+
+    public function __construct() {
+        parent::__construct();
+
+        // If this is a case-sensitive filesystem mark the file_name column
+        // to be filtered with a binary cast to enforce case-sensitive comparison
+        if(ee()->config->item('filesystem_case_sensitive') === 'y') {
+            static::$_binary_comparisons[] = 'file_name';
+        }
+    }
 
     /**
      * A link back to the owning group object.


### PR DESCRIPTION
Added a new config variable for anyone who wants or needs the old behavior.  Set `$config['filesystem_case_sensitive'] = 'y';`. Although it would really be recommended to just use a case-sensitive database collation available in MySQL 8 for the best performance.