### PR TITLE
Resolved #4993 where expiration of password reset links did not match email instructions

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -1117,6 +1117,8 @@ class Member_auth extends Member
     {
         return ee()->localize->now - (24 * 60 * 60); // 24 hours as per email instructions
     }
+
+}
 // END CLASS
 
 // EOF

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -1115,9 +1115,8 @@ class Member_auth extends Member
      */
     private function getTokenExpiration()
     {
-        return ee()->localize->now - (60 * 60); // One hour
+        return ee()->localize->now - (24 * 60 * 60); // 24 hours as per email instructions
     }
-}
 // END CLASS
 
 // EOF


### PR DESCRIPTION
Resolved #4993 where expiration of password reset links did not match email instructions