### PR TITLE
Optimize spam training

### DIFF
--- a/system/ee/ExpressionEngine/Addons/spam/Service/Training.php
+++ b/system/ee/ExpressionEngine/Addons/spam/Service/Training.php
@@ -147,15 +147,19 @@ class Training
      */
     private function getParameters($class)
     {
-        $parameters = ee('Model')->get('spam:SpamParameter')
-            ->fields('mean', 'variance')
-            ->filter('class', $class)
-            ->filter('kernel_id', $this->kernel->kernel_id)
-            ->all();
-
+        $parameters = ee()->db->select('mean, variance')
+            ->from('spam_parameters')
+            ->where('class', $class)
+            ->where('kernel_id', $this->kernel->kernel_id)
+            ->get();
+		
         $result = array();
+		
+        if ($parameters->num_rows() == 0) {
+            return $result;
+        }
 
-        foreach ($parameters as $parameter) {
+        foreach ($parameters->result() as $parameter) {
             $result[] = ee('spam:Distribution', $parameter->mean, $parameter->variance);
         }
 


### PR DESCRIPTION
User one a large site was getting a memory error when submitting comments.  I couldn't replicate locally, but they found their own fix, which was switching from a model to active record for this particular function in the spam add-on.  

This is pretty much their fix added in.