### PR TITLE
Final fix for MSM cp site switching

### DIFF
--- a/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
@@ -74,6 +74,12 @@ class Grid_lib
         $column_headings = array();
         $blank_column = array();
         $i = 0;
+        $show_field_names = false;
+        if (ee()->session->userdata('member_id') !== 0) {
+            $role_settings = ee()->session->getMember()->getRoleSettingsForSite((int) ee()->config->item('site_id'));
+            $show_field_names = (! empty($role_settings) && $role_settings->show_field_names == 'y');
+        }
+
         foreach ($columns as $column) {
             $column_headings[$i] = array(
                 'label' => $column['col_label'],
@@ -81,7 +87,7 @@ class Grid_lib
                 'required' => ($column['col_required'] == 'y')
             );
 
-            if (ee()->session->userdata('member_id') !== 0 && ee()->session->getMember()->PrimaryRole->RoleSettings->filter('site_id', ee()->config->item('site_id'))->first()->show_field_names == 'y' && !empty($this->field_short_name)) {
+            if ($show_field_names && ! empty($this->field_short_name)) {
                 $column_headings[$i]['badge'] = ee('View')->make('publish/partials/name_badge_copy')->render(['name' => (empty($this->fluid_field_data_id) ? $this->field_short_name : 'content') . ':' . $column['col_name']]);
             }
 

--- a/system/ee/ExpressionEngine/Model/Channel/ChannelFieldGroup.php
+++ b/system/ee/ExpressionEngine/Model/Channel/ChannelFieldGroup.php
@@ -156,7 +156,9 @@ class ChannelFieldGroup extends Model
         if (ee()->session->userdata('member_id') == 0) {
             return '';
         }
-        if (ee()->session->getMember()->PrimaryRole->RoleSettings->filter('site_id', ee()->config->item('site_id'))->first()->show_field_names == 'y') {
+
+        $role_settings = ee()->session->getMember()->getRoleSettingsForSite((int) ee()->config->item('site_id'));
+        if (! empty($role_settings) && $role_settings->show_field_names == 'y') {
             $vars = [
                 'name' => $prefix . $this->short_name,
                 'id' => $this->group_id

--- a/system/ee/ExpressionEngine/Model/Content/FieldFacade.php
+++ b/system/ee/ExpressionEngine/Model/Content/FieldFacade.php
@@ -75,7 +75,9 @@ class FieldFacade
         if (ee()->session->userdata('member_id') == 0) {
             return '';
         }
-        if (ee()->session->getMember()->PrimaryRole->RoleSettings->filter('site_id', ee()->config->item('site_id'))->first()->show_field_names == 'y') {
+
+        $role_settings = ee()->session->getMember()->getRoleSettingsForSite((int) ee()->config->item('site_id'));
+        if (! empty($role_settings) && $role_settings->show_field_names == 'y') {
             $field_name = $this->getShortName();
             $field_id = $this->getId();
 

--- a/system/ee/ExpressionEngine/Model/Member/Member.php
+++ b/system/ee/ExpressionEngine/Model/Member/Member.php
@@ -13,6 +13,7 @@ namespace ExpressionEngine\Model\Member;
 use DateTimeZone;
 use ExpressionEngine\Model\Content\ContentModel;
 use ExpressionEngine\Model\Member\Display\MemberFieldLayout;
+use ExpressionEngine\Model\Role\RoleSetting;
 use ExpressionEngine\Model\Content\Display\LayoutInterface;
 use ExpressionEngine\Service\Model\Collection;
 
@@ -646,11 +647,7 @@ class Member extends ContentModel
             $site_id = ee()->config->item('site_id');
         }
 
-        // Make sure to get the correct site, revert once issue #1285 is fixed
-        $primary_role = $this->getModelFacade()->get('RoleSetting')
-            ->filter('role_id', $this->role_id)
-            ->filter('site_id', $site_id)
-            ->first();
+        $role_settings = $this->getRoleSettingsForSite((int) $site_id);
 
         if (! empty($this->cp_homepage)) {
             $cp_homepage = $this->cp_homepage;
@@ -666,10 +663,10 @@ class Member extends ContentModel
                     $cp_homepage_channel = $cp_homepage_channel[$site_id];
                 }
             }
-        } elseif (! empty($primary_role->cp_homepage)) {
-            $cp_homepage = $primary_role->cp_homepage;
-            $cp_homepage_channel = $primary_role->cp_homepage_channel;
-            $cp_homepage_custom = $primary_role->cp_homepage_custom;
+        } elseif (! empty($role_settings) && ! empty($role_settings->cp_homepage)) {
+            $cp_homepage = $role_settings->cp_homepage;
+            $cp_homepage_channel = $role_settings->cp_homepage_channel;
+            $cp_homepage_custom = $role_settings->cp_homepage_custom;
         }
 
         switch ($cp_homepage) {
@@ -985,6 +982,58 @@ class Member extends ContentModel
         }
 
         return $roles;
+    }
+
+    /**
+     * Resolve role settings for a specific site from all assigned roles.
+     *
+     * @param int|null $site_id Site to resolve settings for. Defaults to current site.
+     * @param bool $requireCpAccess Restrict role candidates to roles that can access CP on this site.
+     * @return RoleSetting|null
+     */
+    public function getRoleSettingsForSite(?int $site_id = null, bool $requireCpAccess = true): ?RoleSetting
+    {
+        $site_id = $site_id ?: (int) ee()->config->item('site_id');
+        $roles = [];
+
+        foreach ($this->getAllRoles() as $role) {
+            $roles[(int) $role->role_id] = $role;
+        }
+
+        if (empty($roles)) {
+            return null;
+        }
+
+        $candidate_role_ids = array_keys($roles);
+
+        if ($requireCpAccess) {
+            $cp_role_ids = array_map('intval', ee('Permission')->rolesThatCan('access_cp', $site_id));
+            $candidate_role_ids = array_values(array_intersect($candidate_role_ids, $cp_role_ids));
+
+            if (empty($candidate_role_ids)) {
+                return null;
+            }
+        }
+
+        sort($candidate_role_ids, SORT_NUMERIC);
+
+        // Prefer primary role when it is a valid candidate for this site.
+        $primary_role_id = (int) $this->role_id;
+        if (in_array($primary_role_id, $candidate_role_ids, true)) {
+            $candidate_role_ids = array_merge(
+                [$primary_role_id],
+                array_values(array_diff($candidate_role_ids, [$primary_role_id]))
+            );
+        }
+
+        foreach ($candidate_role_ids as $role_id) {
+            $role_setting = $roles[$role_id]->RoleSettings->filter('site_id', $site_id)->first();
+            if (! empty($role_setting)) {
+                return $role_setting;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Model/Member/MemberRoleSettingsForSiteTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Model/Member/MemberRoleSettingsForSiteTest.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2026, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Tests\Model\Member;
+
+use ExpressionEngine\Model\Member\Member as MemberModel;
+use ExpressionEngine\Model\Role\RoleSetting;
+use ExpressionEngine\Service\Model\Collection;
+use PHPUnit\Framework\TestCase;
+
+class MemberRoleSettingsForSiteTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ee()->resetMocks();
+        ee()->config->resetConfig();
+    }
+
+    protected function tearDown(): void
+    {
+        ee()->resetMocks();
+        ee()->config->resetConfig();
+    }
+
+    public function testPrefersPrimaryRoleWhenItQualifiesForSite()
+    {
+        $primarySetting = $this->createRoleSettingMock();
+        $secondarySetting = $this->createRoleSettingMock();
+
+        $member = new MemberRoleSettingsForSiteMemberStub();
+        $member->setAllRoles([
+            $this->createRoleStub(7, [2 => $primarySetting]),
+            $this->createRoleStub(3, [2 => $secondarySetting]),
+        ]);
+        $this->setPrimaryRoleId($member, 7);
+
+        ee()->setMock('Permission', new MemberRoleSettingsForSitePermissionStub([3, 7]));
+
+        $result = $member->getRoleSettingsForSite(2, true);
+
+        $this->assertSame($primarySetting, $result);
+    }
+
+    public function testFallsBackToLowestRoleIdWhenPrimaryHasNoSiteSettings()
+    {
+        $roleTwoSetting = $this->createRoleSettingMock();
+        $roleFiveSetting = $this->createRoleSettingMock();
+
+        $member = new MemberRoleSettingsForSiteMemberStub();
+        $member->setAllRoles([
+            $this->createRoleStub(10, [1 => $this->createRoleSettingMock()]),
+            $this->createRoleStub(5, [2 => $roleFiveSetting]),
+            $this->createRoleStub(2, [2 => $roleTwoSetting]),
+        ]);
+        $this->setPrimaryRoleId($member, 10);
+
+        ee()->setMock('Permission', new MemberRoleSettingsForSitePermissionStub([2, 5, 10]));
+
+        $result = $member->getRoleSettingsForSite(2, true);
+
+        $this->assertSame($roleTwoSetting, $result);
+    }
+
+    public function testReturnsNullWhenNoCpAccessRoleCandidatesExist()
+    {
+        $member = new MemberRoleSettingsForSiteMemberStub();
+        $member->setAllRoles([
+            $this->createRoleStub(2, [2 => $this->createRoleSettingMock()]),
+            $this->createRoleStub(5, [2 => $this->createRoleSettingMock()]),
+        ]);
+        $this->setPrimaryRoleId($member, 2);
+
+        ee()->setMock('Permission', new MemberRoleSettingsForSitePermissionStub([9]));
+
+        $result = $member->getRoleSettingsForSite(2, true);
+
+        $this->assertNull($result);
+    }
+
+    public function testCanResolveUsingPrimaryRoleWithoutCpAccessRequirement()
+    {
+        $primarySetting = $this->createRoleSettingMock();
+        $secondarySetting = $this->createRoleSettingMock();
+
+        $member = new MemberRoleSettingsForSiteMemberStub();
+        $member->setAllRoles([
+            $this->createRoleStub(10, [2 => $primarySetting]),
+            $this->createRoleStub(2, [2 => $secondarySetting]),
+        ]);
+        $this->setPrimaryRoleId($member, 10);
+
+        ee()->setMock('Permission', new MemberRoleSettingsForSitePermissionStub([2]));
+
+        $result = $member->getRoleSettingsForSite(2, false);
+
+        $this->assertSame($primarySetting, $result);
+    }
+
+    public function testReturnsNullWhenNoAssignedRolesHaveSiteSettings()
+    {
+        $member = new MemberRoleSettingsForSiteMemberStub();
+        $member->setAllRoles([
+            $this->createRoleStub(2, [1 => $this->createRoleSettingMock()]),
+            $this->createRoleStub(5, [1 => $this->createRoleSettingMock()]),
+        ]);
+        $this->setPrimaryRoleId($member, 2);
+
+        ee()->setMock('Permission', new MemberRoleSettingsForSitePermissionStub([2, 5]));
+
+        $result = $member->getRoleSettingsForSite(2, true);
+
+        $this->assertNull($result);
+    }
+
+    private function createRoleSettingMock(): RoleSetting
+    {
+        return $this->getMockBuilder(RoleSetting::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    private function createRoleStub(int $roleId, array $settingsBySite): object
+    {
+        return (object) [
+            'role_id' => $roleId,
+            'RoleSettings' => new MemberRoleSettingsForSiteRoleSettingsCollectionStub($settingsBySite),
+        ];
+    }
+
+    private function setPrimaryRoleId(MemberModel $member, int $roleId): void
+    {
+        $property = new \ReflectionProperty(MemberModel::class, 'role_id');
+        $property->setAccessible(true);
+        $property->setValue($member, $roleId);
+    }
+}
+
+class MemberRoleSettingsForSiteMemberStub extends MemberModel
+{
+    private $roles = [];
+
+    public function setAllRoles(array $roles): void
+    {
+        $this->roles = $roles;
+    }
+
+    public function getAllRoles($cache = true)
+    {
+        return new Collection($this->roles);
+    }
+}
+
+class MemberRoleSettingsForSitePermissionStub
+{
+    private $roleIds;
+
+    public function __construct(array $roleIds)
+    {
+        $this->roleIds = $roleIds;
+    }
+
+    public function rolesThatCan($permission, $site_id = null)
+    {
+        return $this->roleIds;
+    }
+}
+
+class MemberRoleSettingsForSiteRoleSettingsCollectionStub
+{
+    private $settingsBySite;
+
+    public function __construct(array $settingsBySite)
+    {
+        $this->settingsBySite = $settingsBySite;
+    }
+
+    public function filter($field, $value)
+    {
+        if ($field !== 'site_id') {
+            return new MemberRoleSettingsForSiteRoleSettingsFilterResultStub(null);
+        }
+
+        return new MemberRoleSettingsForSiteRoleSettingsFilterResultStub(
+            $this->settingsBySite[$value] ?? null
+        );
+    }
+}
+
+class MemberRoleSettingsForSiteRoleSettingsFilterResultStub
+{
+    private $setting;
+
+    public function __construct($setting)
+    {
+        $this->setting = $setting;
+    }
+
+    public function first()
+    {
+        return $this->setting;
+    }
+}
+
+// EOF

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/SessionMemberQueryFallbackTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/SessionMemberQueryFallbackTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * This source file is part of the open source project
+ * ExpressionEngine (https://expressionengine.com)
+ *
+ * @link      https://expressionengine.com/
+ * @copyright Copyright (c) 2003-2026, Packet Tide, LLC (https://www.packettide.com)
+ * @license   https://expressionengine.com/license Licensed under Apache License, Version 2.0
+ */
+
+namespace ExpressionEngine\Tests\ExpressionEngine\legacy\Libraries;
+
+require_once __DIR__ . '/../../../eeObjectMock.php';
+require_once SYSPATH . 'ee/legacy/libraries/Session.php';
+
+use PHPUnit\Framework\TestCase;
+
+if (! defined('REQ')) {
+    define('REQ', 'CP');
+}
+
+class SessionMemberQueryFallbackShim extends \EE_Session
+{
+    public function callDoMemberQuery()
+    {
+        return $this->_do_member_query();
+    }
+
+    public function setMemberModelForTest($memberModel): void
+    {
+        $property = new \ReflectionProperty(\EE_Session::class, 'member_model');
+        $property->setAccessible(true);
+        $property->setValue($this, $memberModel);
+    }
+}
+
+class SessionMemberQueryFallbackDbMock
+{
+    public $getCalls = 0;
+
+    private $results;
+
+    public function __construct(array $results)
+    {
+        $this->results = $results;
+    }
+
+    public function from($table)
+    {
+        return $this;
+    }
+
+    public function where($field, $value = null, $escape = true)
+    {
+        return $this;
+    }
+
+    public function get($table = null)
+    {
+        $this->getCalls++;
+
+        return array_shift($this->results);
+    }
+}
+
+class SessionMemberQueryFallbackResultStub
+{
+    private $numRows;
+
+    public function __construct(int $numRows)
+    {
+        $this->numRows = $numRows;
+    }
+
+    public function num_rows()
+    {
+        return $this->numRows;
+    }
+}
+
+class SessionMemberQueryFallbackMemberModelStub
+{
+    public $member_id;
+
+    private $roleSetting;
+
+    public function __construct(int $memberId, $roleSetting)
+    {
+        $this->member_id = $memberId;
+        $this->roleSetting = $roleSetting;
+    }
+
+    public function getRoleSettingsForSite($siteId, $requireCpAccess = true)
+    {
+        return $this->roleSetting;
+    }
+}
+
+class SessionMemberQueryFallbackTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ee()->resetMocks();
+        ee()->config->resetConfig();
+        ee()->config->setItem('site_id', 2);
+    }
+
+    protected function tearDown(): void
+    {
+        ee()->resetMocks();
+        ee()->config->resetConfig();
+    }
+
+    public function testFallbackReturnsEmptyArrayWhenNoRoleSettingsCanBeResolved()
+    {
+        $db = new SessionMemberQueryFallbackDbMock([
+            new SessionMemberQueryFallbackResultStub(0),
+            new SessionMemberQueryFallbackResultStub(1),
+        ]);
+        ee()->setMock('db', $db);
+
+        $session = $this->newSessionWithoutConstructor();
+        $session->sdata = ['member_id' => 42];
+        $session->validation = 's';
+        $session->setMemberModelForTest(new SessionMemberQueryFallbackMemberModelStub(42, null));
+
+        $result = $session->callDoMemberQuery();
+
+        $this->assertSame([], $result);
+        $this->assertSame(2, $db->getCalls);
+    }
+
+    public function testFallbackReturnsMemberQueryWhenRoleSettingsResolve()
+    {
+        $fallbackResult = new SessionMemberQueryFallbackResultStub(1);
+
+        $db = new SessionMemberQueryFallbackDbMock([
+            new SessionMemberQueryFallbackResultStub(0),
+            $fallbackResult,
+        ]);
+        ee()->setMock('db', $db);
+
+        $session = $this->newSessionWithoutConstructor();
+        $session->sdata = ['member_id' => 42];
+        $session->validation = 's';
+        $session->setMemberModelForTest(
+            new SessionMemberQueryFallbackMemberModelStub(42, new \stdClass())
+        );
+
+        $result = $session->callDoMemberQuery();
+
+        $this->assertSame($fallbackResult, $result);
+        $this->assertSame(2, $db->getCalls);
+    }
+
+    private function newSessionWithoutConstructor(): SessionMemberQueryFallbackShim
+    {
+        return (new \ReflectionClass(SessionMemberQueryFallbackShim::class))
+            ->newInstanceWithoutConstructor();
+    }
+}
+
+// EOF

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -571,12 +571,18 @@ class EE_Core
             return ee()->output->fatal_error(lang('not_authorized'));
         }
 
+        $is_mfa_required_for_role = false;
+        if (ee()->session->userdata('member_id') !== 0) {
+            $role_settings = ee()->session->getMember()->getRoleSettingsForSite((int) ee()->config->item('site_id'));
+            $is_mfa_required_for_role = (! empty($role_settings) && $role_settings->require_mfa == 'y');
+        }
+
         //is member role forced to use MFA?
         if (
             (ee()->config->item('enable_mfa') === false || ee()->config->item('enable_mfa') === 'y') &&
             ee()->session->userdata('member_id') !== 0 &&
             ee()->session->getMember()->enable_mfa !== true &&
-            ee()->session->getMember()->PrimaryRole->RoleSettings->filter('site_id', ee()->config->item('site_id'))->first()->require_mfa == 'y'
+            $is_mfa_required_for_role
         ) {
             if (!(ee()->uri->segment(2) == 'login' && ee()->uri->segment(3) == 'logout') && !(ee()->uri->segment(2) == 'members' && ee()->uri->segment(3) == 'profile' && ee()->uri->segment(4) == 'pro' && ee()->uri->segment(5) == 'mfa')) {
                 ee()->lang->load('pro');

--- a/system/ee/legacy/libraries/Session.php
+++ b/system/ee/legacy/libraries/Session.php
@@ -1204,6 +1204,14 @@ class EE_Session
             ee()->db->where('member_id', (int) $member_id);
 
             $data = ee()->db->get();
+
+            // Hardening: allow CP session bootstrap even when a site-specific
+            // role_settings row is missing for the member's primary role.
+            if ($data->num_rows() == 0) {
+                $data = ee()->db->from('members')
+                    ->where('member_id', (int) $member_id)
+                    ->get();
+            }
         }
 
         if (! is_object($this->member_model) || $this->member_model->member_id != $member_id) {

--- a/system/ee/legacy/libraries/Session.php
+++ b/system/ee/legacy/libraries/Session.php
@@ -621,19 +621,10 @@ class EE_Session
         $this->userdata['group_title'] = $this->member_model->PrimaryRole->name;
         $this->userdata['group_description'] = $this->member_model->PrimaryRole->description;
 
-        // Merge role_settings for the current site when missing (e.g. fallback query path).
-        // Use the first role with site-specific settings; members with secondary-role-only
-        // access may have a primary role with no settings for this site.
-        if (! array_key_exists('prv_msg_send_limit', $this->userdata)) {
-            $site_id = (int) ee()->config->item('site_id');
-            foreach ($this->member_model->getAllRoles() as $role) {
-                $roleSetting = $role->RoleSettings->filter('site_id', $site_id)->first();
-                if ($roleSetting) {
-                    $roleSettings = array_diff_key($roleSetting->getValues(), array_flip(array('id', 'role_id', 'site_id')));
-                    $this->userdata = array_merge($this->userdata, $roleSettings);
-                    break;
-                }
-            }
+        $roleSetting = $this->member_model->getRoleSettingsForSite((int) ee()->config->item('site_id'), REQ == 'CP');
+        if ($roleSetting) {
+            $roleSettings = array_diff_key($roleSetting->getValues(), array_flip(array('id', 'role_id', 'site_id')));
+            $this->userdata = array_merge($this->userdata, $roleSettings);
         }
 
         // Add in the Permissions for backwards compatibility
@@ -1201,6 +1192,7 @@ class EE_Session
         // Query DB for member data.  Depending on the validation type we'll
         // either use the cookie data or the member ID gathered with the session query.
         $data = [];
+        $used_fallback_member_query = false;
 
         $member_id = $this->sdata['member_id'];
 
@@ -1220,9 +1212,10 @@ class EE_Session
 
             $data = ee()->db->get();
 
-            // Hardening: allow CP session bootstrap even when a site-specific
-            // role_settings row is missing for the member's primary role.
+            // Allow query fallback when the primary role is missing site-specific
+            // role_settings. Eligibility is validated after member model setup.
             if ($data->num_rows() == 0) {
+                $used_fallback_member_query = true;
                 $data = ee()->db->from('members')
                     ->where('member_id', (int) $member_id)
                     ->get();
@@ -1231,6 +1224,14 @@ class EE_Session
 
         if (! is_object($this->member_model) || $this->member_model->member_id != $member_id) {
             $this->_setupMemberModel($member_id);
+        }
+
+        // If the primary-role role_settings join was not available, require an assigned role
+        // with site-specific settings before continuing session bootstrap.
+        if (! empty($used_fallback_member_query)) {
+            if (! is_object($this->member_model) || ! $this->member_model->getRoleSettingsForSite((int) ee()->config->item('site_id'), REQ == 'CP')) {
+                return [];
+            }
         }
 
         return $data;

--- a/system/ee/legacy/libraries/Session.php
+++ b/system/ee/legacy/libraries/Session.php
@@ -621,6 +621,21 @@ class EE_Session
         $this->userdata['group_title'] = $this->member_model->PrimaryRole->name;
         $this->userdata['group_description'] = $this->member_model->PrimaryRole->description;
 
+        // Merge role_settings for the current site when missing (e.g. fallback query path).
+        // Use the first role with site-specific settings; members with secondary-role-only
+        // access may have a primary role with no settings for this site.
+        if (! array_key_exists('prv_msg_send_limit', $this->userdata)) {
+            $site_id = (int) ee()->config->item('site_id');
+            foreach ($this->member_model->getAllRoles() as $role) {
+                $roleSetting = $role->RoleSettings->filter('site_id', $site_id)->first();
+                if ($roleSetting) {
+                    $roleSettings = array_diff_key($roleSetting->getValues(), array_flip(array('id', 'role_id', 'site_id')));
+                    $this->userdata = array_merge($this->userdata, $roleSettings);
+                    break;
+                }
+            }
+        }
+
         // Add in the Permissions for backwards compatibility
         $permissions = $this->member_model->getPermissions();
         foreach ($permissions as $perm => $perm_id) {
@@ -1236,7 +1251,9 @@ class EE_Session
         if (REQ == 'CP') {
             $memberQuery->with('EntryManagerViews');
         }
-        $memberQuery->filter('RoleSettings.site_id', ee()->config->item('site_id'));
+        // Do not filter by RoleSettings.site_id - members with access via a secondary role
+        // may have a primary role with no site-specific role_settings, which would exclude
+        // them. Permission checks (e.g. can_access_cp) correctly use getAllRoles().
         $this->member_model = $memberQuery->all()->first();
     }
 


### PR DESCRIPTION
See now closed https://github.com/ExpressionEngine/ExpressionEngine/pull/5175

MSM site, users with multiple roles. The dropdown shows all sites that at least one of their roles allowed CP access to, but the 'switch' failed because cp bootstrap was only looking at primary role as a first condition.

After digging into the original fix- which did solve the initial problem of being able to switch the site, it was incomplete.  Basically, once the user is on the new site, other parts of the cp could glitch because they also assumed the Primary Role held the settings for the current site.  Specifically spotted issues with MFA, grid and field groups, and maybe more.

So- much bigger change BUT I think it's needed.