### PR TITLE
Resolved #4690 MSM wrong config issue

### DIFF
--- a/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
+++ b/system/ee/legacy/libraries/channel_entries_parser/components/Simple_variable.php
@@ -61,7 +61,11 @@ class EE_Channel_simple_variable_parser implements EE_Channel_parser_component
         $data = $obj->row();
         $prefix = $obj->prefix();
 
-        $overrides = ee()->config->get_cached_site_prefs($data['entry_site_id']);
+		// If parsing the member tags-profile in particular- the entry_site_id is null
+		// Getting the cached prefs of null can end up with the wrong site id and then the wrong config values
+		$data['entry_site_id'] = (empty($data['entry_site_id'])) ? ee()->config->item('site_id') : $data['entry_site_id'];
+
+        $overrides = ee()->config->get_cached_site_prefs($data['entry_site_id']);	
         $data['channel_url'] = parse_config_variables($data['channel_url'], $overrides);
         $data['comment_url'] = parse_config_variables($data['comment_url'], $overrides);
 


### PR DESCRIPTION
Fixed an issue with parsing member profile tags (and possibly other non-entries using single variable channel entry parser) https://github.com/ExpressionEngine/ExpressionEngine/issues/4690

Handle null entry_site_id to prevent incorrect site config values.

