### PR TITLE
Adding email_as_username param to the registration page

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
@@ -237,6 +237,7 @@ class Member_register extends Member
             'P' => ee()->functions->get_protected_form_params([
                 'primary_role' => ee()->TMPL->fetch_param('primary_role'),
                 'inline_errors' => ee()->TMPL->fetch_param('inline_errors'),
+                'email_as_username' => ee()->TMPL->fetch_param('email_as_username', 'no'),
             ]),
         );
 
@@ -289,6 +290,8 @@ class Member_register extends Member
         // Handle our protected data if any. This contains our extra params.
         $protected = ee()->functions->handle_protected();
 
+        $emailAsUsername = get_bool_from_string($protected['email_as_username'] ?? 'n');
+
         // Determine where we need to return to in case of success or error.
         $return_link = ee()->functions->determine_return();
         $return_error_link = ee()->functions->determine_error_return();
@@ -336,6 +339,11 @@ class Member_register extends Member
             if (! isset($_POST[$val])) {
                 $_POST[$val] = '';
             }
+        }
+
+        // Allow username to fall back to the submitted email when enabled
+        if ($emailAsUsername && $_POST['username'] === '' && !empty($_POST['email'])) {
+            $_POST['username'] = trim_nbs(ee()->input->post('email'));
         }
 
         if ($_POST['screen_name'] == '') {

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
@@ -661,7 +661,9 @@ class Member_register extends Member
 
     private function _apply_email_as_username_fallback($email_as_username)
     {
-        if (!$email_as_username || $_POST['username'] !== '' || empty($_POST['email'])) {
+        $username = trim_nbs((string) ($_POST['username'] ?? ''));
+
+        if (!$email_as_username || $username !== '' || empty($_POST['email'])) {
             return true;
         }
 

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
@@ -9,7 +9,6 @@
  */
 
 use ExpressionEngine\Service\Member\Member as Mbr;
-use ExpressionEngine\Service\Validation\Rule\ValidUsername;
 
 /**
  * Member Management Register
@@ -291,7 +290,7 @@ class Member_register extends Member
         // Handle our protected data if any. This contains our extra params.
         $protected = ee()->functions->handle_protected();
 
-        $emailAsUsername = get_bool_from_string($protected['email_as_username'] ?? 'n');
+        $email_as_username = get_bool_from_string($protected['email_as_username'] ?? 'n');
 
         // Determine where we need to return to in case of success or error.
         $return_link = ee()->functions->determine_return();
@@ -342,9 +341,9 @@ class Member_register extends Member
             }
         }
 
-        $fallbackResult = $this->_apply_email_as_username_fallback($emailAsUsername);
-        if ($fallbackResult !== true) {
-            return $fallbackResult;
+        $fallback_result = $this->_apply_email_as_username_fallback($email_as_username);
+        if ($fallback_result !== true) {
+            return $fallback_result;
         }
 
         if ($_POST['screen_name'] == '') {
@@ -660,9 +659,9 @@ class Member_register extends Member
         return ee()->functions->redirect($return_link);
     }
 
-    private function _apply_email_as_username_fallback($emailAsUsername)
+    private function _apply_email_as_username_fallback($email_as_username)
     {
-        if (!$emailAsUsername || $_POST['username'] !== '' || empty($_POST['email'])) {
+        if (!$email_as_username || $_POST['username'] !== '' || empty($_POST['email'])) {
             return true;
         }
 
@@ -677,19 +676,19 @@ class Member_register extends Member
 
     private function _derive_email_as_username_fallback($email)
     {
-        return trim_nbs(ValidUsername::stripDisallowedCharacters($email));
+        return trim_nbs(preg_replace("/[\|'\"!<>\{\}]/", '', (string) $email));
     }
 
     private function _is_valid_email_as_username_fallback($username)
     {
         $username = (string) $username;
-        $minLength = (int) ee()->config->item('un_min_len');
+        $min_length = (int) ee()->config->item('un_min_len');
 
         if ($username === '') {
             return false;
         }
 
-        if (strlen($username) < $minLength) {
+        if (strlen($username) < $min_length) {
             return false;
         }
 
@@ -697,7 +696,7 @@ class Member_register extends Member
             return false;
         }
 
-        return !ValidUsername::containsDisallowedCharacters($username);
+        return preg_match("/[\|'\"!<>\{\}]/", $username) !== 1;
     }
 
     private function _do_form_query()

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
@@ -9,6 +9,7 @@
  */
 
 use ExpressionEngine\Service\Member\Member as Mbr;
+use ExpressionEngine\Service\Validation\Rule\ValidUsername;
 
 /**
  * Member Management Register
@@ -341,9 +342,9 @@ class Member_register extends Member
             }
         }
 
-        // Allow username to fall back to the submitted email when enabled
-        if ($emailAsUsername && $_POST['username'] === '' && !empty($_POST['email'])) {
-            $_POST['username'] = trim_nbs(ee()->input->post('email'));
+        $fallbackResult = $this->_apply_email_as_username_fallback($emailAsUsername);
+        if ($fallbackResult !== true) {
+            return $fallbackResult;
         }
 
         if ($_POST['screen_name'] == '') {
@@ -657,6 +658,46 @@ class Member_register extends Member
         );
 
         return ee()->functions->redirect($return_link);
+    }
+
+    private function _apply_email_as_username_fallback($emailAsUsername)
+    {
+        if (!$emailAsUsername || $_POST['username'] !== '' || empty($_POST['email'])) {
+            return true;
+        }
+
+        $_POST['username'] = $this->_derive_email_as_username_fallback(ee()->input->post('email'));
+
+        if (!$this->_is_valid_email_as_username_fallback($_POST['username'])) {
+            return ee()->output->show_form_error(array('email' => lang('mbr_email_cannot_be_used_as_username')), 'submission');
+        }
+
+        return true;
+    }
+
+    private function _derive_email_as_username_fallback($email)
+    {
+        return trim_nbs(ValidUsername::stripDisallowedCharacters($email));
+    }
+
+    private function _is_valid_email_as_username_fallback($username)
+    {
+        $username = (string) $username;
+        $minLength = (int) ee()->config->item('un_min_len');
+
+        if ($username === '') {
+            return false;
+        }
+
+        if (strlen($username) < $minLength) {
+            return false;
+        }
+
+        if (strlen($username) > USERNAME_MAX_LENGTH) {
+            return false;
+        }
+
+        return !ValidUsername::containsDisallowedCharacters($username);
     }
 
     private function _do_form_query()

--- a/system/ee/ExpressionEngine/Service/Validation/Rule/ValidUsername.php
+++ b/system/ee/ExpressionEngine/Service/Validation/Rule/ValidUsername.php
@@ -17,12 +17,24 @@ use ExpressionEngine\Service\Validation\ValidationRule;
  */
 class ValidUsername extends ValidationRule
 {
+    public const DISALLOWED_CHARACTERS_PATTERN = "/[\|'\"!<>\{\}]/";
+
     protected $last_error = '';
+
+    public static function containsDisallowedCharacters($username)
+    {
+        return preg_match(self::DISALLOWED_CHARACTERS_PATTERN, (string) $username) === 1;
+    }
+
+    public static function stripDisallowedCharacters($username)
+    {
+        return preg_replace(self::DISALLOWED_CHARACTERS_PATTERN, '', (string) $username);
+    }
 
     public function validate($key, $username)
     {
         $username = (string) $username;
-        if (preg_match("/[\|'\"!<>\{\}]/", $username)) {
+        if (self::containsDisallowedCharacters($username)) {
             $this->last_error = 'invalid_characters_in_username';
             return false;
         }

--- a/system/ee/ExpressionEngine/Service/Validation/Rule/ValidUsername.php
+++ b/system/ee/ExpressionEngine/Service/Validation/Rule/ValidUsername.php
@@ -17,24 +17,12 @@ use ExpressionEngine\Service\Validation\ValidationRule;
  */
 class ValidUsername extends ValidationRule
 {
-    public const DISALLOWED_CHARACTERS_PATTERN = "/[\|'\"!<>\{\}]/";
-
     protected $last_error = '';
-
-    public static function containsDisallowedCharacters($username)
-    {
-        return preg_match(self::DISALLOWED_CHARACTERS_PATTERN, (string) $username) === 1;
-    }
-
-    public static function stripDisallowedCharacters($username)
-    {
-        return preg_replace(self::DISALLOWED_CHARACTERS_PATTERN, '', (string) $username);
-    }
 
     public function validate($key, $username)
     {
         $username = (string) $username;
-        if (self::containsDisallowedCharacters($username)) {
+        if (preg_match("/[\|'\"!<>\{\}]/", $username)) {
             $this->last_error = 'invalid_characters_in_username';
             return false;
         }

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Member/Mod/MemberRegisterEmailAsUsernameTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Member/Mod/MemberRegisterEmailAsUsernameTest.php
@@ -1,0 +1,265 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once PATH_ADDONS . 'member/mod.member.php';
+require_once PATH_ADDONS . 'member/mod.member_register.php';
+
+if (! defined('USERNAME_MAX_LENGTH')) {
+    define('USERNAME_MAX_LENGTH', 75);
+}
+
+if (! function_exists('trim_nbs')) {
+    function trim_nbs($str)
+    {
+        return trim(str_replace("\xc2\xa0", ' ', (string) $str));
+    }
+}
+
+if (! function_exists('get_bool_from_string')) {
+    function get_bool_from_string($value)
+    {
+        if (is_bool($value) || is_null($value)) {
+            return $value;
+        }
+
+        switch (strtolower((string) $value)) {
+            case 'true':
+            case 'yes':
+            case 'y':
+            case 'on':
+            case '1':
+                return true;
+
+            case 'false':
+            case 'no':
+            case 'n':
+            case 'off':
+            case '0':
+                return false;
+        }
+
+        return null;
+    }
+}
+
+class MemberRegisterEmailAsUsernameConfigMock
+{
+    private $items = [];
+
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+
+    public function item($key)
+    {
+        return $this->items[$key] ?? null;
+    }
+}
+
+class MemberRegisterEmailAsUsernameFunctionsMock
+{
+    private $protected = [];
+
+    public function __construct(array $protected = [])
+    {
+        $this->protected = $protected;
+    }
+
+    public function handle_protected()
+    {
+        return $this->protected;
+    }
+
+    public function determine_return()
+    {
+        return '/return';
+    }
+
+    public function determine_error_return()
+    {
+        return '/error';
+    }
+}
+
+class MemberRegisterEmailAsUsernameSessionMock
+{
+    public function userdata($key, $default = false)
+    {
+        return false;
+    }
+}
+
+class MemberRegisterEmailAsUsernameLoadMock
+{
+    public function helper($name)
+    {
+        return;
+    }
+}
+
+class MemberRegisterEmailAsUsernameExtensionsMock
+{
+    public $end_script = false;
+
+    public function call()
+    {
+        return;
+    }
+}
+
+class MemberRegisterEmailAsUsernameInputMock
+{
+    public function post($key)
+    {
+        return $_POST[$key] ?? null;
+    }
+}
+
+class MemberRegisterEmailAsUsernameOutputMock
+{
+    public $errors = [];
+
+    public function show_form_error($errors, $type = 'general')
+    {
+        $payload = [
+            'errors' => $errors,
+            'type' => $type,
+        ];
+        $this->errors[] = $payload;
+
+        return $payload;
+    }
+
+    public function show_user_error($type, $errors = [])
+    {
+        return [
+            'type' => $type,
+            'errors' => $errors,
+        ];
+    }
+}
+
+class MemberRegisterEmailAsUsernameTest extends TestCase
+{
+    private $memberRegister;
+    private $output;
+
+    protected function setUp(): void
+    {
+        if (function_exists('ee') && method_exists(ee(), 'resetMocks')) {
+            ee()->resetMocks();
+        }
+
+        $_POST = [];
+
+        $reflection = new ReflectionClass(Member_register::class);
+        $this->memberRegister = $reflection->newInstanceWithoutConstructor();
+    }
+
+    protected function tearDown(): void
+    {
+        if (function_exists('ee') && method_exists(ee(), 'resetMocks')) {
+            ee()->resetMocks();
+        }
+
+        $_POST = [];
+    }
+
+    public function testDeriveEmailAsUsernameFallbackStripsDisallowedCharacters()
+    {
+        $this->assertSame(
+            'oconnor@example.com',
+            $this->callPrivateMethod('_derive_email_as_username_fallback', ["o'connor!@example.com"])
+        );
+    }
+
+    public function testDeriveEmailAsUsernameFallbackLeavesValidEmailUnchanged()
+    {
+        $this->assertSame(
+            'simple.user@example.com',
+            $this->callPrivateMethod('_derive_email_as_username_fallback', array('simple.user@example.com'))
+        );
+    }
+
+    public function testApplyEmailAsUsernameFallbackDoesNothingWhenUsernameProvided()
+    {
+        $_POST['username'] = 'chosen-username';
+        $_POST['email'] = "o'connor@example.com";
+
+        $result = $this->callPrivateMethod('_apply_email_as_username_fallback', array(true));
+
+        $this->assertTrue($result);
+        $this->assertSame('chosen-username', $_POST['username']);
+    }
+
+    public function testApplyEmailAsUsernameFallbackSetsSanitizedUsername()
+    {
+        $this->setBaseMocks([
+            'un_min_len' => 3,
+        ]);
+
+        $_POST['username'] = '';
+        $_POST['email'] = "o'!@x.io";
+
+        $result = $this->callPrivateMethod('_apply_email_as_username_fallback', array(true));
+
+        $this->assertTrue($result);
+        $this->assertSame('o@x.io', $_POST['username']);
+    }
+
+    public function testRegisterMemberReturnsEmailErrorWhenSanitizedFallbackTooShort()
+    {
+        $this->setBaseMocks(
+            [
+                'allow_member_registration' => 'y',
+                'un_min_len' => 10,
+            ],
+            [
+                'email_as_username' => 'yes',
+            ]
+        );
+
+        $_POST['username'] = '';
+        $_POST['email'] = "o'!@x.io";
+
+        $result = $this->memberRegister->register_member();
+
+        $this->assertSame('o@x.io', $_POST['username']);
+        $this->assertCount(1, $this->output->errors);
+        $this->assertSame(
+            ['email' => 'mbr_email_cannot_be_used_as_username'],
+            $this->output->errors[0]['errors']
+        );
+        $this->assertSame('submission', $this->output->errors[0]['type']);
+        $this->assertSame($this->output->errors[0], $result);
+    }
+
+    private function setBaseMocks(array $configItems = [], array $protected = [])
+    {
+        $defaultConfig = [
+            'allow_member_registration' => 'y',
+            'un_min_len' => 4,
+        ];
+
+        ee()->setMock('config', new MemberRegisterEmailAsUsernameConfigMock(array_merge($defaultConfig, $configItems)));
+        ee()->setMock('functions', new MemberRegisterEmailAsUsernameFunctionsMock($protected));
+        ee()->setMock('session', new MemberRegisterEmailAsUsernameSessionMock());
+        ee()->setMock('load', new MemberRegisterEmailAsUsernameLoadMock());
+        ee()->setMock('extensions', new MemberRegisterEmailAsUsernameExtensionsMock());
+        ee()->setMock('input', new MemberRegisterEmailAsUsernameInputMock());
+        ee()->setMock('blockedlist', (object) ['blocked' => 'n', 'allowed' => 'y']);
+
+        $this->output = new MemberRegisterEmailAsUsernameOutputMock();
+        ee()->setMock('output', $this->output);
+    }
+
+    private function callPrivateMethod($methodName, array $args = array())
+    {
+        $method = new ReflectionMethod($this->memberRegister, $methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($this->memberRegister, $args);
+    }
+}

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Member/Mod/MemberRegisterEmailAsUsernameTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Member/Mod/MemberRegisterEmailAsUsernameTest.php
@@ -2,45 +2,13 @@
 
 use PHPUnit\Framework\TestCase;
 
+require_once SYSPATH . 'ee/ExpressionEngine/Boot/boot.common.php';
+require_once APPPATH . 'helpers/string_helper.php';
 require_once PATH_ADDONS . 'member/mod.member.php';
 require_once PATH_ADDONS . 'member/mod.member_register.php';
 
 if (! defined('USERNAME_MAX_LENGTH')) {
     define('USERNAME_MAX_LENGTH', 75);
-}
-
-if (! function_exists('trim_nbs')) {
-    function trim_nbs($str)
-    {
-        return trim(str_replace("\xc2\xa0", ' ', (string) $str));
-    }
-}
-
-if (! function_exists('get_bool_from_string')) {
-    function get_bool_from_string($value)
-    {
-        if (is_bool($value) || is_null($value)) {
-            return $value;
-        }
-
-        switch (strtolower((string) $value)) {
-            case 'true':
-            case 'yes':
-            case 'y':
-            case 'on':
-            case '1':
-                return true;
-
-            case 'false':
-            case 'no':
-            case 'n':
-            case 'off':
-            case '0':
-                return false;
-        }
-
-        return null;
-    }
 }
 
 class MemberRegisterEmailAsUsernameConfigMock
@@ -201,6 +169,21 @@ class MemberRegisterEmailAsUsernameTest extends TestCase
         ]);
 
         $_POST['username'] = '';
+        $_POST['email'] = "o'!@x.io";
+
+        $result = $this->callPrivateMethod('_apply_email_as_username_fallback', array(true));
+
+        $this->assertTrue($result);
+        $this->assertSame('o@x.io', $_POST['username']);
+    }
+
+    public function testApplyEmailAsUsernameFallbackTreatsWhitespaceUsernameAsBlank()
+    {
+        $this->setBaseMocks([
+            'un_min_len' => 3,
+        ]);
+
+        $_POST['username'] = '   ';
         $_POST['email'] = "o'!@x.io";
 
         $result = $this->callPrivateMethod('_apply_email_as_username_fallback', array(true));

--- a/system/ee/language/english/member_lang.php
+++ b/system/ee/language/english/member_lang.php
@@ -406,6 +406,8 @@ $lang = array(
 
     'mbr_username_length' => 'Usernames must be at least %x characters long',
 
+    'mbr_email_cannot_be_used_as_username' => 'Please provide a different email address or username.',
+
     'mbr_view_posts_by_member' => 'View all posts by this member',
 
     'mbr_yahoo' => 'Yahoo Messenger',


### PR DESCRIPTION
Per user request.  You can login with just your email, your email and username can be identical.  But there's no way to register with the member tag without setting a username.  While there are workarounds, why make things hard?

Docs pr https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1109