### PR TITLE
Change word length check from 2 to 0

### DIFF
--- a/system/ee/ExpressionEngine/Service/Model/Query/Builder.php
+++ b/system/ee/ExpressionEngine/Service/Model/Query/Builder.php
@@ -288,7 +288,7 @@ class Builder
             $word .= $char;
         }
 
-        if (strlen($word) > 2) {
+        if (strlen($word) > 0) {
             $words[] = $word;
         }
 


### PR DESCRIPTION
Adjust keyword search minimum character length from 2 to 0. I'm not sure why this lower limit exists in the first place, but it made the keyword search useless for me when searching for things with 2 characters. My specific use case was an abbreviation used in the field name (`lp` instead of `landing_page`), but searching for `lp` unexpectedly returned all results.

## Examples

### Searching fields for `ab`

Before:
<img width="1840" height="1134" alt="image" src="https://github.com/user-attachments/assets/e5f50dfb-6667-448e-8f49-541c961e1f27" />

After:
<img width="1840" height="1134" alt="image" src="https://github.com/user-attachments/assets/ca426337-db07-4ef2-8c0b-a728617e5c46" />

### Searching channels for `te`

Before:
<img width="1840" height="1134" alt="image" src="https://github.com/user-attachments/assets/6e82007e-007a-4535-a0c4-7c92f657dc57" />

After:
<img width="1840" height="1134" alt="image" src="https://github.com/user-attachments/assets/01df4342-f2b2-42c1-af43-b8ecb6dcb14f" />
