### PR TITLE
Fix resizing of webp files with transparency when using GD lib

### DIFF
--- a/system/ee/legacy/libraries/Image_lib.php
+++ b/system/ee/legacy/libraries/Image_lib.php
@@ -803,8 +803,8 @@ class EE_Image_lib
      */
     public function image_preserve_alpha($new_img, $src_img)
     {
-        // Preserve transparancies for GIFs and PNGs
-        if ($this->image_type == IMAGETYPE_GIF || $this->image_type == IMAGETYPE_PNG) {
+        // Preserve transparancies for GIFs, PNGs, and WebPs
+        if ($this->image_type == IMAGETYPE_GIF || $this->image_type == IMAGETYPE_PNG || $this->image_type == 18) {
             $src_alpha_index = imagecolortransparent($src_img);
 
             if ($src_alpha_index >= 0
@@ -823,7 +823,7 @@ class EE_Image_lib
                 // Set alpha color as background color and make it transparent
                 imagefill($new_img, 0, 0, $alpha_index);
                 imagecolortransparent($new_img, $alpha_index);
-            } elseif ($this->image_type == IMAGETYPE_PNG) {
+            } elseif ($this->image_type == IMAGETYPE_PNG || $this->image_type == 18) {
                 imagealphablending($new_img, false);
 
                 // Create a new transparent color for image


### PR DESCRIPTION
It was uploading them fine, but if resizing, the transparency was replaced by a solid color.

Note- it's not clear this always happened.  But at least some cases where running gd with webp support, they were losing the transparency.

Both myself and end user confirmed the fix worked, but it could definitely use a dev eyeball.