### PR TITLE
Download and install update for add-on

### DIFF
--- a/system/ee/ExpressionEngine/Cli/Cli.php
+++ b/system/ee/ExpressionEngine/Cli/Cli.php
@@ -103,6 +103,7 @@ class Cli
         'addons:list' => Commands\CommandAddonsList::class,
         'addons:uninstall' => Commands\CommandAddonsUninstall::class,
         'addons:update' => Commands\CommandAddonsUpdate::class,
+        'addons:unpack' => Commands\CommandAddonsUnpack::class,
 
         // Backup
         'backup:database' => Commands\CommandBackupDatabase::class,

--- a/system/ee/ExpressionEngine/Cli/Cli.php
+++ b/system/ee/ExpressionEngine/Cli/Cli.php
@@ -104,6 +104,7 @@ class Cli
         'addons:uninstall' => Commands\CommandAddonsUninstall::class,
         'addons:update' => Commands\CommandAddonsUpdate::class,
         'addons:unpack' => Commands\CommandAddonsUnpack::class,
+        'addons:pack' => Commands\CommandAddonsPack::class,
 
         // Backup
         'backup:database' => Commands\CommandBackupDatabase::class,

--- a/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsPack.php
+++ b/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsPack.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Cli\Commands;
+
+use ExpressionEngine\Cli\Cli;
+use ExpressionEngine\Service\Updater\Downloader\UpdaterPaths;
+use FilesystemIterator;
+
+/**
+ * Command to pack addon to zip
+ */
+class CommandAddonsPack extends Cli
+{
+    use UpdaterPaths;
+
+    /**
+     * name of command
+     * @var string
+     */
+    public $name = 'Packs an add-on';
+
+    /**
+     * signature of command
+     * @var string
+     */
+    public $signature = 'addons:pack';
+
+    /**
+     * How to use command
+     * @var string
+     */
+    public $usage = 'php eecli.php addons:pack -a <addon_name>';
+
+    /**
+     * options available for use in command
+     * @var array
+     */
+    public $commandOptions = [
+        'addon,a:'        => 'command_addons_pack_option_addon',
+    ];
+
+    protected $data = [];
+
+    /**
+     * Run the command
+     * @return mixed
+     */
+    public function handle()
+    {
+        defined('CLI_VERBOSE') || define('CLI_VERBOSE', $this->option('-v', false));
+        ee()->lang->loadfile('addons');
+        $this->info('command_addons_pack_begin');
+
+        $packer = ee('Updater/Packer');
+
+        $addonShortName = $this->data['addon'] = $this->getOptionOrAskAddon('--addon', "command_addons_pack_ask_addon", 'first', true, 'all');
+
+        $addon = ee('pro:Addon')->get($this->data['addon']);
+
+        $packer->setAddonArchivePath($addonShortName);
+
+        $this->info(sprintf(lang('command_addons_pack_in_progress'), $addon->getName()));
+
+        try {
+            $resultMessage = $packer->packAddon($addonShortName);
+        } catch (\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+
+        $this->info($resultMessage);
+    }
+}

--- a/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsUnpack.php
+++ b/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsUnpack.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Cli\Commands;
+
+use ExpressionEngine\Cli\Cli;
+use ExpressionEngine\Service\Updater\Downloader\UpdaterPaths;
+use FilesystemIterator;
+
+/**
+ * Command to unpack addon and move to proper location
+ */
+class CommandAddonsUnpack extends Cli
+{
+    use UpdaterPaths;
+
+    /**
+     * name of command
+     * @var string
+     */
+    public $name = 'Unpacks an add-on';
+
+    /**
+     * signature of command
+     * @var string
+     */
+    public $signature = 'addons:unpack';
+
+    /**
+     * How to use command
+     * @var string
+     */
+    public $usage = 'php eecli.php addons:unpack -a <addon_name>';
+
+    /**
+     * options available for use in command
+     * @var array
+     */
+    public $commandOptions = [
+        'addon,a:'        => 'command_addons_unpack_option_addon',
+        'delete-zip,d'    => 'command_addons_unpack_option_delete_zip',
+    ];
+
+    protected $data = [];
+
+    /**
+     * Run the command
+     * @return mixed
+     */
+    public function handle()
+    {
+        defined('CLI_VERBOSE') || define('CLI_VERBOSE', $this->option('-v', false));
+        ee()->lang->loadfile('addons');
+        $this->info('command_addons_unpack_begin');
+
+        $unpacker = ee('Updater/Unpacker');
+
+        // get the list of zip files
+        $addons = $unpacker->getAddonsList();
+
+        // Gather all the addon information
+        $addonShortName = $this->data['addon'] = $this->getOptionOrAsk('--addon', "command_addons_unpack_ask_addon", 'first', true, $addons);
+
+        // unpack the addon
+        $this->info(sprintf(lang('command_addons_unpack_in_progress'), $addonShortName));
+
+        $unpacker->setAddonArchivePath($addonShortName);
+        $unpacker->unzipPackage();
+
+        $this->info(sprintf(lang('command_addons_unpack_moving_files'), $addonShortName));
+
+        try {
+            $resultMessage = $unpacker->unpackAndMoveAddon($addonShortName, $this->option('--delete-zip'));
+        } catch (\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+
+        $this->info($resultMessage);
+    }
+
+    public function getOptionOrAsk($option, $askText, $default = '', $required = false, $addonList = [])
+    {
+        // Get option if it was passed
+        if ($this->option($option)) {
+            return $this->option($option);
+        }
+
+        // Get the answer by asking
+        $answer = $this->askAddon(lang($askText), $addonList, $default);
+
+        // If it was a required field and no answer was passed, fail
+        if ($required && empty(trim($answer))) {
+            $this->fail(lang('cli_error_is_required_field') . $option);
+        }
+
+        return $answer;
+    }
+}

--- a/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsUnpack.php
+++ b/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsUnpack.php
@@ -61,9 +61,14 @@ class CommandAddonsUnpack extends Cli
         $this->info('command_addons_unpack_begin');
 
         $unpacker = ee('Updater/Unpacker');
+        $unpacker->setAddonArchivePath();
 
         // get the list of zip files
         $addons = $unpacker->getAddonsList();
+
+        if (empty($addons)) {
+            $this->fail('command_addons_unpack_no_zips_found');
+        }
 
         // Gather all the addon information
         $addonShortName = $this->data['addon'] = $this->getOptionOrAsk('--addon', "command_addons_unpack_ask_addon", 'first', true, $addons);

--- a/system/ee/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/ExpressionEngine/Controller/Addons/Addons.php
@@ -14,6 +14,7 @@ use CP_Controller;
 use Michelf\MarkdownExtra;
 use ExpressionEngine\Library\CP\Table;
 use ExpressionEngine\Service\Addon\Mcp;
+use ExpressionEngine\Service\Updater\UpdaterException;
 
 /**
  * Addons Controller
@@ -357,6 +358,27 @@ class Addons extends CP_Controller
             $addons = array($addons);
         }
 
+        $this->updateAddons($addons);
+
+        $return = $this->base_url;
+
+        if (ee()->input->get('return')) {
+            $return = ee('CP/URL')->decodeUrl(ee()->input->get('return'));
+        }
+
+        $return .= '#tab=t-update';
+
+        ee()->functions->redirect($return);
+    }
+
+    /**
+     * Updates add-ons
+     *
+     * @param   array   $addons The name(s) of add-ons to update
+     * @return  void
+     */
+    private function updateAddons($addons)
+    {
         $updated = array(
             'first' => array(),
             'third' => array()
@@ -499,16 +521,6 @@ class Addons extends CP_Controller
                     ->defer();
             }
         }
-
-        $return = $this->base_url;
-
-        if (ee()->input->get('return')) {
-            $return = ee('CP/URL')->decodeUrl(ee()->input->get('return'));
-        }
-
-        $return .= '#tab=t-update';
-
-        ee()->functions->redirect($return);
     }
 
     /**
@@ -817,6 +829,14 @@ class Addons extends CP_Controller
 
                 break;
             case 'update_available':
+                if (ee('Permission')->isSuperAdmin()) {
+                    ee('CP/Alert')->makeBanner('addon-update-available')
+                        ->asTip()
+                        ->canClose()
+                        ->withTitle(lang('license_update_available'))
+                        ->addToBody(sprintf(lang('license_update_available_message'), $info->getName(), ee('CP/URL')->make('addons/download/' . $addon)->compile()))
+                        ->now();
+                }
                 $licenseStatusBadge = '<a class="license-status-badge license-status-update_available" href="https://expressionengine.com/store/licenses#update-available" target="_blank">' . lang('license_update_available') . '</a>';
 
                 break;
@@ -934,6 +954,43 @@ class Addons extends CP_Controller
         ee()->view->body_class = 'add-on-layout';
 
         ee()->cp->render('addons/settings', $vars);
+    }
+
+    public function download($addon)
+    {
+        ee()->lang->loadfile('updater');
+
+        if (!ee('Permission')->can('admin_addons')) {
+            show_error(lang('unauthorized_access'), 403);
+        }
+
+        $info = ee('Addon')->get($addon);
+
+        if (empty($info)) {
+            show_404();
+        }
+
+        $downloader = ee('Updater/Downloader');
+        $downloader->setAddonArchivePath();
+        try {
+            $downloader->downloadPackage('https://updates.expressionengine.com/download/' . $addon);
+        } catch (UpdaterException $e) {
+            show_error($e->getMessage());
+        }
+
+        $unpacker = ee('Updater/Unpacker');
+        $unpacker->setAddonArchivePath($addon);
+        $unpacker->unzipPackage();
+
+        try {
+            $unpacker->unpackAndMoveAddon($addon, true);
+        } catch (\Exception $e) {
+            show_error($e->getMessage());
+        }
+
+        $this->updateAddons([$addon]);
+
+        ee()->functions->redirect(ee('CP/URL')->make('addons')->compile());
     }
 
     /**

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Packer.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Packer.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Service\Updater\Downloader;
+
+use ExpressionEngine\Service\Updater\Downloader\UpdaterPaths;
+use ExpressionEngine\Service\Updater\UpdaterException;
+use ExpressionEngine\Service\Updater\Verifier;
+use ExpressionEngine\Service\Updater\Logger;
+use ExpressionEngine\Service\Updater\RequirementsCheckerLoader;
+use ExpressionEngine\Library\Filesystem\Filesystem;
+use ZipArchive;
+use FilesystemIterator;
+
+/**
+ * Updater unpacker
+ *
+ * Unpacks the downloaded ExpressionEngine zip archive, verifies the integrity
+ * of the files, checks the downloaded installation's server requirements, and
+ * finally moves the micro app into place to facilitate the rest of the upgrade
+ */
+class Packer
+{
+    use UpdaterPaths;
+
+    protected $filesystem;
+    protected $zip_archive;
+
+    protected $manifest_location = 'system/ee/installer/updater/hash-manifest';
+
+    /**
+     * Constructor
+     *
+     * @param Filesystem $filesystem Filesystem service object
+     * @param ZipArchive $zip_archive PHP-native ZipArchive object
+     */
+    public function __construct(Filesystem $filesystem, ZipArchive $zip_archive)
+    {
+        $this->filesystem = $filesystem;
+        $this->zip_archive = $zip_archive;
+    }
+
+    /**
+     * Pack and copy the addon folder
+     *
+     * @param string $addonShortName Short name of the addon
+     * @return string Result message
+     */
+    public function packAddon($addonShortName)
+    {
+        $destinationPath = $this->path() . $addonShortName;
+
+        // if the folder already exists, remove it
+        if (ee('Filesystem')->exists($destinationPath)) {
+            ee('Filesystem')->deleteDir($destinationPath);
+        }
+        try {
+            ee('Filesystem')->copy(PATH_THIRD . $addonShortName, $destinationPath . '/system/user/addons/' . $addonShortName);
+        } catch (\Exception $e) {
+            throw new \Exception(lang('addons_pack_copy_failed'));
+        }
+
+        if (ee('Filesystem')->exists(PATH_THIRD_THEMES . $addonShortName)) {
+            try {
+                ee('Filesystem')->copy(PATH_THIRD_THEMES . $addonShortName, $destinationPath . '/themes/user/' . $addonShortName);
+            } catch (\Exception $e) {
+                throw new \Exception(lang('addons_pack_copy_failed'));
+            }
+        }
+
+        if (ee('Filesystem')->exists($this->getArchiveFilePath())) {
+            ee('Filesystem')->rename($this->getArchiveFilePath(), $this->path() . $addonShortName . '_'. ee()->localize->now . '.zip');
+        }
+
+        $this->zip_archive->open($this->getArchiveFilePath(), ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+        // Create recursive directory iterator
+        // Skip parent and root directories ( "." and ".." )
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($destinationPath, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        foreach ($files as $name => $file) {
+            // Get real and relative path for current file
+            $filePath = $file->getRealPath();
+
+            // Calculate the relative path within the zip archive
+            // The +1 is to remove the leading slash from the relative path if the source path is absolute
+            $relativePath = substr($filePath, strlen($destinationPath) + 1);
+
+            if (!$file->isDir()) {
+                // Add current file to archive
+                $this->zip_archive->addFile($filePath, $relativePath);
+            } else {
+                // Add empty directory to archive (only if it's an actual directory and not just a file path component)
+                // Note: addFile() automatically creates parent directories when adding a file path
+                if ($relativePath !== false) {
+                    $this->zip_archive->addEmptyDir($relativePath);
+                }
+            }
+        }
+
+        $this->zip_archive->close();
+
+        ee('Filesystem')->deleteDir($this->getExtractedArchivePath());
+
+        $addon = ee('pro:Addon')->get($addonShortName);
+        $resultMessage = sprintf(lang('addons_pack_complete'), $addon->getName());
+
+        return $resultMessage;
+    }
+}
+
+// EOF

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
@@ -38,14 +38,18 @@ class Unpacker
 
     protected $manifest_location = 'system/ee/installer/updater/hash-manifest';
 
+    protected $addonZipFolders = [];
+    protected $addonFolders = [];
+    protected $themesFolders = [];
+
     /**
      * Constructor
      *
-     * @param	Filesystem $filesystem Filesystem service object
-     * @param	ZipArchive $zip_archive PHP-native ZipArchive object
-     * @param	Verifier $verifier File verifier object
-     * @param	Logger $logger 	Updater logger object
-     * @param	RequirementsCheckerLoader $requirements Requirements checker loader object
+     * @param   Filesystem $filesystem Filesystem service object
+     * @param   ZipArchive $zip_archive PHP-native ZipArchive object
+     * @param   Verifier $verifier File verifier object
+     * @param   Logger $logger Updater logger object
+     * @param   RequirementsCheckerLoader $requirements Requirements checker loader object
      */
     public function __construct(Filesystem $filesystem, ZipArchive $zip_archive, Verifier $verifier, Logger $logger, RequirementsCheckerLoader $requirements)
     {
@@ -202,110 +206,14 @@ class Unpacker
         // - there is a single folder inside the extracted folder that contains the files, matching the addon name
         // - there is system/user/addons structure inside the extracted folder
         $extracted = $this->getExtractedArchivePath();
-        $addonFolders = [];
-        $themesFolders = [];
-        $somethingFound = false;
-        $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
-        foreach ($files as $item) {
-            if ($item->isDir() && !in_array($item->getBasename(), ['.', '..']) && !in_array($item->getBasename(), ['system', 'themes'])) {
-                $firstDir = $item->getBasename();
-            }
-            if ($item->getBasename() == 'addon.setup.php') {
-                $addonFolders[$addonShortName] = $extracted;
-                $somethingFound = true;
-                break;
-            }
-            if ($item->isDir() && $item->getBasename() == $addonShortName) {
-                $addonFolders[$addonShortName] = $item->getPathname();
-                $somethingFound = true;
-                break;
-            }
+
+        $this->iterateForAddon($extracted, $addonShortName);
+
+        if (!array_key_exists($addonShortName, $this->addonFolders)) {
+            $addonShortName = array_key_first($this->addonFolders);
         }
 
-        if (!$somethingFound) {
-            // look deeper
-            if (isset($firstDir)) {
-                $extracted .= '/' . $firstDir;
-                $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
-                foreach ($files as $item) {
-                    if ($item->getBasename() == 'addon.setup.php') {
-                        $addonFolders[$addonShortName] = $extracted;
-                        break;
-                    }
-                    if ($item->isDir() && $item->getBasename() == $addonShortName) {
-                        $addonFolders[$addonShortName] = $item->getPathname();
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (empty($addonFolders)) {
-            $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
-            foreach ($files as $item) {
-                if ($item->isDir() && $item->getBasename() == 'system') {
-                    $systemFiles = new FilesystemIterator($item->getPathname(), FilesystemIterator::UNIX_PATHS);
-                    foreach ($systemFiles as $subitem) {
-                        if ($subitem->isDir() && $subitem->getBasename() == $addonShortName) {
-                            $addonFolders[$addonShortName] = $subitem->getPathname();
-                            break;
-                        }
-                        if ($subitem->isDir() && $subitem->getBasename() == 'user') {
-                            $userFiles = new FilesystemIterator($subitem->getPathname(), FilesystemIterator::UNIX_PATHS);
-                            foreach ($userFiles as $userSubitem) {
-                                if ($userSubitem->isDir() && $userSubitem->getBasename() == 'addons') {
-                                    $userAddonsFiles = new FilesystemIterator($userSubitem->getPathname(), FilesystemIterator::UNIX_PATHS);
-                                    foreach ($userAddonsFiles as $addonSubitem) {
-                                        // there can be multiple adddons, so we need each folder that has a setup file
-                                        if ($addonSubitem->isDir() && !in_array($addonSubitem->getBasename(), ['.', '..'])) {
-                                            $addonFolderFiles = new FilesystemIterator($addonSubitem->getPathname(), FilesystemIterator::UNIX_PATHS);
-                                            foreach ($addonFolderFiles as $file) {
-                                                if ($file->getBasename() == 'addon.setup.php') {
-                                                    $addonFolders[$addonSubitem->getBasename()] = $addonSubitem->getPathname();
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    }
-                                    break 2;
-                                }
-                            }
-                        }
-                    }
-                }
-                if ($item->isDir() && $item->getBasename() == 'themes') {
-                    $themeFiles = new FilesystemIterator($item->getPathname(), FilesystemIterator::UNIX_PATHS);
-                    foreach ($themeFiles as $subitem) {
-                        if ($subitem->isDir() && $subitem->getBasename() == $addonShortName) {
-                            $themesFolders[$subitem->getBasename()] = $subitem->getPathname();
-                            break;
-                        }
-                        if ($subitem->isDir() && $subitem->getBasename() == 'user') {
-                            $userFiles = new FilesystemIterator($subitem->getPathname(), FilesystemIterator::UNIX_PATHS);
-                            foreach ($userFiles as $userSubitem) {
-                                if ($userSubitem->isDir() && !in_array($userSubitem->getBasename(), ['.', '..'])) {
-                                    $themesFolders[$userSubitem->getBasename()] = $userSubitem->getPathname();
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // make sure the folder has addon.setup.php file
-        foreach ($addonFolders as $i => $addonFolder) {
-            $files = new FilesystemIterator($addonFolder, FilesystemIterator::UNIX_PATHS);
-            foreach ($files as $item) {
-                if ($item->getBasename() == 'addon.setup.php') {
-                    break 2;
-                }
-            }
-            // if no setup file, remove from the list
-            unset($addonFolders[$i]);
-        }
-
-        if (empty($addonFolders)) {
+        if (empty($this->addonFolders)) {
             ee('Filesystem')->deleteDir($this->getExtractedArchivePath());
             throw new \Exception(lang('addons_unpack_invalid_structure'));
         }
@@ -313,7 +221,7 @@ class Unpacker
         $failedToMove = [];
         $backupFolderId = uniqid();
         // copy everything we have to addons folder
-        foreach ($addonFolders as $addonName => $addonFolder) {
+        foreach ($this->addonFolders as $addonName => $addonFolder) {
             // back up first
             if (ee('Filesystem')->exists(PATH_THIRD . $addonName)) {
                 ee('Filesystem')->copy(PATH_THIRD . $addonName, $this->path() . 'backup/' . $addonName . '_' . $backupFolderId);
@@ -333,9 +241,9 @@ class Unpacker
             }
         }
 
-        if (!empty($themesFolders)) {
+        if (!empty($this->themesFolders)) {
             // copy themes if we have them
-            foreach ($themesFolders as $folderName => $themesFolder) {
+            foreach ($this->themesFolders as $folderName => $themesFolder) {
                 // back up first
                 if (ee('Filesystem')->exists(PATH_THIRD_THEMES . $folderName)) {
                     ee('Filesystem')->copy(PATH_THIRD_THEMES . $folderName, $this->path() . 'backup_themes/' . $folderName . '_' . $backupFolderId);
@@ -377,6 +285,52 @@ class Unpacker
         }
 
         return $resultMessage;
+    }
+
+    /**
+     * Look for add-on and themes folders
+     *
+     * @param string $directory
+     * @param string $addonShortName
+     * @return void
+     */
+    private function iterateForAddon($directory, $addonShortName)
+    {
+        $directory = realpath($directory);
+
+        $files = new FilesystemIterator($directory, FilesystemIterator::UNIX_PATHS | FilesystemIterator::SKIP_DOTS);
+        foreach ($files as $item) {
+            // is this the addon folder?
+            if ($item->getBasename() == 'addon.setup.php') {
+                $this->addonFolders[$addonShortName] = $directory;
+                break;
+            }
+            // if it's not add-on folder, is this a themes folder?
+            $normalizedPath = str_replace('\\', '/', $item->getPathname());
+            if (strpos($normalizedPath, '/themes/user') !== false && strpos($normalizedPath, '/themes/user') === strlen($normalizedPath) - strlen('/themes/user') && $item->isDir()) {
+                $themeFiles = new FilesystemIterator($normalizedPath, FilesystemIterator::UNIX_PATHS | FilesystemIterator::SKIP_DOTS);
+                foreach ($themeFiles as $item) {
+                    if ($item->isDir()) {
+                        $this->themesFolders[$item->getBasename()] = $item->getPathname();
+                    }
+                }
+                break;
+            }
+            // go deeper
+            if ($item->isDir() && !in_array(realpath($item->getPathname()), $this->addonZipFolders)) {
+                return $this->iterateForAddon($item->getPathname(), $item->getBasename());
+            }
+        }
+
+        $this->addonZipFolders[] = $directory;
+
+        // go up one level
+        while ($directory != realpath($this->getExtractedArchivePath())) {
+            $directory = realpath($directory . '/..');
+            if (!in_array($directory, $this->addonZipFolders)) {
+                return $this->iterateForAddon($directory, $addonShortName);
+            }
+        }
     }
 }
 

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
@@ -17,6 +17,7 @@ use ExpressionEngine\Service\Updater\Logger;
 use ExpressionEngine\Service\Updater\RequirementsCheckerLoader;
 use ExpressionEngine\Library\Filesystem\Filesystem;
 use ZipArchive;
+use FilesystemIterator;
 
 /**
  * Updater unpacker
@@ -167,6 +168,213 @@ class Unpacker
                 $e->getCode()
             );
         }
+    }
+
+    /**
+     * Get the list of add-on zip files in folder
+     *
+     * @return array List of add-on short names
+     */
+    public function getAddonsList()
+    {
+        $addons = [];
+        $path = $this->path('addons');
+        $files = new \FilesystemIterator($path, \FilesystemIterator::UNIX_PATHS);
+        foreach ($files as $item) {
+            if ($item->getExtension() == 'zip') {
+                $addons[] = $item->getBasename('.zip');
+            }
+        }
+        return $addons;
+    }
+
+    /**
+     * Unpack and move the addon to the correct location
+     *
+     * @param string $addonShortName Short name of the addon
+     * @return string Result message
+     */
+    public function unpackAndMoveAddon($addonShortName, $deleteZip = false)
+    {
+        // check if it has correct folder structure
+        // several options here:
+        // - the files are directly in the extracted folder
+        // - there is a single folder inside the extracted folder that contains the files, matching the addon name
+        // - there is system/user/addons structure inside the extracted folder
+        $extracted = $this->getExtractedArchivePath();
+        $addonFolders = [];
+        $themesFolders = [];
+        $somethingFound = false;
+        $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
+        foreach ($files as $item) {
+            if ($item->isDir() && !in_array($item->getBasename(), ['.', '..'])) {
+                $firstDir = $item->getBasename();
+            }
+            if ($item->getBasename() == 'addon.setup.php') {
+                $addonFolders[$addonShortName] = $extracted;
+                $somethingFound = true;
+                break;
+            }
+            if ($item->isDir() && $item->getBasename() == $addonShortName) {
+                $addonFolders[$addonShortName] = $item->getPathname();
+                $somethingFound = true;
+                break;
+            }
+        }
+
+        if (!$somethingFound) {
+            // look deeper
+            if (isset($firstDir)) {
+                $extracted .= '/' . $firstDir;
+                $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
+                foreach ($files as $item) {
+                    if ($item->getBasename() == 'addon.setup.php') {
+                        $addonFolders[$addonShortName] = $extracted;
+                        break;
+                    }
+                    if ($item->isDir() && $item->getBasename() == $addonShortName) {
+                        $addonFolders[$addonShortName] = $item->getPathname();
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (empty($addonFolders)) {
+            $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
+            foreach ($files as $item) {
+                if ($item->isDir() && $item->getBasename() == 'system') {
+                    $systemFiles = new FilesystemIterator($item->getPathname(), FilesystemIterator::UNIX_PATHS);
+                    foreach ($systemFiles as $subitem) {
+                        if ($subitem->isDir() && $subitem->getBasename() == $addonShortName) {
+                            $addonFolders[$addonShortName] = $subitem->getPathname();
+                            break;
+                        }
+                        if ($subitem->isDir() && $subitem->getBasename() == 'user') {
+                            $userFiles = new FilesystemIterator($subitem->getPathname(), FilesystemIterator::UNIX_PATHS);
+                            foreach ($userFiles as $userSubitem) {
+                                if ($userSubitem->isDir() && $userSubitem->getBasename() == 'addons') {
+                                    $userAddonsFiles = new FilesystemIterator($userSubitem->getPathname(), FilesystemIterator::UNIX_PATHS);
+                                    foreach ($userAddonsFiles as $addonSubitem) {
+                                        // there can be multiple adddons, so we need each folder that has a setup file
+                                        if ($addonSubitem->isDir() && !in_array($addonSubitem->getBasename(), ['.', '..'])) {
+                                            $addonFolderFiles = new FilesystemIterator($addonSubitem->getPathname(), FilesystemIterator::UNIX_PATHS);
+                                            foreach ($addonFolderFiles as $file) {
+                                                if ($file->getBasename() == 'addon.setup.php') {
+                                                    $addonFolders[$addonSubitem->getBasename()] = $addonSubitem->getPathname();
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    break 2;
+                                }
+                            }
+                        }
+                    }
+                }
+                if ($item->isDir() && $item->getBasename() == 'themes') {
+                    $themeFiles = new FilesystemIterator($item->getPathname(), FilesystemIterator::UNIX_PATHS);
+                    foreach ($themeFiles as $subitem) {
+                        if ($subitem->isDir() && $subitem->getBasename() == $addonShortName) {
+                            $themesFolders[$subitem->getBasename()] = $subitem->getPathname();
+                            break;
+                        }
+                        if ($subitem->isDir() && $subitem->getBasename() == 'user') {
+                            $userFiles = new FilesystemIterator($subitem->getPathname(), FilesystemIterator::UNIX_PATHS);
+                            foreach ($userFiles as $userSubitem) {
+                                if ($userSubitem->isDir() && !in_array($userSubitem->getBasename(), ['.', '..'])) {
+                                    $themesFolders[$userSubitem->getBasename()] = $userSubitem->getPathname();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // make sure the folder has addon.setup.php file
+        foreach ($addonFolders as $i => $addonFolder) {
+            $files = new FilesystemIterator($addonFolder, FilesystemIterator::UNIX_PATHS);
+            foreach ($files as $item) {
+                if ($item->getBasename() == 'addon.setup.php') {
+                    break 2;
+                }
+            }
+            // if no setup file, remove from the list
+            unset($addonFolders[$i]);
+        }
+
+        if (empty($addonFolders)) {
+            ee('Filesystem')->deleteDir($this->getExtractedArchivePath());
+            throw new \Exception(lang('addons_unpack_invalid_structure'));
+        }
+
+        $failedToMove = [];
+        $backupFolderId = uniqid();
+        // copy everything we have to addons folder
+        foreach ($addonFolders as $addonName => $addonFolder) {
+            // back up first
+            if (ee('Filesystem')->exists(PATH_THIRD . $addonName)) {
+                ee('Filesystem')->copy(PATH_THIRD . $addonName, $this->path() . 'backup/' . $addonName . '_' . $backupFolderId);
+                ee('Filesystem')->deleteDir(PATH_THIRD . $addonName);
+            }
+            try {
+                ee('Filesystem')->copy($addonFolder, PATH_THIRD . $addonName);
+            } catch (\Exception $e) {
+                if (ee('Filesystem')->exists($this->path() . 'backup/' . $addonName . '_' . $backupFolderId)) {
+                    // Remove the copied files
+                    ee('Filesystem')->deleteDir(PATH_THIRD . $addonName);
+
+                    // Restore from backup
+                    ee('Filesystem')->copy($this->path() . 'backup/' . $addonName . '_' . $backupFolderId, PATH_THIRD . $addonName);
+                }
+                $failedToMove[] = 'addons/' . $addonName;
+            }
+        }
+
+        if (!empty($themesFolders)) {
+            // copy themes if we have them
+            foreach ($themesFolders as $folderName => $themesFolder) {
+                // back up first
+                if (ee('Filesystem')->exists(PATH_THIRD_THEMES . $folderName)) {
+                    ee('Filesystem')->copy(PATH_THIRD_THEMES . $folderName, $this->path() . 'backup_themes/' . $folderName . '_' . $backupFolderId);
+                    ee('Filesystem')->deleteDir(PATH_THIRD_THEMES . $folderName);
+                }
+                try {
+                    ee('Filesystem')->copy($themesFolder, PATH_THIRD_THEMES . $folderName);
+                } catch (\Exception $e) {
+                    if (ee('Filesystem')->exists($this->path() . 'backup_themes/' . $folderName . '_' . $backupFolderId)) {
+                        // Remove the copied files
+                        ee('Filesystem')->deleteDir(PATH_THIRD_THEMES . $folderName);
+
+                        // Restore from backup
+                        ee('Filesystem')->copy($this->path() . 'backup_themes/' . $folderName . '_' . $backupFolderId, PATH_THIRD_THEMES . $folderName);
+                    }
+                    $failedToMove[] = 'themes/' . $folderName;
+                }
+            }
+        }
+
+        // remove the leftover files
+        ee('Filesystem')->deleteDir($this->getExtractedArchivePath());
+        if (empty($failedToMove)) {
+            ee('Filesystem')->deleteDir($this->path() . 'backup');
+            if (ee('Filesystem')->exists($this->path() . 'backup_themes')) {
+                ee('Filesystem')->deleteDir($this->path() . 'backup_themes');
+            }
+
+            if ($deleteZip) {
+                ee('Filesystem')->delete($this->getArchiveFilePath());
+            }
+
+            $addon = ee('pro:Addon')->get($addonShortName);
+            $resultMessage = sprintf(lang('command_addons_unpack_complete'), $addon->getName());
+        } else {
+            $resultMessage = sprintf(lang('command_addons_unpack_failed'), implode(', ', $failedToMove));
+        }
+
+        return $resultMessage;
     }
 }
 

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
@@ -207,7 +207,7 @@ class Unpacker
         $somethingFound = false;
         $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
         foreach ($files as $item) {
-            if ($item->isDir() && !in_array($item->getBasename(), ['.', '..'])) {
+            if ($item->isDir() && !in_array($item->getBasename(), ['.', '..']) && !in_array($item->getBasename(), ['system', 'themes'])) {
                 $firstDir = $item->getBasename();
             }
             if ($item->getBasename() == 'addon.setup.php') {
@@ -359,7 +359,9 @@ class Unpacker
         // remove the leftover files
         ee('Filesystem')->deleteDir($this->getExtractedArchivePath());
         if (empty($failedToMove)) {
-            ee('Filesystem')->deleteDir($this->path() . 'backup');
+            if (ee('Filesystem')->exists($this->path() . 'backup')) {
+                ee('Filesystem')->deleteDir($this->path() . 'backup');
+            }
             if (ee('Filesystem')->exists($this->path() . 'backup_themes')) {
                 ee('Filesystem')->deleteDir($this->path() . 'backup_themes');
             }
@@ -369,9 +371,9 @@ class Unpacker
             }
 
             $addon = ee('pro:Addon')->get($addonShortName);
-            $resultMessage = sprintf(lang('command_addons_unpack_complete'), $addon->getName());
+            $resultMessage = sprintf(lang('addons_unpack_complete'), $addon->getName());
         } else {
-            $resultMessage = sprintf(lang('command_addons_unpack_failed'), implode(', ', $failedToMove));
+            $resultMessage = sprintf(lang('addons_unpack_failed'), implode(', ', $failedToMove));
         }
 
         return $resultMessage;

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/UpdaterPaths.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/UpdaterPaths.php
@@ -17,6 +17,7 @@ trait UpdaterPaths
 {
     protected $filename = 'ExpressionEngine.zip';
     protected $extracted_folder = 'ExpressionEngine';
+    protected $folder = 'ee_update';
 
     /**
      * Constructs and returns the path to the downloaded zip archive
@@ -46,13 +47,25 @@ trait UpdaterPaths
      */
     protected function path()
     {
-        $cache_path = PATH_CACHE . 'ee_update/';
+        $cache_path = PATH_CACHE . $this->folder . '/';
 
         if (! is_dir($cache_path)) {
             $this->filesystem->mkDir($cache_path);
         }
 
         return $cache_path;
+    }
+
+    /**
+     * Sets the addon archive path and extracted folder name
+     *
+     * @param string $addon_name Name of the addon
+     */
+    public function setAddonArchivePath($addon_name)
+    {
+        $this->folder = 'addons';
+        $this->filename = $addon_name . '.zip';
+        $this->extracted_folder = $addon_name;
     }
 }
 // EOF

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/UpdaterPaths.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/UpdaterPaths.php
@@ -61,11 +61,13 @@ trait UpdaterPaths
      *
      * @param string $addon_name Name of the addon
      */
-    public function setAddonArchivePath($addon_name)
+    public function setAddonArchivePath($addon_name = '')
     {
         $this->folder = 'addons';
-        $this->filename = $addon_name . '.zip';
-        $this->extracted_folder = $addon_name;
+        if (!empty($addon_name)) {
+            $this->filename = $addon_name . '.zip';
+            $this->extracted_folder = $addon_name;
+        }
     }
 }
 // EOF

--- a/system/ee/ExpressionEngine/app.setup.php
+++ b/system/ee/ExpressionEngine/app.setup.php
@@ -298,6 +298,15 @@ $setup = [
             );
         },
 
+        'Updater/Packer' => function ($ee) {
+            $filesystem = $ee->make('Filesystem');
+
+            return new Updater\Downloader\Packer(
+                $ee->make('Filesystem'),
+                new \ZipArchive()
+            );
+        },
+
         'Updater/Preflight' => function ($ee) {
             $theme_paths = $ee->make('Model')->get('Config')
                 ->filter('key', 'theme_folder_path')

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -61,6 +61,8 @@ $lang = array(
 
     'addons_not_installed' => 'Add-Ons Not Installed',
 
+    'addons_unpack_invalid_structure' => 'The unpacked add-on does not have a valid structure.',
+
     'addon_not_fully_functional' => '%s is not fully functional',
 
     'existing_consent_request' => 'The following add-on(s) could not be installed due to an existing Consent Request which the add-on(s) are trying to create:',

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -63,6 +63,14 @@ $lang = array(
 
     'addons_unpack_invalid_structure' => 'The unpacked add-on does not have a valid structure.',
 
+    'addons_unpack_complete' => '%s unpacked successfully',
+
+    'addons_unpack_failed' => 'Failed to unpack %s',
+
+    'addons_pack_copy_failed' => 'Failed to copy the add-on files.',
+
+    'addons_pack_complete' => '%s packed successfully',
+
     'addon_not_fully_functional' => '%s is not fully functional',
 
     'existing_consent_request' => 'The following add-on(s) could not be installed due to an existing Consent Request which the add-on(s) are trying to create:',

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -178,6 +178,7 @@ $lang = array(
     'license_invalid_license_key' => 'Invalid Key',
     'license_missing_license_key' => 'Missing Key',
     'license_update_available' => 'Update Available',
+    'license_update_available_message' => 'A new version of %s is available. Get <a href="https://expressionengine.com/store/licenses#update-available" target="_blank">more info</a> or <a href="%s">download the update</a>.',
     'unlicensed_addon' => 'Unlicensed Add-on',
     'unlicensed_addon_message' => '<b>%s</b> does not have a valid license. <a href="https://expressionengine.com/store/licenses" target="_blank">More Info</a>',
 

--- a/system/ee/language/english/cli_lang.php
+++ b/system/ee/language/english/cli_lang.php
@@ -30,6 +30,20 @@ $lang = array(
     'command_addons_install_complete'               => '%s installed successfully',
     'command_addons_install_option_addon'           => 'Add-on\'s short name',
 
+    // Lang entries for command addons:unpack
+    'command_addons_unpack_description'            => 'Unpacks an add-on and moves it to the proper location',
+    'command_addons_unpack_summary'                => '',
+    'command_addons_unpack_begin'                  => 'Add-on unpacking is about to begin',
+    'command_addons_unpack_ask_addon'              => 'Which add-on do you want to unpack?',
+    'command_addons_unpack_in_progress'            => 'Performing %s add-on unpacking',
+    'command_addons_unpack_complete'               => '%s unpacked successfully',
+    'command_addons_unpack_option_addon'           => 'Add-on\'s short name',
+    'command_addons_unpack_complete'               => '%s unpacked successfully',
+    'command_addons_unpack_option_addon'           => 'Add-on\'s short name',
+    'command_addons_unpack_option_delete_zip'      => 'Delete the original zip file after unpacking',
+    'command_addons_unpack_moving_files'           => 'Moving files to add-on folder for %s...',
+    'command_addons_some_files_not_copied'         => 'Some files were not copied: %s',
+
     // Lang entries for command addons:uninstall
     'command_addons_uninstall_description'            => 'Uninstalls add-on and all its components',
     'command_addons_uninstall_summary'                => '',

--- a/system/ee/language/english/cli_lang.php
+++ b/system/ee/language/english/cli_lang.php
@@ -36,13 +36,18 @@ $lang = array(
     'command_addons_unpack_begin'                  => 'Add-on unpacking is about to begin',
     'command_addons_unpack_ask_addon'              => 'Which add-on do you want to unpack?',
     'command_addons_unpack_in_progress'            => 'Performing %s add-on unpacking',
-    'command_addons_unpack_complete'               => '%s unpacked successfully',
-    'command_addons_unpack_option_addon'           => 'Add-on\'s short name',
-    'command_addons_unpack_complete'               => '%s unpacked successfully',
     'command_addons_unpack_option_addon'           => 'Add-on\'s short name',
     'command_addons_unpack_option_delete_zip'      => 'Delete the original zip file after unpacking',
     'command_addons_unpack_moving_files'           => 'Moving files to add-on folder for %s...',
     'command_addons_some_files_not_copied'         => 'Some files were not copied: %s',
+
+    // Lang entries for command addons:pack
+    'command_addons_pack_description'            => 'Packs an add-on into a zip file',
+    'command_addons_pack_summary'                => '',
+    'command_addons_pack_begin'                  => 'Add-on packing is about to begin',
+    'command_addons_pack_ask_addon'              => 'Which add-on do you want to pack?',
+    'command_addons_pack_in_progress'            => 'Performing %s add-on packing',
+    'command_addons_pack_option_addon'           => 'Add-on\'s short name',
 
     // Lang entries for command addons:uninstall
     'command_addons_uninstall_description'            => 'Uninstalls add-on and all its components',

--- a/system/ee/language/english/cli_lang.php
+++ b/system/ee/language/english/cli_lang.php
@@ -40,6 +40,7 @@ $lang = array(
     'command_addons_unpack_option_delete_zip'      => 'Delete the original zip file after unpacking',
     'command_addons_unpack_moving_files'           => 'Moving files to add-on folder for %s...',
     'command_addons_some_files_not_copied'         => 'Some files were not copied: %s',
+    'command_addons_unpack_no_zips_found'          => 'No add-on zip files were found to unpack.',
 
     // Lang entries for command addons:pack
     'command_addons_pack_description'            => 'Packs an add-on into a zip file',


### PR DESCRIPTION
This is a follow-up for https://github.com/ExpressionEngine/ExpressionEngine/pull/5099

Currently prototype. as it lacks endpoint that needs to be built in EE store

If the add-on has update available in License Store (license returns as update_available) it will show the banner with the link. Clicking on the link will have the add-on downloaded, unpacked and updated.

Note: the "update available" is currently only shown for add-ons that have Settings page. We need to expand that.
The server side of downloader is yet to be implemented on EE Store side. It needs to serve the add-on zip with the file name matching add-on name.
We also want hash file to verify the intergrity, built using same algorythm as EE update hash file.