### PR TITLE
Resolved a possible generator error when field type was missing

### DIFF
--- a/system/ee/ExpressionEngine/Service/TemplateGenerator/Factory.php
+++ b/system/ee/ExpressionEngine/Service/TemplateGenerator/Factory.php
@@ -359,15 +359,39 @@ class Factory
         if (is_null($this->ftStubsAndGenerators)) {
             $this->ftStubsAndGenerators = [];
             ee()->legacy_api->instantiate('channel_fields');
+            if (!isset(ee()->addons)) {
+                ee()->load->library('addons');
+            }
+            $fieldtypes = ee()->addons->get_files('fieldtypes');
             foreach (ee('Addon')->installed() as $addon) {
                 if ($addon->hasFieldtype()) {
                     $provider = $addon->getProvider();
                     foreach ($addon->get('fieldtypes', array($provider->getPrefix() => [])) as $fieldtype => $metadata) {
+                        if (!$this->fieldtypeFileExists($fieldtype, $fieldtypes)) {
+                            $this->logFieldtypeWarning(sprintf(
+                                'TemplateGenerator skipped fieldtype "%s". Could not find expected file ft.%s.php.',
+                                $fieldtype,
+                                $fieldtype
+                            ));
+
+                            continue;
+                        }
+
                         $stub = 'field';
                         $generator = null;
                         $ftClassName = ee()->api_channel_fields->include_handler($fieldtype);
-                        $reflection = new \ReflectionClass($ftClassName);
-                        $instance = $reflection->newInstanceWithoutConstructor();
+                        try {
+                            $reflection = new \ReflectionClass($ftClassName);
+                            $instance = $reflection->newInstanceWithoutConstructor();
+                        } catch (\Throwable $e) {
+                            $this->logFieldtypeWarning(sprintf(
+                                'TemplateGenerator skipped fieldtype "%s" due to reflection error: %s',
+                                $fieldtype,
+                                $e->getMessage()
+                            ));
+
+                            continue;
+                        }
                         if (isset($instance->stub)) {
                             // grab the stub out of fieldtype property
                             $stub = $instance->stub;
@@ -391,6 +415,40 @@ class Factory
         }
 
         return $this->ftStubsAndGenerators;
+    }
+
+    /**
+     * Check whether the expected fieldtype file can be discovered.
+     */
+    protected function fieldtypeFileExists(string $fieldtype, array $fieldtypes): bool
+    {
+        $file = 'ft.' . $fieldtype . '.php';
+        $paths = [PATH_ADDONS . $fieldtype . '/'];
+
+        if (isset($fieldtypes[$fieldtype])) {
+            $paths[] = PATH_THIRD . $fieldtypes[$fieldtype]['package'] . '/';
+            $paths[] = PATH_ADDONS . $fieldtypes[$fieldtype]['package'] . '/';
+        }
+
+        $paths[] = PATH_ADDONS . $fieldtype . '/';
+
+        foreach ($paths as $path) {
+            if (file_exists($path . $file)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Log a warning without assuming the legacy logger is always loaded.
+     */
+    protected function logFieldtypeWarning(string $message): void
+    {
+        if (function_exists('log_message')) {
+            log_message('error', $message);
+        }
     }
 
     protected function getProviderGeneratorClass(Provider $provider, $class)


### PR DESCRIPTION
Avoid fatal errors when scanning installed fieldtypes for template generation. Load the addons library and gather fieldtype files, skip fieldtypes whose expected ft.<name>.php file cannot be found, and catch Reflection exceptions when instantiating handlers. Log warnings for skipped fieldtypes (using log_message if available). Add helper methods fieldtypeFileExists() and logFieldtypeWarning() to encapsulate the checks and logging.

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
