### PR TITLE
Fixed php deprecation error

### DIFF
--- a/system/ee/ExpressionEngine/Service/Consent/Consent.php
+++ b/system/ee/ExpressionEngine/Service/Consent/Consent.php
@@ -211,9 +211,9 @@ class Consent
 
                 return $consents[$grants[$request_ref]->consent_request_id]->isGranted();
             }
-
-            return false;
         }
+		
+        return false;
     }
 
     /**
@@ -242,9 +242,9 @@ class Consent
 
                 return $consents[$rid]->response_date != false;
             }
-
-            return false;
         }
+
+        return false;		
     }
 
     /**


### PR DESCRIPTION
php 8.3

Deprecated
str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated ee/legacy/libraries/Template.php, line 544
Severity: E_DEPRECATED
Deprecated
str_replace(): Passing null to parameter #2 ($replace) of type array|string is deprecated ee/legacy/libraries/Template.php, line 545
Severity: E_DEPRECATED

So if anon and it didn't meet the isset() check, it wasn't returning so you ended up with a null which throws the deprecation in template.php.

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
