### PR TITLE
Resolved an error with relationship single variable

### DIFF
--- a/system/ee/legacy/libraries/relationship_parser/Tree_builder.php
+++ b/system/ee/legacy/libraries/relationship_parser/Tree_builder.php
@@ -116,10 +116,14 @@ class EE_relationship_tree_builder
             }
 
             // Store flattened ids for the big entry query
-            $all_entry_ids[] = $this->_propagate_ids(
-                $node,
-                ee()->relationship_model->node_query($node, $entry_ids, $this->grid_field_id, $this->fluid_field_data_id)
-            );
+            $result = ee()->relationship_model->node_query($node, $entry_ids, $this->grid_field_id, $this->fluid_field_data_id);
+
+            if (empty($result)) {
+                $all_entry_ids[] = array();
+                continue; // Nothing to propagate for this node
+            }
+
+            $all_entry_ids[] = $this->_propagate_ids($node, $result);
         }
 
         $this->_unique_ids = array_unique(

--- a/system/ee/legacy/libraries/relationship_parser/Tree_builder.php
+++ b/system/ee/legacy/libraries/relationship_parser/Tree_builder.php
@@ -117,13 +117,7 @@ class EE_relationship_tree_builder
 
             // Store flattened ids for the big entry query
             $result = ee()->relationship_model->node_query($node, $entry_ids, $this->grid_field_id, $this->fluid_field_data_id);
-
-            if (empty($result)) {
-                $all_entry_ids[] = array();
-                continue; // Nothing to propagate for this node
-            }
-
-            $all_entry_ids[] = $this->_propagate_ids($node, $result);
+            $all_entry_ids[] = $this->_propagate_ids($node, is_array($result) ? $result : array());
         }
 
         $this->_unique_ids = array_unique(


### PR DESCRIPTION
I suspect this is php version related.  But in any case, I was using this conditional: {if add_on_editions:total_results > 0} as a single variable.  And when total results was 0 I was getting an error:

```
Argument 2 passed to EE_relationship_tree_builder::_propagate_ids() must be of the type array, null given, called in ee/legacy/libraries/relationship_parser/Tree_builder.php on line 121

ee/legacy/libraries/relationship_parser/Tree_builder.php:406
```

<!--
