### PR TITLE
Resolved an issue where Live Preview could fail silently due to a web server removing the Authorization header

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -5480,6 +5480,12 @@ class Channel
             }
         }
 
+        // Display an error if the webserver is preventing access to the Authorization header
+        if (empty($preview_token)) {
+            ee()->lang->load('cp');
+            return ee()->output->show_user_error('general', lang('http_auth_header_missing'));
+        }
+
         $token_origin = $from_origin ?: ($origin_header ?: ($referer_header ?: $return));
 
         $token_context = ee('LivePreviewToken')->validateAndResolveMember(

--- a/system/ee/language/english/cp_lang.php
+++ b/system/ee/language/english/cp_lang.php
@@ -512,6 +512,8 @@ $lang = array(
 
     '404_does_not_exist_desc' => 'Sorry, we could not find the item you are trying to access in the system.',
 
+    'http_auth_header_missing' => 'HTTP Authorization Header Missing',
+
     'http_code_400' => 'Bad Request',
 
     'http_code_401' => 'Unauthorized',


### PR DESCRIPTION
See docs https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1119