### PR TITLE
"Licenses" tab on add-ons page in CP

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/mod.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/mod.file.php
@@ -481,11 +481,16 @@ class File
             }
         } else {
             $addon = ee('Addon')->get(ee()->input->get('addon'));
-            $filename = ee()->input->get('file');
-            if (!in_array($filename, ['icon.svg', 'icon.png'])) {
-                $filename = 'icon.svg';
+            // if there is no add-on folder, go to cache/store folder
+            if (is_null($addon)) {
+                $path = PATH_CACHE . 'store/' . ee()->input->get('addon') . '/icon';
+            } else {
+                $filename = ee()->input->get('file');
+                if (!in_array($filename, ['icon.svg', 'icon.png'])) {
+                    $filename = 'icon.svg';
+                }
+                $path = $addon->getPath() . '/' . $filename;
             }
-            $path = $addon->getPath() . '/' . $filename;
         }
         if (empty($path)) {
             $path = 'icon.svg';

--- a/system/ee/ExpressionEngine/Addons/file/mod.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/mod.file.php
@@ -483,7 +483,15 @@ class File
             $addon = ee('Addon')->get(ee()->input->get('addon'));
             // if there is no add-on folder, go to cache/store folder
             if (is_null($addon)) {
-                $path = PATH_CACHE . 'store/' . ee()->input->get('addon') . '/icon';
+                $cache_key = 'store/' . ee()->input->get('addon') . '/icon';
+                $data = ee()->cache->get($cache_key, Cache::GLOBAL_SCOPE);
+                if (!empty($data)) {
+                    $finfo = ee()->cache->file->get_metadata($cache_key, Cache::GLOBAL_SCOPE);
+                    ee()->output->send_cache_headers($finfo['mtime'], 2592000, $cache_key);
+                    $mime = ee('MimeType')->ofBuffer($data);
+                } else {
+                    unset($data);
+                }
             } else {
                 $filename = ee()->input->get('file');
                 if (!in_array($filename, ['icon.svg', 'icon.png'])) {
@@ -498,18 +506,21 @@ class File
 
         ee()->output->out_type = 'cp_asset';
         ee()->output->enable_profiler(false);
-        if (file_exists($path) && is_file($path)) {
-            ee()->output->send_cache_headers(filemtime($path), 5184000, $path);
-        } else {
-            $path = PATH_THEMES . 'asset/img/default-addon-icon.svg';
+        if (!isset($data)) {
+            if (file_exists($path) && is_file($path)) {
+                ee()->output->send_cache_headers(filemtime($path), 5184000, $path);
+                $mime = ee('MimeType')->ofFile($path);
+            } else {
+                $path = PATH_THEMES . 'asset/img/default-addon-icon.svg';
+                $mime = 'image/svg+xml';
+            }
+            $data = file_get_contents($path);
         }
-        $mime = ee('MimeType')->ofFile($path);
         if ($mime == 'image/svg') {
             $mime = 'image/svg+xml';
         }
         @header('Content-type: ' . $mime);
-
-        ee()->output->set_output(file_get_contents($path));
+        ee()->output->set_output($data);
 
         if (ee()->config->item('send_headers') == 'y') {
             @header('Content-Length: ' . strlen(ee()->output->final_output));

--- a/system/ee/ExpressionEngine/Cli/Cli.php
+++ b/system/ee/ExpressionEngine/Cli/Cli.php
@@ -103,6 +103,7 @@ class Cli
         'addons:list' => Commands\CommandAddonsList::class,
         'addons:uninstall' => Commands\CommandAddonsUninstall::class,
         'addons:update' => Commands\CommandAddonsUpdate::class,
+        'addons:unpack' => Commands\CommandAddonsUnpack::class,
 
         // Backup
         'backup:database' => Commands\CommandBackupDatabase::class,

--- a/system/ee/ExpressionEngine/Cli/Cli.php
+++ b/system/ee/ExpressionEngine/Cli/Cli.php
@@ -104,6 +104,7 @@ class Cli
         'addons:uninstall' => Commands\CommandAddonsUninstall::class,
         'addons:update' => Commands\CommandAddonsUpdate::class,
         'addons:unpack' => Commands\CommandAddonsUnpack::class,
+        'addons:pack' => Commands\CommandAddonsPack::class,
 
         // Backup
         'backup:database' => Commands\CommandBackupDatabase::class,

--- a/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsPack.php
+++ b/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsPack.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Cli\Commands;
+
+use ExpressionEngine\Cli\Cli;
+use ExpressionEngine\Service\Updater\Downloader\UpdaterPaths;
+use FilesystemIterator;
+
+/**
+ * Command to pack addon to zip
+ */
+class CommandAddonsPack extends Cli
+{
+    use UpdaterPaths;
+
+    /**
+     * name of command
+     * @var string
+     */
+    public $name = 'Packs an add-on';
+
+    /**
+     * signature of command
+     * @var string
+     */
+    public $signature = 'addons:pack';
+
+    /**
+     * How to use command
+     * @var string
+     */
+    public $usage = 'php eecli.php addons:pack -a <addon_name>';
+
+    /**
+     * options available for use in command
+     * @var array
+     */
+    public $commandOptions = [
+        'addon,a:'        => 'command_addons_pack_option_addon',
+    ];
+
+    protected $data = [];
+
+    /**
+     * Run the command
+     * @return mixed
+     */
+    public function handle()
+    {
+        defined('CLI_VERBOSE') || define('CLI_VERBOSE', $this->option('-v', false));
+        ee()->lang->loadfile('addons');
+        $this->info('command_addons_pack_begin');
+
+        $packer = ee('Updater/Packer');
+
+        $addonShortName = $this->data['addon'] = $this->getOptionOrAskAddon('--addon', "command_addons_pack_ask_addon", 'first', true, 'all');
+
+        $addon = ee('pro:Addon')->get($this->data['addon']);
+
+        $packer->setAddonArchivePath($addonShortName);
+
+        $this->info(sprintf(lang('command_addons_pack_in_progress'), $addon->getName()));
+
+        try {
+            $resultMessage = $packer->packAddon($addonShortName);
+        } catch (\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+
+        $this->info($resultMessage);
+    }
+}

--- a/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsUnpack.php
+++ b/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsUnpack.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Cli\Commands;
+
+use ExpressionEngine\Cli\Cli;
+use ExpressionEngine\Service\Updater\Downloader\UpdaterPaths;
+use FilesystemIterator;
+
+/**
+ * Command to unpack addon and move to proper location
+ */
+class CommandAddonsUnpack extends Cli
+{
+    use UpdaterPaths;
+
+    /**
+     * name of command
+     * @var string
+     */
+    public $name = 'Unpacks an add-on';
+
+    /**
+     * signature of command
+     * @var string
+     */
+    public $signature = 'addons:unpack';
+
+    /**
+     * How to use command
+     * @var string
+     */
+    public $usage = 'php eecli.php addons:unpack -a <addon_name>';
+
+    /**
+     * options available for use in command
+     * @var array
+     */
+    public $commandOptions = [
+        'addon,a:'        => 'command_addons_unpack_option_addon',
+        'delete-zip,d'    => 'command_addons_unpack_option_delete_zip',
+    ];
+
+    protected $data = [];
+
+    /**
+     * Run the command
+     * @return mixed
+     */
+    public function handle()
+    {
+        defined('CLI_VERBOSE') || define('CLI_VERBOSE', $this->option('-v', false));
+        ee()->lang->loadfile('addons');
+        $this->info('command_addons_unpack_begin');
+
+        $unpacker = ee('Updater/Unpacker');
+
+        // get the list of zip files
+        $addons = $unpacker->getAddonsList();
+
+        // Gather all the addon information
+        $addonShortName = $this->data['addon'] = $this->getOptionOrAsk('--addon', "command_addons_unpack_ask_addon", 'first', true, $addons);
+
+        // unpack the addon
+        $this->info(sprintf(lang('command_addons_unpack_in_progress'), $addonShortName));
+
+        $unpacker->setAddonArchivePath($addonShortName);
+        $unpacker->unzipPackage();
+
+        $this->info(sprintf(lang('command_addons_unpack_moving_files'), $addonShortName));
+
+        try {
+            $resultMessage = $unpacker->unpackAndMoveAddon($addonShortName, $this->option('--delete-zip'));
+        } catch (\Exception $e) {
+            $this->fail($e->getMessage());
+        }
+
+        $this->info($resultMessage);
+    }
+
+    public function getOptionOrAsk($option, $askText, $default = '', $required = false, $addonList = [])
+    {
+        // Get option if it was passed
+        if ($this->option($option)) {
+            return $this->option($option);
+        }
+
+        // Get the answer by asking
+        $answer = $this->askAddon(lang($askText), $addonList, $default);
+
+        // If it was a required field and no answer was passed, fail
+        if ($required && empty(trim($answer))) {
+            $this->fail(lang('cli_error_is_required_field') . $option);
+        }
+
+        return $answer;
+    }
+}

--- a/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsUnpack.php
+++ b/system/ee/ExpressionEngine/Cli/Commands/CommandAddonsUnpack.php
@@ -61,9 +61,14 @@ class CommandAddonsUnpack extends Cli
         $this->info('command_addons_unpack_begin');
 
         $unpacker = ee('Updater/Unpacker');
+        $unpacker->setAddonArchivePath();
 
         // get the list of zip files
         $addons = $unpacker->getAddonsList();
+
+        if (empty($addons)) {
+            $this->fail('command_addons_unpack_no_zips_found');
+        }
 
         // Gather all the addon information
         $addonShortName = $this->data['addon'] = $this->getOptionOrAsk('--addon', "command_addons_unpack_ask_addon", 'first', true, $addons);

--- a/system/ee/ExpressionEngine/Controller/Addons/Addons.php
+++ b/system/ee/ExpressionEngine/Controller/Addons/Addons.php
@@ -11,6 +11,7 @@
 namespace ExpressionEngine\Controller\Addons;
 
 use CP_Controller;
+use Cache;
 use Michelf\MarkdownExtra;
 use ExpressionEngine\Library\CP\Table;
 use ExpressionEngine\Service\Addon\Mcp;
@@ -222,6 +223,87 @@ class Addons extends CP_Controller
         $vars['updates'] = array_filter($addons, function ($addon) {
             return isset($addon['update']);
         });
+
+        // Get the list of licensed add-ons
+        $vars['licenses'] = [];
+        $licensedAddons = ee('Addon')->getLicensedAddons();
+
+        $licensedAddons = ['tagger' => ['license_status' => 'trial']]; // Temporary hardcode for testing; I don't really know the response format yet
+
+        if (!empty($licensedAddons)) {
+
+            // Get the add-on licenses info from the feed
+            $feed = ee()->cache->get('addon-feed', Cache::GLOBAL_SCOPE);
+
+            if (! $feed) {
+                try {
+                    $feed = ee('Curl')->get(
+                        'https://expressionengine.com/add-ons/addon-feed'
+                    )->exec();
+
+                    $feed = json_decode($feed, true);
+
+                    ee()->cache->save(
+                        'addon-feed',
+                        $feed,
+                        60 * 60 * 24,
+                        Cache::GLOBAL_SCOPE
+                    );
+                } catch (\Exception $e) {
+                    if (empty($feed)) {
+                        $feed = ['items' => []];
+                    }
+                }
+            }
+
+            $addonsByKey = array_filter($feed['items'], function ($item) use ($licensedAddons) {
+                return array_key_exists($item['id'], $licensedAddons);
+            });
+
+            $addonIconActionId = ee()->db->select('action_id')
+                ->where('class', 'File')
+                ->where('method', 'addonIcon')
+                ->get('actions');
+
+            foreach ($addonsByKey as $addon) {
+                $slug = $addon['id'];
+                $addon = array_merge($addon, $licensedAddons[$slug]);
+                $addon['package'] = $slug;
+                $addon['name'] = $addon['title'];
+                $addon['description'] = strip_quotes(strip_tags(ee('Security/XSS')->entity_decode($addon['summary'])));
+                $addon['installed'] = array_key_exists($slug, $vars['installed']);
+                $addon['install_url'] = ee('CP/URL')->make('addons/download/' . $slug)->compile();
+                $addon['update_url'] = ee('CP/URL')->make('addons/download/' . $slug, ['return' => $return_url->encode()]);
+                $addon['remove_url'] = ee('CP/URL')->make('addons/remove/' . $slug, ['return' => $return_url->encode()]);
+                $addon['confirm_url'] = ee('CP/URL')->make('addons/confirm/' . $slug);
+                // does the icon file exist? if not, cache for a month
+                $icon = ee()->cache->get('store/' . $slug . '/icon', Cache::GLOBAL_SCOPE);
+                if (! $icon) {
+                    try {
+                        $icon = ee('Curl')->get(
+                            $addon['image']
+                        )->exec();
+
+                        ee()->cache->save(
+                            'store/' . $slug . '/icon',
+                            $icon,
+                            30 * 60 * 60 * 24,
+                            Cache::GLOBAL_SCOPE
+                        );
+                    } catch (\Exception $e) {
+
+                    }
+                }
+                $addon['icon_url'] = ee()->functions->fetch_site_index() . QUERY_MARKER . 'ACT=' . $addonIconActionId->row('action_id') . AMP . 'addon=' . $slug;
+                $addon['show_license_status'] = true;
+                if ($addon['installed'] && version_compare($vars['installed'][$slug]['version'], $addon['version'], '<')) {
+                    $addon['update'] = $addon['version'];
+                    $addon['version'] = $vars['installed'][$slug]['version'];
+                }
+                $vars['licenses'][] = $addon;
+            }
+
+        }
 
         $vars['header'] = array(
             'search_button_value' => lang('search_addons_button'),

--- a/system/ee/ExpressionEngine/Controller/License/License.php
+++ b/system/ee/ExpressionEngine/Controller/License/License.php
@@ -47,6 +47,7 @@ class License extends CP_Controller
             'licenseStatus' => preg_replace('/[^a-z0-9_]/i', '', $licenseResponse['messageType']),
             'site_id' => filter_var(ee()->input->post('site_id'), FILTER_VALIDATE_INT),
             'site_url' => filter_var(ee()->input->post('site_url'), FILTER_VALIDATE_URL),
+            'licensedAddons' => $licenseResponse['addons'],
             'addons' => []
         ];
 

--- a/system/ee/ExpressionEngine/Service/Addon/Addon.php
+++ b/system/ee/ExpressionEngine/Service/Addon/Addon.php
@@ -794,42 +794,9 @@ class Addon
      */
     public function checkCachedLicenseResponse()
     {
-        // See if we have a cached check.
-        $cached = ee()->cache->file->get('/addons-status');
+        $data = ee('Addon')->getDataFromCachedLicenseResponse();
 
-        if (empty($cached)) {
-            return false;
-        }
-
-        if (!ee()->cache->file->is_writable('/addons-status')) {
-            $this->logLicenseError('license_error_file_not_writable');
-
-            return false;
-        }
-
-        list($cache, $integrity) = explode('||s=', $cached);
-
-        // Make sure the cache exists and has the proper integrity to use.
-        if (empty($cache) || empty($integrity) || hash('sha256', $cache) !== $integrity) {
-            $this->logLicenseError('license_error_file_broken');
-
-            return false;
-        }
-
-        $json = ee('Encrypt')->decode($cache, ee()->config->item('session_crypt_key'));
-
-        if (empty($json) || !$data = json_decode($json, true)) {
-            $this->logLicenseError('license_error_file_broken');
-
-            return false;
-        }
-
-        $sha = $data['sha'];
-        unset($data['sha']);
-
-        if ($sha !== hash('sha256', json_encode($data))) {
-            $this->logLicenseError('license_error_file_broken');
-
+        if (is_null($data)) {
             return false;
         }
 
@@ -848,26 +815,6 @@ class Addon
         }
 
         return $addonStatus;
-    }
-
-    /**
-     * Log license error to developer log and display alert in CP
-     *
-     * @param [type] $message
-     * @return void
-     */
-    private function logLicenseError($message)
-    {
-        ee()->load->library('logger');
-        ee()->logger->developer(lang($message), true);
-        if (REQ == 'CP') {
-            ee('CP/Alert')->makeBanner('license-error')
-                ->asWarning()
-                ->canClose()
-                ->withTitle(lang('license_error'))
-                ->addToBody(lang($message))
-                ->now();
-        }
     }
 
     /**

--- a/system/ee/ExpressionEngine/Service/Addon/Factory.php
+++ b/system/ee/ExpressionEngine/Service/Addon/Factory.php
@@ -108,6 +108,92 @@ class Factory
 
         return (strpos($path, PATH_ADDONS) === 0 || strpos($path, PATH_THIRD) === 0);
     }
+
+    /**
+     * Get licensed add-ons from cached license response
+     *
+     * @return array
+     */
+    public function getLicensedAddons()
+    {
+        $data = $this->getDataFromCachedLicenseResponse();
+
+        if (is_null($data) || !isset($data['licensedAddons'])) {
+            return [];
+        }
+
+        return $data['licensedAddons'];
+    }
+
+    /**
+     * Get data from cached license response
+     *
+     * @return array|null
+     */
+    public function getDataFromCachedLicenseResponse()
+    {
+        // See if we have a cached check.
+        $cached = ee()->cache->file->get('/addons-status');
+
+        if (empty($cached)) {
+            return null;
+        }
+
+        if (!ee()->cache->file->is_writable('/addons-status')) {
+            $this->logLicenseError('license_error_file_not_writable');
+
+            return null;
+        }
+
+        list($cache, $integrity) = explode('||s=', $cached);
+
+        // Make sure the cache exists and has the proper integrity to use.
+        if (empty($cache) || empty($integrity) || hash('sha256', $cache) !== $integrity) {
+            $this->logLicenseError('license_error_file_broken');
+
+            return null;
+        }
+
+        $json = ee('Encrypt')->decode($cache, ee()->config->item('session_crypt_key'));
+
+        if (empty($json) || !$data = json_decode($json, true)) {
+            $this->logLicenseError('license_error_file_broken');
+
+            return null;
+        }
+
+        $sha = $data['sha'];
+        unset($data['sha']);
+
+        if ($sha !== hash('sha256', json_encode($data))) {
+            $this->logLicenseError('license_error_file_broken');
+
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Log license error to developer log and display alert in CP
+     *
+     * @param [type] $message
+     * @return void
+     */
+    private function logLicenseError($message)
+    {
+        ee()->load->library('logger');
+        ee()->logger->developer(lang($message), true);
+        if (REQ == 'CP') {
+            ee('CP/Alert')->makeBanner('license-error')
+                ->asWarning()
+                ->canClose()
+                ->withTitle(lang('license_error'))
+                ->addToBody(lang($message))
+                ->now();
+        }
+    }
+
 }
 
 // EOF

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Packer.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Packer.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2023, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Service\Updater\Downloader;
+
+use ExpressionEngine\Service\Updater\Downloader\UpdaterPaths;
+use ExpressionEngine\Service\Updater\UpdaterException;
+use ExpressionEngine\Service\Updater\Verifier;
+use ExpressionEngine\Service\Updater\Logger;
+use ExpressionEngine\Service\Updater\RequirementsCheckerLoader;
+use ExpressionEngine\Library\Filesystem\Filesystem;
+use ZipArchive;
+use FilesystemIterator;
+
+/**
+ * Updater unpacker
+ *
+ * Unpacks the downloaded ExpressionEngine zip archive, verifies the integrity
+ * of the files, checks the downloaded installation's server requirements, and
+ * finally moves the micro app into place to facilitate the rest of the upgrade
+ */
+class Packer
+{
+    use UpdaterPaths;
+
+    protected $filesystem;
+    protected $zip_archive;
+
+    protected $manifest_location = 'system/ee/installer/updater/hash-manifest';
+
+    /**
+     * Constructor
+     *
+     * @param Filesystem $filesystem Filesystem service object
+     * @param ZipArchive $zip_archive PHP-native ZipArchive object
+     */
+    public function __construct(Filesystem $filesystem, ZipArchive $zip_archive)
+    {
+        $this->filesystem = $filesystem;
+        $this->zip_archive = $zip_archive;
+    }
+
+    /**
+     * Pack and copy the addon folder
+     *
+     * @param string $addonShortName Short name of the addon
+     * @return string Result message
+     */
+    public function packAddon($addonShortName)
+    {
+        $destinationPath = $this->path() . $addonShortName;
+
+        // if the folder already exists, remove it
+        if (ee('Filesystem')->exists($destinationPath)) {
+            ee('Filesystem')->deleteDir($destinationPath);
+        }
+        try {
+            ee('Filesystem')->copy(PATH_THIRD . $addonShortName, $destinationPath . '/system/user/addons/' . $addonShortName);
+        } catch (\Exception $e) {
+            throw new \Exception(lang('addons_pack_copy_failed'));
+        }
+
+        if (ee('Filesystem')->exists(PATH_THIRD_THEMES . $addonShortName)) {
+            try {
+                ee('Filesystem')->copy(PATH_THIRD_THEMES . $addonShortName, $destinationPath . '/themes/user/' . $addonShortName);
+            } catch (\Exception $e) {
+                throw new \Exception(lang('addons_pack_copy_failed'));
+            }
+        }
+
+        if (ee('Filesystem')->exists($this->getArchiveFilePath())) {
+            ee('Filesystem')->rename($this->getArchiveFilePath(), $this->path() . $addonShortName . '_'. ee()->localize->now . '.zip');
+        }
+
+        $this->zip_archive->open($this->getArchiveFilePath(), ZipArchive::CREATE | ZipArchive::OVERWRITE);
+
+        // Create recursive directory iterator
+        // Skip parent and root directories ( "." and ".." )
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($destinationPath, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        foreach ($files as $name => $file) {
+            // Get real and relative path for current file
+            $filePath = $file->getRealPath();
+
+            // Calculate the relative path within the zip archive
+            // The +1 is to remove the leading slash from the relative path if the source path is absolute
+            $relativePath = substr($filePath, strlen($destinationPath) + 1);
+
+            if (!$file->isDir()) {
+                // Add current file to archive
+                $this->zip_archive->addFile($filePath, $relativePath);
+            } else {
+                // Add empty directory to archive (only if it's an actual directory and not just a file path component)
+                // Note: addFile() automatically creates parent directories when adding a file path
+                if ($relativePath !== false) {
+                    $this->zip_archive->addEmptyDir($relativePath);
+                }
+            }
+        }
+
+        $this->zip_archive->close();
+
+        ee('Filesystem')->deleteDir($this->getExtractedArchivePath());
+
+        $addon = ee('pro:Addon')->get($addonShortName);
+        $resultMessage = sprintf(lang('addons_pack_complete'), $addon->getName());
+
+        return $resultMessage;
+    }
+}
+
+// EOF

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
@@ -38,14 +38,18 @@ class Unpacker
 
     protected $manifest_location = 'system/ee/installer/updater/hash-manifest';
 
+    protected $addonZipFolders = [];
+    protected $addonFolders = [];
+    protected $themesFolders = [];
+
     /**
      * Constructor
      *
-     * @param	Filesystem $filesystem Filesystem service object
-     * @param	ZipArchive $zip_archive PHP-native ZipArchive object
-     * @param	Verifier $verifier File verifier object
-     * @param	Logger $logger 	Updater logger object
-     * @param	RequirementsCheckerLoader $requirements Requirements checker loader object
+     * @param   Filesystem $filesystem Filesystem service object
+     * @param   ZipArchive $zip_archive PHP-native ZipArchive object
+     * @param   Verifier $verifier File verifier object
+     * @param   Logger $logger Updater logger object
+     * @param   RequirementsCheckerLoader $requirements Requirements checker loader object
      */
     public function __construct(Filesystem $filesystem, ZipArchive $zip_archive, Verifier $verifier, Logger $logger, RequirementsCheckerLoader $requirements)
     {
@@ -202,110 +206,14 @@ class Unpacker
         // - there is a single folder inside the extracted folder that contains the files, matching the addon name
         // - there is system/user/addons structure inside the extracted folder
         $extracted = $this->getExtractedArchivePath();
-        $addonFolders = [];
-        $themesFolders = [];
-        $somethingFound = false;
-        $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
-        foreach ($files as $item) {
-            if ($item->isDir() && !in_array($item->getBasename(), ['.', '..']) && !in_array($item->getBasename(), ['system', 'themes'])) {
-                $firstDir = $item->getBasename();
-            }
-            if ($item->getBasename() == 'addon.setup.php') {
-                $addonFolders[$addonShortName] = $extracted;
-                $somethingFound = true;
-                break;
-            }
-            if ($item->isDir() && $item->getBasename() == $addonShortName) {
-                $addonFolders[$addonShortName] = $item->getPathname();
-                $somethingFound = true;
-                break;
-            }
+
+        $this->iterateForAddon($extracted, $addonShortName);
+
+        if (!array_key_exists($addonShortName, $this->addonFolders)) {
+            $addonShortName = array_key_first($this->addonFolders);
         }
 
-        if (!$somethingFound) {
-            // look deeper
-            if (isset($firstDir)) {
-                $extracted .= '/' . $firstDir;
-                $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
-                foreach ($files as $item) {
-                    if ($item->getBasename() == 'addon.setup.php') {
-                        $addonFolders[$addonShortName] = $extracted;
-                        break;
-                    }
-                    if ($item->isDir() && $item->getBasename() == $addonShortName) {
-                        $addonFolders[$addonShortName] = $item->getPathname();
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (empty($addonFolders)) {
-            $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
-            foreach ($files as $item) {
-                if ($item->isDir() && $item->getBasename() == 'system') {
-                    $systemFiles = new FilesystemIterator($item->getPathname(), FilesystemIterator::UNIX_PATHS);
-                    foreach ($systemFiles as $subitem) {
-                        if ($subitem->isDir() && $subitem->getBasename() == $addonShortName) {
-                            $addonFolders[$addonShortName] = $subitem->getPathname();
-                            break;
-                        }
-                        if ($subitem->isDir() && $subitem->getBasename() == 'user') {
-                            $userFiles = new FilesystemIterator($subitem->getPathname(), FilesystemIterator::UNIX_PATHS);
-                            foreach ($userFiles as $userSubitem) {
-                                if ($userSubitem->isDir() && $userSubitem->getBasename() == 'addons') {
-                                    $userAddonsFiles = new FilesystemIterator($userSubitem->getPathname(), FilesystemIterator::UNIX_PATHS);
-                                    foreach ($userAddonsFiles as $addonSubitem) {
-                                        // there can be multiple adddons, so we need each folder that has a setup file
-                                        if ($addonSubitem->isDir() && !in_array($addonSubitem->getBasename(), ['.', '..'])) {
-                                            $addonFolderFiles = new FilesystemIterator($addonSubitem->getPathname(), FilesystemIterator::UNIX_PATHS);
-                                            foreach ($addonFolderFiles as $file) {
-                                                if ($file->getBasename() == 'addon.setup.php') {
-                                                    $addonFolders[$addonSubitem->getBasename()] = $addonSubitem->getPathname();
-                                                    break;
-                                                }
-                                            }
-                                        }
-                                    }
-                                    break 2;
-                                }
-                            }
-                        }
-                    }
-                }
-                if ($item->isDir() && $item->getBasename() == 'themes') {
-                    $themeFiles = new FilesystemIterator($item->getPathname(), FilesystemIterator::UNIX_PATHS);
-                    foreach ($themeFiles as $subitem) {
-                        if ($subitem->isDir() && $subitem->getBasename() == $addonShortName) {
-                            $themesFolders[$subitem->getBasename()] = $subitem->getPathname();
-                            break;
-                        }
-                        if ($subitem->isDir() && $subitem->getBasename() == 'user') {
-                            $userFiles = new FilesystemIterator($subitem->getPathname(), FilesystemIterator::UNIX_PATHS);
-                            foreach ($userFiles as $userSubitem) {
-                                if ($userSubitem->isDir() && !in_array($userSubitem->getBasename(), ['.', '..'])) {
-                                    $themesFolders[$userSubitem->getBasename()] = $userSubitem->getPathname();
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // make sure the folder has addon.setup.php file
-        foreach ($addonFolders as $i => $addonFolder) {
-            $files = new FilesystemIterator($addonFolder, FilesystemIterator::UNIX_PATHS);
-            foreach ($files as $item) {
-                if ($item->getBasename() == 'addon.setup.php') {
-                    break 2;
-                }
-            }
-            // if no setup file, remove from the list
-            unset($addonFolders[$i]);
-        }
-
-        if (empty($addonFolders)) {
+        if (empty($this->addonFolders)) {
             ee('Filesystem')->deleteDir($this->getExtractedArchivePath());
             throw new \Exception(lang('addons_unpack_invalid_structure'));
         }
@@ -313,7 +221,7 @@ class Unpacker
         $failedToMove = [];
         $backupFolderId = uniqid();
         // copy everything we have to addons folder
-        foreach ($addonFolders as $addonName => $addonFolder) {
+        foreach ($this->addonFolders as $addonName => $addonFolder) {
             // back up first
             if (ee('Filesystem')->exists(PATH_THIRD . $addonName)) {
                 ee('Filesystem')->copy(PATH_THIRD . $addonName, $this->path() . 'backup/' . $addonName . '_' . $backupFolderId);
@@ -333,9 +241,9 @@ class Unpacker
             }
         }
 
-        if (!empty($themesFolders)) {
+        if (!empty($this->themesFolders)) {
             // copy themes if we have them
-            foreach ($themesFolders as $folderName => $themesFolder) {
+            foreach ($this->themesFolders as $folderName => $themesFolder) {
                 // back up first
                 if (ee('Filesystem')->exists(PATH_THIRD_THEMES . $folderName)) {
                     ee('Filesystem')->copy(PATH_THIRD_THEMES . $folderName, $this->path() . 'backup_themes/' . $folderName . '_' . $backupFolderId);
@@ -377,6 +285,52 @@ class Unpacker
         }
 
         return $resultMessage;
+    }
+
+    /**
+     * Look for add-on and themes folders
+     *
+     * @param string $directory
+     * @param string $addonShortName
+     * @return void
+     */
+    private function iterateForAddon($directory, $addonShortName)
+    {
+        $directory = realpath($directory);
+
+        $files = new FilesystemIterator($directory, FilesystemIterator::UNIX_PATHS | FilesystemIterator::SKIP_DOTS);
+        foreach ($files as $item) {
+            // is this the addon folder?
+            if ($item->getBasename() == 'addon.setup.php') {
+                $this->addonFolders[$addonShortName] = $directory;
+                break;
+            }
+            // if it's not add-on folder, is this a themes folder?
+            $normalizedPath = str_replace('\\', '/', $item->getPathname());
+            if (strpos($normalizedPath, '/themes/user') !== false && strpos($normalizedPath, '/themes/user') === strlen($normalizedPath) - strlen('/themes/user') && $item->isDir()) {
+                $themeFiles = new FilesystemIterator($normalizedPath, FilesystemIterator::UNIX_PATHS | FilesystemIterator::SKIP_DOTS);
+                foreach ($themeFiles as $item) {
+                    if ($item->isDir()) {
+                        $this->themesFolders[$item->getBasename()] = $item->getPathname();
+                    }
+                }
+                break;
+            }
+            // go deeper
+            if ($item->isDir() && !in_array(realpath($item->getPathname()), $this->addonZipFolders)) {
+                return $this->iterateForAddon($item->getPathname(), $item->getBasename());
+            }
+        }
+
+        $this->addonZipFolders[] = $directory;
+
+        // go up one level
+        while ($directory != realpath($this->getExtractedArchivePath())) {
+            $directory = realpath($directory . '/..');
+            if (!in_array($directory, $this->addonZipFolders)) {
+                return $this->iterateForAddon($directory, $addonShortName);
+            }
+        }
     }
 }
 

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
@@ -17,6 +17,7 @@ use ExpressionEngine\Service\Updater\Logger;
 use ExpressionEngine\Service\Updater\RequirementsCheckerLoader;
 use ExpressionEngine\Library\Filesystem\Filesystem;
 use ZipArchive;
+use FilesystemIterator;
 
 /**
  * Updater unpacker
@@ -167,6 +168,213 @@ class Unpacker
                 $e->getCode()
             );
         }
+    }
+
+    /**
+     * Get the list of add-on zip files in folder
+     *
+     * @return array List of add-on short names
+     */
+    public function getAddonsList()
+    {
+        $addons = [];
+        $path = $this->path('addons');
+        $files = new \FilesystemIterator($path, \FilesystemIterator::UNIX_PATHS);
+        foreach ($files as $item) {
+            if ($item->getExtension() == 'zip') {
+                $addons[] = $item->getBasename('.zip');
+            }
+        }
+        return $addons;
+    }
+
+    /**
+     * Unpack and move the addon to the correct location
+     *
+     * @param string $addonShortName Short name of the addon
+     * @return string Result message
+     */
+    public function unpackAndMoveAddon($addonShortName, $deleteZip = false)
+    {
+        // check if it has correct folder structure
+        // several options here:
+        // - the files are directly in the extracted folder
+        // - there is a single folder inside the extracted folder that contains the files, matching the addon name
+        // - there is system/user/addons structure inside the extracted folder
+        $extracted = $this->getExtractedArchivePath();
+        $addonFolders = [];
+        $themesFolders = [];
+        $somethingFound = false;
+        $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
+        foreach ($files as $item) {
+            if ($item->isDir() && !in_array($item->getBasename(), ['.', '..'])) {
+                $firstDir = $item->getBasename();
+            }
+            if ($item->getBasename() == 'addon.setup.php') {
+                $addonFolders[$addonShortName] = $extracted;
+                $somethingFound = true;
+                break;
+            }
+            if ($item->isDir() && $item->getBasename() == $addonShortName) {
+                $addonFolders[$addonShortName] = $item->getPathname();
+                $somethingFound = true;
+                break;
+            }
+        }
+
+        if (!$somethingFound) {
+            // look deeper
+            if (isset($firstDir)) {
+                $extracted .= '/' . $firstDir;
+                $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
+                foreach ($files as $item) {
+                    if ($item->getBasename() == 'addon.setup.php') {
+                        $addonFolders[$addonShortName] = $extracted;
+                        break;
+                    }
+                    if ($item->isDir() && $item->getBasename() == $addonShortName) {
+                        $addonFolders[$addonShortName] = $item->getPathname();
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (empty($addonFolders)) {
+            $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
+            foreach ($files as $item) {
+                if ($item->isDir() && $item->getBasename() == 'system') {
+                    $systemFiles = new FilesystemIterator($item->getPathname(), FilesystemIterator::UNIX_PATHS);
+                    foreach ($systemFiles as $subitem) {
+                        if ($subitem->isDir() && $subitem->getBasename() == $addonShortName) {
+                            $addonFolders[$addonShortName] = $subitem->getPathname();
+                            break;
+                        }
+                        if ($subitem->isDir() && $subitem->getBasename() == 'user') {
+                            $userFiles = new FilesystemIterator($subitem->getPathname(), FilesystemIterator::UNIX_PATHS);
+                            foreach ($userFiles as $userSubitem) {
+                                if ($userSubitem->isDir() && $userSubitem->getBasename() == 'addons') {
+                                    $userAddonsFiles = new FilesystemIterator($userSubitem->getPathname(), FilesystemIterator::UNIX_PATHS);
+                                    foreach ($userAddonsFiles as $addonSubitem) {
+                                        // there can be multiple adddons, so we need each folder that has a setup file
+                                        if ($addonSubitem->isDir() && !in_array($addonSubitem->getBasename(), ['.', '..'])) {
+                                            $addonFolderFiles = new FilesystemIterator($addonSubitem->getPathname(), FilesystemIterator::UNIX_PATHS);
+                                            foreach ($addonFolderFiles as $file) {
+                                                if ($file->getBasename() == 'addon.setup.php') {
+                                                    $addonFolders[$addonSubitem->getBasename()] = $addonSubitem->getPathname();
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    break 2;
+                                }
+                            }
+                        }
+                    }
+                }
+                if ($item->isDir() && $item->getBasename() == 'themes') {
+                    $themeFiles = new FilesystemIterator($item->getPathname(), FilesystemIterator::UNIX_PATHS);
+                    foreach ($themeFiles as $subitem) {
+                        if ($subitem->isDir() && $subitem->getBasename() == $addonShortName) {
+                            $themesFolders[$subitem->getBasename()] = $subitem->getPathname();
+                            break;
+                        }
+                        if ($subitem->isDir() && $subitem->getBasename() == 'user') {
+                            $userFiles = new FilesystemIterator($subitem->getPathname(), FilesystemIterator::UNIX_PATHS);
+                            foreach ($userFiles as $userSubitem) {
+                                if ($userSubitem->isDir() && !in_array($userSubitem->getBasename(), ['.', '..'])) {
+                                    $themesFolders[$userSubitem->getBasename()] = $userSubitem->getPathname();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // make sure the folder has addon.setup.php file
+        foreach ($addonFolders as $i => $addonFolder) {
+            $files = new FilesystemIterator($addonFolder, FilesystemIterator::UNIX_PATHS);
+            foreach ($files as $item) {
+                if ($item->getBasename() == 'addon.setup.php') {
+                    break 2;
+                }
+            }
+            // if no setup file, remove from the list
+            unset($addonFolders[$i]);
+        }
+
+        if (empty($addonFolders)) {
+            ee('Filesystem')->deleteDir($this->getExtractedArchivePath());
+            throw new \Exception(lang('addons_unpack_invalid_structure'));
+        }
+
+        $failedToMove = [];
+        $backupFolderId = uniqid();
+        // copy everything we have to addons folder
+        foreach ($addonFolders as $addonName => $addonFolder) {
+            // back up first
+            if (ee('Filesystem')->exists(PATH_THIRD . $addonName)) {
+                ee('Filesystem')->copy(PATH_THIRD . $addonName, $this->path() . 'backup/' . $addonName . '_' . $backupFolderId);
+                ee('Filesystem')->deleteDir(PATH_THIRD . $addonName);
+            }
+            try {
+                ee('Filesystem')->copy($addonFolder, PATH_THIRD . $addonName);
+            } catch (\Exception $e) {
+                if (ee('Filesystem')->exists($this->path() . 'backup/' . $addonName . '_' . $backupFolderId)) {
+                    // Remove the copied files
+                    ee('Filesystem')->deleteDir(PATH_THIRD . $addonName);
+
+                    // Restore from backup
+                    ee('Filesystem')->copy($this->path() . 'backup/' . $addonName . '_' . $backupFolderId, PATH_THIRD . $addonName);
+                }
+                $failedToMove[] = 'addons/' . $addonName;
+            }
+        }
+
+        if (!empty($themesFolders)) {
+            // copy themes if we have them
+            foreach ($themesFolders as $folderName => $themesFolder) {
+                // back up first
+                if (ee('Filesystem')->exists(PATH_THIRD_THEMES . $folderName)) {
+                    ee('Filesystem')->copy(PATH_THIRD_THEMES . $folderName, $this->path() . 'backup_themes/' . $folderName . '_' . $backupFolderId);
+                    ee('Filesystem')->deleteDir(PATH_THIRD_THEMES . $folderName);
+                }
+                try {
+                    ee('Filesystem')->copy($themesFolder, PATH_THIRD_THEMES . $folderName);
+                } catch (\Exception $e) {
+                    if (ee('Filesystem')->exists($this->path() . 'backup_themes/' . $folderName . '_' . $backupFolderId)) {
+                        // Remove the copied files
+                        ee('Filesystem')->deleteDir(PATH_THIRD_THEMES . $folderName);
+
+                        // Restore from backup
+                        ee('Filesystem')->copy($this->path() . 'backup_themes/' . $folderName . '_' . $backupFolderId, PATH_THIRD_THEMES . $folderName);
+                    }
+                    $failedToMove[] = 'themes/' . $folderName;
+                }
+            }
+        }
+
+        // remove the leftover files
+        ee('Filesystem')->deleteDir($this->getExtractedArchivePath());
+        if (empty($failedToMove)) {
+            ee('Filesystem')->deleteDir($this->path() . 'backup');
+            if (ee('Filesystem')->exists($this->path() . 'backup_themes')) {
+                ee('Filesystem')->deleteDir($this->path() . 'backup_themes');
+            }
+
+            if ($deleteZip) {
+                ee('Filesystem')->delete($this->getArchiveFilePath());
+            }
+
+            $addon = ee('pro:Addon')->get($addonShortName);
+            $resultMessage = sprintf(lang('command_addons_unpack_complete'), $addon->getName());
+        } else {
+            $resultMessage = sprintf(lang('command_addons_unpack_failed'), implode(', ', $failedToMove));
+        }
+
+        return $resultMessage;
     }
 }
 

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/Unpacker.php
@@ -207,7 +207,7 @@ class Unpacker
         $somethingFound = false;
         $files = new FilesystemIterator($extracted, FilesystemIterator::UNIX_PATHS);
         foreach ($files as $item) {
-            if ($item->isDir() && !in_array($item->getBasename(), ['.', '..'])) {
+            if ($item->isDir() && !in_array($item->getBasename(), ['.', '..']) && !in_array($item->getBasename(), ['system', 'themes'])) {
                 $firstDir = $item->getBasename();
             }
             if ($item->getBasename() == 'addon.setup.php') {
@@ -359,7 +359,9 @@ class Unpacker
         // remove the leftover files
         ee('Filesystem')->deleteDir($this->getExtractedArchivePath());
         if (empty($failedToMove)) {
-            ee('Filesystem')->deleteDir($this->path() . 'backup');
+            if (ee('Filesystem')->exists($this->path() . 'backup')) {
+                ee('Filesystem')->deleteDir($this->path() . 'backup');
+            }
             if (ee('Filesystem')->exists($this->path() . 'backup_themes')) {
                 ee('Filesystem')->deleteDir($this->path() . 'backup_themes');
             }
@@ -369,9 +371,9 @@ class Unpacker
             }
 
             $addon = ee('pro:Addon')->get($addonShortName);
-            $resultMessage = sprintf(lang('command_addons_unpack_complete'), $addon->getName());
+            $resultMessage = sprintf(lang('addons_unpack_complete'), $addon->getName());
         } else {
-            $resultMessage = sprintf(lang('command_addons_unpack_failed'), implode(', ', $failedToMove));
+            $resultMessage = sprintf(lang('addons_unpack_failed'), implode(', ', $failedToMove));
         }
 
         return $resultMessage;

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/UpdaterPaths.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/UpdaterPaths.php
@@ -17,6 +17,7 @@ trait UpdaterPaths
 {
     protected $filename = 'ExpressionEngine.zip';
     protected $extracted_folder = 'ExpressionEngine';
+    protected $folder = 'ee_update';
 
     /**
      * Constructs and returns the path to the downloaded zip archive
@@ -46,13 +47,25 @@ trait UpdaterPaths
      */
     protected function path()
     {
-        $cache_path = PATH_CACHE . 'ee_update/';
+        $cache_path = PATH_CACHE . $this->folder . '/';
 
         if (! is_dir($cache_path)) {
             $this->filesystem->mkDir($cache_path);
         }
 
         return $cache_path;
+    }
+
+    /**
+     * Sets the addon archive path and extracted folder name
+     *
+     * @param string $addon_name Name of the addon
+     */
+    public function setAddonArchivePath($addon_name)
+    {
+        $this->folder = 'addons';
+        $this->filename = $addon_name . '.zip';
+        $this->extracted_folder = $addon_name;
     }
 }
 // EOF

--- a/system/ee/ExpressionEngine/Service/Updater/Downloader/UpdaterPaths.php
+++ b/system/ee/ExpressionEngine/Service/Updater/Downloader/UpdaterPaths.php
@@ -61,11 +61,13 @@ trait UpdaterPaths
      *
      * @param string $addon_name Name of the addon
      */
-    public function setAddonArchivePath($addon_name)
+    public function setAddonArchivePath($addon_name = '')
     {
         $this->folder = 'addons';
-        $this->filename = $addon_name . '.zip';
-        $this->extracted_folder = $addon_name;
+        if (!empty($addon_name)) {
+            $this->filename = $addon_name . '.zip';
+            $this->extracted_folder = $addon_name;
+        }
     }
 }
 // EOF

--- a/system/ee/ExpressionEngine/View/_shared/add-on-card.php
+++ b/system/ee/ExpressionEngine/View/_shared/add-on-card.php
@@ -59,7 +59,7 @@
 	</div>
 
 	<?php endif; ?>
-	<?php if ($addon['installed'] && !empty($addon['license_status']) && !in_array($addon['license_status'], ['na', 'license_valid', 'valid'])) : ?>
+	<?php if (($addon['installed'] || (isset($addon['show_license_status']) && $addon['show_license_status'])) && !empty($addon['license_status']) && !in_array($addon['license_status'], ['na', 'license_valid', 'valid'])) : ?>
 		<div class="corner-ribbon-wrap">
 			<p class="corner-ribbon top-left <?=$addon['license_status']?> shadow"<?php if ($addon['license_status'] == 'update_available') : ?> style="font-size: 62%;"<?php endif ;?>><?=lang('license_' . $addon['license_status'])?></p>
 		</div>

--- a/system/ee/ExpressionEngine/View/addons/index.php
+++ b/system/ee/ExpressionEngine/View/addons/index.php
@@ -14,23 +14,27 @@
             <span class="tab-bar__tab-notification"><?=count($updates)?></span>
         </button>
         <?php endif; ?>
+        <button type="button" class="tab-bar__tab js-tab-button" rel="t-licenses">
+            <?=lang('licensed')?>
+            <span class="tab-bar__tab-notification tab-notification-generic"><?=count($licenses)?></span></button>
+        </button>
     </div>
 </div>
 
 <div class="tab t-all tab-open">
 
     <div class="add-on-card-list">
-        <?php $addons = $installed; foreach ($addons as $addon): ?>
+        <?php $addons = $installed; foreach ($addons as $addon) : ?>
             <?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => false]); ?>
         <?php endforeach; ?>
     </div>
 
-    <?php if (count($uninstalled)): ?>
+    <?php if (count($uninstalled)) : ?>
         <h4 class="line-heading"><?=lang('uninstalled')?></h4>
         <hr>
 
         <div class="add-on-card-list">
-            <?php foreach ($uninstalled as $addon): ?>
+            <?php foreach ($uninstalled as $addon) : ?>
                 <?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => false]); ?>
             <?php endforeach; ?>
         </div>
@@ -40,7 +44,17 @@
 <?php if (!empty($updates)) : ?>
     <div class="tab t-updates">
         <div class="add-on-card-list">
-            <?php foreach ($updates as $addon): ?>
+            <?php foreach ($updates as $addon) : ?>
+                <?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => true]); ?>
+            <?php endforeach; ?>
+        </div>
+    </div>
+<?php endif; ?>
+
+<?php if (!empty($licenses)) : ?>
+    <div class="tab t-licenses">
+        <div class="add-on-card-list">
+            <?php foreach ($licenses as $addon) : ?>
                 <?php $this->embed('_shared/add-on-card', ['addon' => $addon, 'show_updates' => true]); ?>
             <?php endforeach; ?>
         </div>

--- a/system/ee/ExpressionEngine/app.setup.php
+++ b/system/ee/ExpressionEngine/app.setup.php
@@ -298,6 +298,15 @@ $setup = [
             );
         },
 
+        'Updater/Packer' => function ($ee) {
+            $filesystem = $ee->make('Filesystem');
+
+            return new Updater\Downloader\Packer(
+                $ee->make('Filesystem'),
+                new \ZipArchive()
+            );
+        },
+
         'Updater/Preflight' => function ($ee) {
             $theme_paths = $ee->make('Model')->get('Config')
                 ->filter('key', 'theme_folder_path')

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -113,6 +113,8 @@ $lang = array(
 
     'uninstalled' => 'Uninstalled',
 
+    'licensed' => 'Licensed',
+
     /* 2.x */
 
     'configuration' => 'Configuration',

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -61,6 +61,8 @@ $lang = array(
 
     'addons_not_installed' => 'Add-Ons Not Installed',
 
+    'addons_unpack_invalid_structure' => 'The unpacked add-on does not have a valid structure.',
+
     'addon_not_fully_functional' => '%s is not fully functional',
 
     'existing_consent_request' => 'The following add-on(s) could not be installed due to an existing Consent Request which the add-on(s) are trying to create:',

--- a/system/ee/language/english/addons_lang.php
+++ b/system/ee/language/english/addons_lang.php
@@ -63,6 +63,14 @@ $lang = array(
 
     'addons_unpack_invalid_structure' => 'The unpacked add-on does not have a valid structure.',
 
+    'addons_unpack_complete' => '%s unpacked successfully',
+
+    'addons_unpack_failed' => 'Failed to unpack %s',
+
+    'addons_pack_copy_failed' => 'Failed to copy the add-on files.',
+
+    'addons_pack_complete' => '%s packed successfully',
+
     'addon_not_fully_functional' => '%s is not fully functional',
 
     'existing_consent_request' => 'The following add-on(s) could not be installed due to an existing Consent Request which the add-on(s) are trying to create:',

--- a/system/ee/language/english/cli_lang.php
+++ b/system/ee/language/english/cli_lang.php
@@ -30,6 +30,20 @@ $lang = array(
     'command_addons_install_complete'               => '%s installed successfully',
     'command_addons_install_option_addon'           => 'Add-on\'s short name',
 
+    // Lang entries for command addons:unpack
+    'command_addons_unpack_description'            => 'Unpacks an add-on and moves it to the proper location',
+    'command_addons_unpack_summary'                => '',
+    'command_addons_unpack_begin'                  => 'Add-on unpacking is about to begin',
+    'command_addons_unpack_ask_addon'              => 'Which add-on do you want to unpack?',
+    'command_addons_unpack_in_progress'            => 'Performing %s add-on unpacking',
+    'command_addons_unpack_complete'               => '%s unpacked successfully',
+    'command_addons_unpack_option_addon'           => 'Add-on\'s short name',
+    'command_addons_unpack_complete'               => '%s unpacked successfully',
+    'command_addons_unpack_option_addon'           => 'Add-on\'s short name',
+    'command_addons_unpack_option_delete_zip'      => 'Delete the original zip file after unpacking',
+    'command_addons_unpack_moving_files'           => 'Moving files to add-on folder for %s...',
+    'command_addons_some_files_not_copied'         => 'Some files were not copied: %s',
+
     // Lang entries for command addons:uninstall
     'command_addons_uninstall_description'            => 'Uninstalls add-on and all its components',
     'command_addons_uninstall_summary'                => '',

--- a/system/ee/language/english/cli_lang.php
+++ b/system/ee/language/english/cli_lang.php
@@ -36,13 +36,18 @@ $lang = array(
     'command_addons_unpack_begin'                  => 'Add-on unpacking is about to begin',
     'command_addons_unpack_ask_addon'              => 'Which add-on do you want to unpack?',
     'command_addons_unpack_in_progress'            => 'Performing %s add-on unpacking',
-    'command_addons_unpack_complete'               => '%s unpacked successfully',
-    'command_addons_unpack_option_addon'           => 'Add-on\'s short name',
-    'command_addons_unpack_complete'               => '%s unpacked successfully',
     'command_addons_unpack_option_addon'           => 'Add-on\'s short name',
     'command_addons_unpack_option_delete_zip'      => 'Delete the original zip file after unpacking',
     'command_addons_unpack_moving_files'           => 'Moving files to add-on folder for %s...',
     'command_addons_some_files_not_copied'         => 'Some files were not copied: %s',
+
+    // Lang entries for command addons:pack
+    'command_addons_pack_description'            => 'Packs an add-on into a zip file',
+    'command_addons_pack_summary'                => '',
+    'command_addons_pack_begin'                  => 'Add-on packing is about to begin',
+    'command_addons_pack_ask_addon'              => 'Which add-on do you want to pack?',
+    'command_addons_pack_in_progress'            => 'Performing %s add-on packing',
+    'command_addons_pack_option_addon'           => 'Add-on\'s short name',
 
     // Lang entries for command addons:uninstall
     'command_addons_uninstall_description'            => 'Uninstalls add-on and all its components',

--- a/system/ee/language/english/cli_lang.php
+++ b/system/ee/language/english/cli_lang.php
@@ -40,6 +40,7 @@ $lang = array(
     'command_addons_unpack_option_delete_zip'      => 'Delete the original zip file after unpacking',
     'command_addons_unpack_moving_files'           => 'Moving files to add-on folder for %s...',
     'command_addons_some_files_not_copied'         => 'Some files were not copied: %s',
+    'command_addons_unpack_no_zips_found'          => 'No add-on zip files were found to unpack.',
 
     // Lang entries for command addons:pack
     'command_addons_pack_description'            => 'Packs an add-on into a zip file',


### PR DESCRIPTION
Another follow-up for `feature/7.x/addon-unpacker` and `feature/7.x/addon-updater`
It shows list of add-ons that are licensed for this site in a new tab on add-ons listing page in CP

Is still WIP because the list of add-ons is hardcoded; need to have few add-ons with different license statuses attached to test site to finalize