### PR TITLE
Resolved an issue where regex template routes could create php warnings

### DIFF
--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/TemplateRouter/RouteTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/TemplateRouter/RouteTest.php
@@ -90,6 +90,184 @@ class RouteTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(0, preg_match($pattern, 'other/foo'));
     }
 
+    public function testRegexContainingUnescapedSlashIsRejectedWithoutWarningSpam(): void
+    {
+        $warnings = [];
+        $exception = null;
+
+        set_error_handler(function ($severity, $message, $file = null, $line = null) use (&$warnings) {
+            if ($severity === E_WARNING) {
+                $warnings[] = sprintf('%s (%s:%d)', $message, (string) $file, (int) $line);
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            new \EE_Route('/x/{slug:regex[(foo/bar)]}', false);
+        } catch (\Exception $e) {
+            $exception = $e;
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertInstanceOf(\Exception::class, $exception);
+        $this->assertSame('invalid_regex', $exception->getMessage());
+        $this->assertSame([], $warnings, "Unexpected warnings:\n" . implode("\n", $warnings));
+    }
+
+    public function testRegexContainingEscapedSlashParsesWithoutWarningSpam(): void
+    {
+        $warnings = [];
+
+        set_error_handler(function ($severity, $message, $file = null, $line = null) use (&$warnings) {
+            if ($severity === E_WARNING) {
+                $warnings[] = sprintf('%s (%s:%d)', $message, (string) $file, (int) $line);
+                return true;
+            }
+
+            return false;
+        });
+
+        $compiled = '';
+
+        try {
+            $compiled = (new \EE_Route('/x/{slug:regex[(foo\/bar)]}', false))->compile();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotEmpty($compiled);
+        $this->assertSame([], $warnings, "Unexpected warnings:\n" . implode("\n", $warnings));
+    }
+
+    public function testRegexRuleCanBeFollowedByAnotherRule(): void
+    {
+        $route = new \EE_Route('/x/{slug:regex[(foo|bar)]|max_length[20]}', true);
+        $compiled = $route->compile();
+        $pattern = '#' . $compiled . '#i';
+
+        $this->assertNotEmpty($compiled);
+        $this->assertSame(1, preg_match($pattern, 'x/foo'));
+        $this->assertSame(1, preg_match($pattern, 'x/bar'));
+        $this->assertSame(0, preg_match($pattern, 'x/baz'));
+        $this->assertSame(0, preg_match($pattern, 'x/abcdefghijklmnopqrstuvwxyz'));
+    }
+
+    public function testRegexValidationRestoresPreviousErrorHandlerOnSuccess(): void
+    {
+        $captured = [];
+
+        set_error_handler(function ($severity, $message) use (&$captured) {
+            if ($severity === E_USER_WARNING) {
+                $captured[] = (string) $message;
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            (new \EE_Route('/x/{slug:regex[(foo|bar)]}', false))->compile();
+            trigger_error('outer-handler-success', E_USER_WARNING);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(['outer-handler-success'], $captured);
+    }
+
+    public function testRegexValidationRestoresPreviousErrorHandlerOnException(): void
+    {
+        $captured = [];
+        $exception = null;
+
+        set_error_handler(function ($severity, $message) use (&$captured) {
+            if ($severity === E_USER_WARNING) {
+                $captured[] = (string) $message;
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            new \EE_Route('/x/{slug:regex[((abc]}', false);
+        } catch (\Exception $e) {
+            $exception = $e;
+            trigger_error('outer-handler-exception', E_USER_WARNING);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertInstanceOf(\Exception::class, $exception);
+        $this->assertSame('invalid_regex', $exception->getMessage());
+        $this->assertSame(['outer-handler-exception'], $captured);
+    }
+
+    public function testRegexContainingEscapedClosingBracketParsesWithoutWarningSpam(): void
+    {
+        $warnings = [];
+
+        set_error_handler(function ($severity, $message, $file = null, $line = null) use (&$warnings) {
+            if ($severity === E_WARNING) {
+                $warnings[] = sprintf('%s (%s:%d)', $message, (string) $file, (int) $line);
+                return true;
+            }
+
+            return false;
+        });
+
+        $compiled = '';
+
+        try {
+            $compiled = (new \EE_Route('/x/{slug:regex[([a-z\]])]}', false))->compile();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotEmpty($compiled);
+        $this->assertSame([], $warnings, "Unexpected warnings:\n" . implode("\n", $warnings));
+    }
+
+    public function testMultipleRegexVariablesInOneRouteRemainIndependent(): void
+    {
+        $route = new \EE_Route('/x/{a:regex[(foo|bar)]}/{b:regex[(one|two)]}', true);
+        $compiled = $route->compile();
+        $pattern = '#' . $compiled . '#i';
+
+        $this->assertSame(1, preg_match($pattern, 'x/foo/one'));
+        $this->assertSame(1, preg_match($pattern, 'x/bar/two'));
+        $this->assertSame(0, preg_match($pattern, 'x/foo/three'));
+        $this->assertSame(0, preg_match($pattern, 'x/baz/one'));
+    }
+
+    public function testEscapedSlashWithLookaroundParsesWithoutWarningSpam(): void
+    {
+        $warnings = [];
+
+        set_error_handler(function ($severity, $message, $file = null, $line = null) use (&$warnings) {
+            if ($severity === E_WARNING) {
+                $warnings[] = sprintf('%s (%s:%d)', $message, (string) $file, (int) $line);
+                return true;
+            }
+
+            return false;
+        });
+
+        $compiled = '';
+
+        try {
+            $compiled = (new \EE_Route('/x/{slug:regex[(((?!(foo\/bar)).)+?)]}', false))->compile();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotEmpty($compiled);
+        $this->assertSame([], $warnings, "Unexpected warnings:\n" . implode("\n", $warnings));
+    }
+
     public function complexRegexRouteProvider(): array
     {
         return [

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/TemplateRouter/RouteTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/TemplateRouter/RouteTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace ExpressionEngine\Tests\ExpressionEngine\legacy\Libraries\TemplateRouter;
+
+require_once __DIR__ . '/../../../../eeObjectMock.php';
+require_once BASEPATH . 'libraries/template_router/Route.php';
+
+class RouteTest extends \PHPUnit\Framework\TestCase
+{
+    protected function setUp(): void
+    {
+        ee()->setMock('Security/XSS', new class {
+            public function clean($value)
+            {
+                return $value;
+            }
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        ee()->resetMocks();
+        ee()->config->resetConfig();
+    }
+
+    /**
+     * @dataProvider complexRegexRouteProvider
+     */
+    public function testComplexRegexRoutesParseWithoutPhpWarnings(string $route): void
+    {
+        $warnings = [];
+
+        set_error_handler(function ($severity, $message, $file = null, $line = null) use (&$warnings) {
+            if ($severity === E_WARNING) {
+                $warnings[] = sprintf('%s (%s:%d)', $message, (string) $file, (int) $line);
+                return true;
+            }
+
+            return false;
+        });
+
+        $compiled = '';
+
+        try {
+            $compiled = (new \EE_Route($route, false))->compile();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertNotEmpty($compiled);
+        $this->assertSame([], $warnings, "Unexpected warnings:\n" . implode("\n", $warnings));
+    }
+
+    public function testInvalidRegexThrowsInvalidRegexWithoutWarningSpam(): void
+    {
+        $warnings = [];
+        $exception = null;
+
+        set_error_handler(function ($severity, $message, $file = null, $line = null) use (&$warnings) {
+            if ($severity === E_WARNING) {
+                $warnings[] = sprintf('%s (%s:%d)', $message, (string) $file, (int) $line);
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            new \EE_Route('/x/{slug:regex[((abc]}', false);
+        } catch (\Exception $e) {
+            $exception = $e;
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertInstanceOf(\Exception::class, $exception);
+        $this->assertSame('invalid_regex', $exception->getMessage());
+        $this->assertSame([], $warnings, "Unexpected warnings:\n" . implode("\n", $warnings));
+    }
+
+    public function testSimpleRegexBehaviorRemainsUnchanged(): void
+    {
+        $route = new \EE_Route('/home/{url_title:regex[(foo|bar)]}', true);
+        $compiled = $route->compile();
+        $pattern = '#' . $compiled . '#i';
+
+        $this->assertSame(1, preg_match($pattern, 'home/foo'));
+        $this->assertSame(1, preg_match($pattern, 'home/bar'));
+        $this->assertSame(0, preg_match($pattern, 'home/baz'));
+        $this->assertSame(0, preg_match($pattern, 'other/foo'));
+    }
+
+    public function complexRegexRouteProvider(): array
+    {
+        return [
+            ['/blog/{url_title:regex[(((?!(P\d+|rss-feed$|category\/)).)+?)]}'],
+            ['/add-ons/{url_title:regex[(((?!(P\d+|add-on-developer\/|results\/|no-results\/|tag-search\/)).)+?)]}'],
+            ['/knowledge-base/{url_title:regex[(((?!(P\d+|rss-feed$|category\/)).)+?)]}'],
+            ['/home/{url_title:regex[(((?!(P\d+|category\/)).)+?)]}'],
+            ['/{url_title:regex[(cookie\-policy|privacy\-policy|trademark\-use\-policy|terms\-of\-service)]}'],
+        ];
+    }
+}

--- a/system/ee/legacy/libraries/template_router/Route.php
+++ b/system/ee/legacy/libraries/template_router/Route.php
@@ -310,11 +310,11 @@ class EE_Route
             if ($matches['rule'] == 'regex') {
                 $index = $pos + 7;
                 $regex = substr($matches[0], 6, 1);
-                $valid = @preg_match("/$regex/", '');
+                $valid = $this->is_valid_regex_fragment($regex);
 
-                while ($valid === false) {
+                while (! $valid) {
                     $regex .= substr($rules, $index, 1);
-                    $valid = @preg_match("/$regex/", '');
+                    $valid = $this->is_valid_regex_fragment($regex);
                     $index++;
 
                     if ($end < $index) {
@@ -335,6 +335,48 @@ class EE_Route
         }
 
         return $parsed_rules;
+    }
+
+    /**
+     * Validate a regex fragment without leaking parser warnings.
+     *
+     * @param string $regex
+     * @return bool
+     */
+    private function is_valid_regex_fragment($regex)
+    {
+        $delimiters = array('/', '#', '~', '%', '!', '@', ';', '`', '=');
+        $delimiter = '/';
+
+        foreach ($delimiters as $candidate) {
+            if (strpos($regex, $candidate) === false) {
+                $delimiter = $candidate;
+                break;
+            }
+        }
+
+        if (strpos($regex, $delimiter) !== false) {
+            $regex = str_replace($delimiter, '\\' . $delimiter, $regex);
+        }
+
+        $valid = true;
+
+        set_error_handler(function () use (&$valid) {
+            $valid = false;
+            return true;
+        });
+
+        try {
+            $result = preg_match($delimiter . $regex . $delimiter, '');
+
+            if ($result === false) {
+                $valid = false;
+            }
+        } finally {
+            restore_error_handler();
+        }
+
+        return $valid;
     }
 }
 // END CLASS

--- a/system/ee/legacy/libraries/template_router/Route.php
+++ b/system/ee/legacy/libraries/template_router/Route.php
@@ -310,16 +310,22 @@ class EE_Route
             if ($matches['rule'] == 'regex') {
                 $index = $pos + 7;
                 $regex = substr($matches[0], 6, 1);
-                $valid = $this->is_valid_regex_fragment($regex);
 
-                while (! $valid) {
-                    $regex .= substr($rules, $index, 1);
-                    $valid = $this->is_valid_regex_fragment($regex);
-                    $index++;
+                set_error_handler(function () {
+                    return true;
+                });
 
-                    if ($end < $index) {
-                        throw new Exception(lang('invalid_regex'));
+                try {
+                    while (preg_match('/' . $regex . '/', '') === false) {
+                        $regex .= substr($rules, $index, 1);
+                        $index++;
+
+                        if ($end < $index) {
+                            throw new Exception(lang('invalid_regex'));
+                        }
                     }
+                } finally {
+                    restore_error_handler();
                 }
 
                 $matches[0] = "regex[{$regex}]|";
@@ -335,48 +341,6 @@ class EE_Route
         }
 
         return $parsed_rules;
-    }
-
-    /**
-     * Validate a regex fragment without leaking parser warnings.
-     *
-     * @param string $regex
-     * @return bool
-     */
-    private function is_valid_regex_fragment($regex)
-    {
-        $delimiters = array('/', '#', '~', '%', '!', '@', ';', '`', '=');
-        $delimiter = '/';
-
-        foreach ($delimiters as $candidate) {
-            if (strpos($regex, $candidate) === false) {
-                $delimiter = $candidate;
-                break;
-            }
-        }
-
-        if (strpos($regex, $delimiter) !== false) {
-            $regex = str_replace($delimiter, '\\' . $delimiter, $regex);
-        }
-
-        $valid = true;
-
-        set_error_handler(function () use (&$valid) {
-            $valid = false;
-            return true;
-        });
-
-        try {
-            $result = preg_match($delimiter . $regex . $delimiter, '');
-
-            if ($result === false) {
-                $valid = false;
-            }
-        } finally {
-            restore_error_handler();
-        }
-
-        return $valid;
     }
 }
 // END CLASS


### PR DESCRIPTION
<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
