### PR TITLE
Alternative position for the Edit Layout function in Pull Request 4011

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/Edit.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Edit.php
@@ -513,6 +513,16 @@ class Edit extends AbstractPublishController
 
         $result = $this->validateEntry($entry, $vars['layout']);
 
+        $vars['channel_layout'] = $channel_layout;
+        $can_edit_this_channel_layout = ee('Permission')->has('can_edit_channels');
+        if ($can_edit_this_channel_layout) {
+            ee()->lang->loadfile('channel');
+            $vars['edit_layout_url'] = $channel_layout
+                ? ee('CP/URL')->make('channels/layouts/edit/' . $channel_layout->getId())
+                : ee('CP/URL')->make('channels/layouts/' . $entry->channel_id);
+            $vars['edit_layout_label'] = $channel_layout ? lang('edit_this_layout') : lang('edit_layout');
+        }
+
         if ($result instanceof ValidationResult) {
             $vars['errors'] = $result;
 

--- a/system/ee/ExpressionEngine/Controller/Publish/Publish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/Publish.php
@@ -353,6 +353,16 @@ class Publish extends AbstractPublishController
 
         $result = $this->validateEntry($entry, $vars['layout']);
 
+        $vars['channel_layout'] = $channel_layout;
+        $can_edit_this_channel_layout = ee('Permission')->has('can_edit_channels');
+        if ($can_edit_this_channel_layout) {
+            ee()->lang->loadfile('channel');
+            $vars['edit_layout_url'] = $channel_layout
+                ? ee('CP/URL')->make('channels/layouts/edit/' . $channel_layout->getId())
+                : ee('CP/URL')->make('channels/layouts/' . $entry->channel_id);
+            $vars['edit_layout_label'] = $channel_layout ? lang('edit_this_layout') : lang('edit_layout');
+        }
+
         if ($result instanceof ValidationResult) {
             $vars['errors'] = $result;
 
@@ -377,7 +387,7 @@ class Publish extends AbstractPublishController
             ),
             'ui' => ['draggable'],
             'file' => array(
-                'cp/publish/publish', 
+                'cp/publish/publish',
                 'cp/publish/entry-list',
                 'cp/channel/category_edit',
             )

--- a/system/ee/ExpressionEngine/View/publish/partials/publish_form.php
+++ b/system/ee/ExpressionEngine/View/publish/partials/publish_form.php
@@ -1,3 +1,5 @@
+<style>@media (max-width: 767px) { .edit-layout-btn { display: none !important; } }</style>
+
 <div class="panel">
 <div class="form-standard" data-publish>
     <?=form_open($form_url, $form_attributes, (isset($form_hidden)) ? $form_hidden : array())?>
@@ -48,6 +50,14 @@
                 <button type="button" class="tab-bar__tab js-tab-button" rel="t-autosaves"><?=lang('autosaves')?></button>
             <?php endif; ?>
             </div>
+            <?php endif; ?>
+
+            <?php if (!empty($edit_layout_url)): ?>
+                <a class="button button--secondary fal fa-object-group edit-layout-btn" style="margin-left: auto; align-self: center;"
+                   href="<?=$edit_layout_url?>"
+                   title="<?=$edit_layout_label?>">
+                    <span class="hidden"><?=$edit_layout_label?></span>
+                </a>
             <?php endif; ?>
 
             <?php if (isset($pro_class)) : ?>

--- a/system/ee/language/english/channel_lang.php
+++ b/system/ee/language/english/channel_lang.php
@@ -126,6 +126,8 @@ $lang = array(
 
     'edit_layout' => 'Edit Layout',
 
+    'edit_this_layout' => 'Edit This Layout',
+
     'illegal_tab_name' => 'Tab names may not contain the following characters: *, >, :, +, (, ), [, ], =, |, ", \', ., #, or $',
 
     'import' => 'Import',


### PR DESCRIPTION
See https://github.com/ExpressionEngine/ExpressionEngine/pull/4011

This PR puts the button on the right, below the save button, and gives it more visibility.

If it's preferred, it does need one line of CSS moved into the SCSS.

Resolved https://github.com/ExpressionEngine/ExpressionEngine/discussions/2967