### PR TITLE
Improved #4094: In a Grid field, the handle and trash icons can now be placed as the first column instead of the last column

### DIFF
--- a/cp-styles/app/styles/components/_grid-field.scss
+++ b/cp-styles/app/styles/components/_grid-field.scss
@@ -1,4 +1,68 @@
 
+@mixin grid-card-row-shell($border-color, $bg-color, $mb: 10px, $pb: 15px) {
+	display: flex;
+	flex-direction: column;
+	position: relative;
+	border: 1px solid $border-color;
+	margin-bottom: $mb;
+	padding-bottom: $pb;
+	background-color: $bg-color;
+}
+
+@mixin grid-card-cell-shell($pad: 10px 15px 10px 15px, $font-size: 1rem) {
+	border-right: none;
+	min-width: 0;
+	width: 100%;
+	max-width: 100%;
+	display: block;
+	border-bottom: none;
+	padding: $pad;
+	font-size: $font-size;
+}
+
+@mixin grid-collapsed-item-state($hide-non-fieldset: false) {
+	padding-bottom: 0 !important;
+
+	@if $hide-non-fieldset {
+		td:not(.grid-field__item-fieldset) {
+			display: none !important;
+		}
+	}
+
+	td.grid-field__item-fieldset {
+		border-bottom: none !important;
+
+		.grid-field__item-tool {
+			transform: rotate(180deg);
+		}
+	}
+}
+
+@mixin grid-column-label-stacked {
+	margin-bottom: 10px;
+
+	label {
+		color: var(--ee-text-secondary);
+		margin: 0;
+	}
+
+	em {
+		color: var(--ee-text-secondary);
+		font-style: normal;
+		margin: 0;
+	}
+}
+
+@mixin grid-row-counter-full-width {
+	width: 100% !important;
+}
+
+@mixin grid-hide-tools-column {
+	td.grid-field__column--tools {
+		display: none !important;
+	}
+}
+
 .grid-field {
 	width: 100%;
 
@@ -55,25 +119,20 @@
   			max-width: 100% !important;
   		}
 
-  		&.grid-rte,
-  		&.grid-file-upload,
-  		&.grid-multi-relate {
-  			// min-width: 400px;
-  		}
-
-  		&.grid-field__column--tools {
-
-  		}
-
-  		&.grid-multi-relate {
-  			@include m-tablet-down {
-  				position: relative;
+	  	&.grid-multi-relate {
+	  			@include m-tablet-down {
+	  				position: relative;
 
   				.dropdown--open {
   					top: calc(100% + 4px) !important;
   					transform: none !important;
   				}
   			}
+  		}
+
+  		&.grid-field__column--tools {
+  			max-width: 80px;
+  			min-width: 0;
   		}
   	}
 	}
@@ -114,16 +173,16 @@
   .file-field__dropzone {
     margin-top: 0px;
 
-	.dropdown__link, .file-field__buttons {
-		text-indent: 0;
-	}
-	.dropdown__link--selected {
-		&::before {
-			margin-right: 20px;
-			margin-left: 0;
+		.dropdown__link, .file-field__buttons {
+			text-indent: 0;
 		}
-	}
-  }
+		.dropdown__link--selected {
+			&::before {
+				margin-right: 20px;
+				margin-left: 0;
+			}
+		}
+ 	}
 
 	.file-field__buttons {
 		.dropdown__link {
@@ -166,9 +225,7 @@
 			background: inherit;
 		}
 	}
-}
 
-#routes {
 	.table-responsive {
 		overflow-x: auto;
 	}
@@ -296,17 +353,7 @@
 	}
 
 	tr.grid__item--collapsed {
-		padding-bottom: 0 !important;
-
-		td:not(.grid-field__item-fieldset) { display: none !important;}
-
-		td.grid-field__item-fieldset {
-			border-bottom: none !important;
-
-			.grid-field__item-tool {
-				transform: rotate(180deg);
-			}
-		}
+		@include grid-collapsed-item-state(true);
 	}
 }
 
@@ -336,23 +383,10 @@
 			border: none;
 
 			& > tr:not(.hidden) {
-				display: flex;
-				flex-direction: column;
-				position: relative;
-				border: 1px solid var(--ee-border);
-				margin-bottom: 10px;
-				padding-bottom: 15px;
-				background-color: var(--ee-bg-blank);
+				@include grid-card-row-shell(var(--ee-border), var(--ee-bg-blank));
 
 				& > td {
-					border-right: none;
-					min-width: 0;
-					width: 100%;
-					max-width: 100%;
-					display: block;
-					border-bottom: none;
-					padding: 10px 15px 10px 15px;
-          font-size: 1rem;
+					@include grid-card-cell-shell();
 
 					&.grid-field__column--tools {
 						text-align: left;
@@ -366,8 +400,8 @@
 
 			tr.no-results {
 				padding: 0px;
-        background-color: transparent;
-        border: none;
+				background-color: transparent;
+				border: none;
 
 				td {
 					padding-top: 0;
@@ -376,17 +410,7 @@
 			}
 
 			tr.grid__item--collapsed {
-				padding-bottom: 0 !important;
-
-				// td:not(.grid-field__item-fieldset) { display: none !important;}
-
-				td.grid-field__item-fieldset {
-					border-bottom: none !important;
-
-					.grid-field__item-tool {
-						transform: rotate(180deg);
-					}
-				}
+				@include grid-collapsed-item-state;
 			}
 
 			td.required {
@@ -401,7 +425,7 @@
 		}
 
 		.row-counter-column {
-			width: 100% !important;
+			@include grid-row-counter-full-width;
 		}
 	}
 
@@ -424,23 +448,12 @@
     }
 	}
 
-	.grid-field__column--tools { display: none !important;}
+	@include grid-hide-tools-column;
 
-  .grid-field__column-label {
-  	display: inherit;
-  	margin-bottom: 10px;
-
-  	label {
-  		color: var(--ee-text-secondary);
-  		margin: 0;
-  	}
-
-  	em {
-			color: var(--ee-text-secondary);
-			font-style: normal;
-			margin: 0;
-  	}
-  }
+	.grid-field__column-label {
+		display: inherit;
+		@include grid-column-label-stacked;
+	}
 }
 
 // HORIZONTAL GRID LAYOUT
@@ -475,31 +488,20 @@
 			display: none;
 		}
 
-		& > tbody {
-			& > tr {
-				display: flex;
-				flex-direction: column;
+			& > tbody {
+				& > tr {
+					@include grid-card-row-shell(color(border), var(--ee-bg-blank), 10px, $sq-s);
 
-	      &.hidden {
-	        display: none;
-	      }
-			}
+		      &.hidden {
+		        display: none;
+		      }
+				}
 
-			& > tr {
-				position: relative;
-				border: 1px solid color(border);
-				margin-bottom: 10px;
-				padding-bottom: $sq-s;
-				background-color: var(--ee-bg-blank);
-
-	      &.no-results {
-	        padding: 0px;
-
-	        td {
-	          // padding-top: 0;
-	        }
-	      }
-			}
+				& > tr {
+		      &.no-results {
+		        padding: 0px;
+		      }
+				}
 
 			& > tr > td {
 				display: block !important;
@@ -507,25 +509,15 @@
 				padding: $sq-inset-s;
 			}
 
-			tr.grid__item--collapsed {
-				padding-bottom: 0 !important;
-
-				td:not(.grid-field__item-fieldset) { display: none !important;}
-
-				td.grid-field__item-fieldset {
-					border-bottom: none !important;
-
-					.grid-field__item-tool {
-						transform: rotate(180deg);
-					}
+				tr.grid__item--collapsed {
+					@include grid-collapsed-item-state(true);
 				}
 			}
-		}
 
-		.row-counter-column {
-			width: 100% !important;
+			.row-counter-column {
+				@include grid-row-counter-full-width;
+			}
 		}
-	}
 
 	.grid-field:not(.horizontal-layout) .grid-field__column--tools {
 		text-align: left;
@@ -535,21 +527,21 @@
     }
 	}
 
-	.entry-grid, .vertical-layout {
-		padding: 10px;
-		background: var(--ee-bg-0);
+		.entry-grid, .vertical-layout {
+			padding: 10px;
+			background: var(--ee-bg-0);
 		border: 1px solid var(--ee-border);
 		border-radius: 5px;
 
-		.grid-field__item-fieldset {
-			display: block;
-			position: relative;
-			border-bottom: 1px solid var(--ee-border) !important;
-      font-size: 1rem;
-		}
+			.grid-field__item-fieldset {
+				display: block;
+				position: relative;
+				border-bottom: 1px solid var(--ee-border) !important;
+	      font-size: 1rem;
+			}
 
-		td.grid-field__column--tools { display: none !important;}
-	}
+			@include grid-hide-tools-column;
+		}
 
 	.grid-field.horizontal-layout {
 		tbody {
@@ -582,31 +574,18 @@
 			display: none;
 		}
 
-		& > tbody {
-			width: 100%;
-			border: none;
+			& > tbody {
+				width: 100%;
+				border: none;
 
-			& > tr:not(.hidden) {
-				display: flex;
-				flex-direction: column;
-				position: relative;
-				border: 1px solid var(--ee-border);
-				margin-bottom: 10px;
-				padding-bottom: 15px;
-				background-color: var(--ee-bg-blank);
+				& > tr:not(.hidden) {
+					@include grid-card-row-shell(var(--ee-border), var(--ee-bg-blank));
 
-				& > td:not(.hidden) {
-					border-right: none;
-					min-width: 0;
-					width: 100%;
-					max-width: 100%;
-					display: block;
-					border-bottom: none;
-					padding: 10px 15px 10px 15px;
-					font-size: 1rem;
+					& > td:not(.hidden) {
+						@include grid-card-cell-shell();
 
-					@include m-tablet-up {
-						border-bottom: 1px solid var(--ee-table-border);
+						@include m-tablet-up {
+							border-bottom: 1px solid var(--ee-table-border);
 					}
 
 					&:last-child {
@@ -617,29 +596,18 @@
 						width: 100%;
 					}
 
-					.ee-form-error-message {
-						margin-left: auto;
-					}
-
-					.grid-field__column-label {
-						display: block;
-						color: var(--ee-text-secondary);
-						font-weight: 500;
-						white-space: normal;
-						margin-bottom: 10px;
-						flex: 0 0 100%;
-
-						label {
-							color: var(--ee-text-secondary);
-							margin: 0;
+						.ee-form-error-message {
+							margin-left: auto;
 						}
 
-						em {
-							font-style: normal;
+						.grid-field__column-label {
+							display: block;
 							color: var(--ee-text-secondary);
-							margin: 0;
+							font-weight: 500;
+							white-space: normal;
+							flex: 0 0 100%;
+							@include grid-column-label-stacked;
 						}
-					}
 
 					.grid-field__column-tools {
 						width: 100%;
@@ -662,17 +630,9 @@
 				padding: 0;
 			}
 
-			tr.grid__item--collapsed {
-				padding-bottom: 0 !important;
-
-				td.grid-field__item-fieldset {
-					border-bottom: none !important;
-
-					.grid-field__item-tool {
-						transform: rotate(180deg);
-					}
+				tr.grid__item--collapsed {
+					@include grid-collapsed-item-state;
 				}
-			}
 
 			td.required {
 				&:before {
@@ -685,11 +645,11 @@
 			}
 		}
 
-		.row-counter-column {
-			width: 100% !important;
+			.row-counter-column {
+				@include grid-row-counter-full-width;
+			}
 		}
 	}
-}
 
 .grid-field.overwidth {
 	padding: 10px;
@@ -704,12 +664,9 @@
 
 	.grid-field__table {
 		& > tbody > tr:not(.hidden) {
+			@include grid-hide-tools-column;
+
 			& > td {
-
-				&.grid-field__column--tools { display: none !important;}
-
-				// div:empty:not(.ck-insert-table-dropdown-grid-box) { display: none;}
-
 				&.grid-field__item-fieldset {
 					position: relative;
 
@@ -721,7 +678,7 @@
 		}
 
 		.row-counter-column {
-			width: 100% !important;
+			@include grid-row-counter-full-width;
 		}
 	}
 }

--- a/system/ee/ExpressionEngine/Addons/grid/ft.file_grid.php
+++ b/system/ee/ExpressionEngine/Addons/grid/ft.file_grid.php
@@ -53,6 +53,9 @@ class file_grid_ft extends Grid_ft
             'row_counter' => isset($this->settings['row_counter'])
                 ? get_bool_from_string($this->settings['row_counter'])
                 : false,
+            'tools_position' => isset($this->settings['tools_position'])
+                ? get_bool_from_string($this->settings['tools_position'])
+                : false,
         ]);
     }
 
@@ -158,6 +161,16 @@ class file_grid_ft extends Grid_ft
                                 'value' => isset($data['row_counter']) ? $data['row_counter'] : 'n'
                             )
                         )
+                    ],
+                    [
+                        'title' => 'grid_tools_position_title',
+                        'desc' => 'grid_tools_position_desc',
+                        'fields' => array(
+                            'tools_position' => array(
+                                'type' => 'yes_no',
+                                'value' => isset($data['tools_position']) ? $data['tools_position'] : 'n'
+                            )
+                        )
                     ]
                 ]
             ],
@@ -236,6 +249,7 @@ class file_grid_ft extends Grid_ft
         $settings['allowed_directories'] = $data['allowed_directories'];
         $settings['vertical_layout'] = empty($data['vertical_layout']) ? 'n' : $data['vertical_layout'];
         $settings['row_counter'] = empty($data['row_counter']) ? 'n' : $data['row_counter'];
+        $settings['tools_position'] = empty($data['tools_position']) ? 'n' : $data['tools_position'];
 
         return $settings;
     }

--- a/system/ee/ExpressionEngine/Addons/grid/ft.grid.php
+++ b/system/ee/ExpressionEngine/Addons/grid/ft.grid.php
@@ -190,6 +190,9 @@ class Grid_ft extends EE_Fieldtype
             'row_counter' => isset($this->settings['row_counter'])
                 ? get_bool_from_string($this->settings['row_counter'])
                 : false,
+            'tools_position' => isset($this->settings['tools_position'])
+                ? get_bool_from_string($this->settings['tools_position'])
+                : false,
         ));
         $grid->loadAssets();
         $grid->setNoResultsText(
@@ -634,6 +637,16 @@ class Grid_ft extends EE_Fieldtype
                                 'value' => isset($data['row_counter']) ? $data['row_counter'] : 'n'
                             )
                         )
+                    ),
+                    array(
+                        'title' => 'grid_tools_position_title',
+                        'desc' => 'grid_tools_position_desc',
+                        'fields' => array(
+                            'tools_position' => array(
+                                'type' => 'yes_no',
+                                'value' => isset($data['tools_position']) ? $data['tools_position'] : 'n'
+                            )
+                        )
                     )
                 )
             ),
@@ -799,6 +812,7 @@ class Grid_ft extends EE_Fieldtype
             'allow_reorder' => empty($data['allow_reorder']) ? 'y' : $data['allow_reorder'],
             'vertical_layout' => empty($data['vertical_layout']) ? 'n' : $data['vertical_layout'],
             'row_counter' => empty($data['row_counter']) ? 'n' : $data['row_counter'],
+            'tools_position' => empty($data['tools_position']) ? 'n' : $data['tools_position'],
         );
     }
 

--- a/system/ee/ExpressionEngine/View/_shared/table.php
+++ b/system/ee/ExpressionEngine/View/_shared/table.php
@@ -21,7 +21,7 @@
                 <td>
                     <?=lang($no_results['text'])?>
                     <?php if (! empty($no_results['action_text'])): ?>
-                        <a <?=$no_results['external'] ? 'rel="external"' : '' ?> href="<?=$no_results['action_link']?>"><?=lang($no_results['action_text'])?></a>>
+                        <a <?=$no_results['external'] ? 'rel="external"' : '' ?> href="<?=$no_results['action_link']?>"><?=lang($no_results['action_text'])?></a>
                     <?php endif ?>
                 </td>
             </tr>
@@ -214,7 +214,7 @@
     				<tr class="tbl-action">
     					<td colspan="<?=$colspan?>" class="solo">
     						<?php foreach ($action_buttons as $button): ?>
-    							<a class="<?=$button['class']?>" href="<?=$button['url']?>"><?=$button['text']?></a></td>
+    							<a class="<?=$button['class']?>" href="<?=$button['url']?>"><?=$button['text']?></a>
     						<?php endforeach; ?>
     						<?=$action_content?>
     					</td>
@@ -232,36 +232,47 @@
 
 <?php /* End table */
 
-else: ?>
+else:
+    $has_vertical_layout = isset($vertical_layout);
+    $is_vertical_layout = $has_vertical_layout && $vertical_layout === 'y';
+    $is_horizontal_layout = $has_vertical_layout && $vertical_layout === 'horizontal';
+    $has_row_counter = isset($row_counter) && $row_counter;
+    $show_tools_first = isset($tools_position) && $tools_position && ! $is_vertical_layout;
+    $show_item_fieldset_col = REQ == 'CP' && $has_vertical_layout && ! $is_horizontal_layout;
+?>
     <div
-        class="grid-field <?php if (isset($vertical_layout)) {
-                if ($vertical_layout == 'y') : echo ' vertical-layout';
-                elseif ($vertical_layout == 'horizontal') : echo ' horizontal-layout';
+        class="grid-field <?php if ($has_vertical_layout) {
+                if ($is_vertical_layout) : echo ' vertical-layout';
+                elseif ($is_horizontal_layout) : echo ' horizontal-layout';
                 else : echo 'entry-grid';
                 endif;
             }; ?>"
         id="<?=$grid_field_name?>">
 
-    <div class="table-responsive">
-    <table class="grid-field__table"<?php foreach ($table_attrs as $key => $value):?> <?=$key?>='<?=$value?>'<?php endforeach; ?>>
-    <?php if (empty($columns) && empty($data)): ?>
-        <p class="no-results">
+	    <div class="table-responsive">
+	    <table class="grid-field__table"<?php foreach ($table_attrs as $key => $value):?> <?=$key?>='<?=$value?>'<?php endforeach; ?>>
+	    <?php $has_tools_header_col = ! empty($data); ?>
+	    <?php if (empty($columns) && empty($data)): ?>
+	        <p class="no-results">
             <?=lang($no_results['text'])?>
             <?php if (! empty($no_results['action_text'])): ?>
-                <a <?=$no_results['external'] ? 'rel="external"' : '' ?> href="<?=$no_results['action_link']?>"><?=lang($no_results['action_text'])?></a>>
+                <a <?=$no_results['external'] ? 'rel="external"' : '' ?> href="<?=$no_results['action_link']?>"><?=lang($no_results['action_text'])?></a>
             <?php endif ?>
         </p>
     <?php else: ?>
         <thead>
                 <?php
-                // Don't do reordering logic if the table is empty
-                $reorder = $reorder && ! empty($data);
-                $colspan = ($reorder_header || $reorder) ? count($columns) + 1 : count($columns);
-                if(isset($row_counter) && $row_counter): ?>
+	                // Don't do reordering logic if the table is empty
+	                $reorder = $reorder && ! empty($data);
+	                $colspan = ($reorder_header || $reorder) ? count($columns) + 1 : count($columns);
+	                if ($has_row_counter): ?>
                     <th class="row-counter-column"></th>
                 <?php
                 endif;
-                if (isset($vertical_layout)): ?>
+                if ($show_tools_first && $has_tools_header_col): ?>
+                    <th class="grid-field__column-remove"></th>
+                <?php endif;
+                if ($has_vertical_layout): ?>
                     <th class="hidden"></th>
                 <?php endif;
 
@@ -324,14 +335,18 @@ else: ?>
                     <?php endif ?>
                 <?php endforeach ?>
 
-                <?php if (!empty($data)): ?>
+                <?php if ($has_tools_header_col && ! $show_tools_first): ?>
                     <th class="grid-field__column-remove"></th>
                 <?php endif ?>
         </thead>
     <?php endif ?>
-
+        <?php
+            $no_results_colspan = count($columns)
+                + ($has_row_counter ? 1 : 0)
+                + ($has_tools_header_col ? 1 : 0);
+        ?>
         <tbody>
-            <tr class="no-results<?php if (! empty($action_buttons) || ! empty($action_content)): ?> last<?php endif?> <?php if (!empty($data)): ?>hidden<?php endif?>"><td colspan="<?=(count($columns) + @intval($header_sorts))?>">
+            <tr class="no-results<?php if (! empty($action_buttons) || ! empty($action_content)): ?> last<?php endif?> <?php if (!empty($data)): ?>hidden<?php endif?>"><td colspan="<?=$no_results_colspan?>">
             <?php
             // Output this if Grid input so we can dynamically show it via JS
             ?>
@@ -345,7 +360,7 @@ else: ?>
             <?php $i = 1;
             $dataRowCounter = '';
             $rowCounterNumber = '';
-            if (isset($row_counter) && $row_counter){
+            if ($has_row_counter) {
                 $row_count = 0;
             }
             foreach ($data as $heading => $rows): ?>
@@ -355,6 +370,8 @@ else: ?>
 
                 foreach ($rows as $row):
                     $i++;
+                    $dataRowCounter = '';
+                    $rowCounterNumber = '';
 
                     $row_class = "";
 
@@ -363,7 +380,7 @@ else: ?>
                         unset($row['attrs']['class']);
                     }
 
-                    if (isset($row_counter) && $row_counter){
+                    if ($has_row_counter) {
                         if (empty($row_class)) {
                             $row_count++;
                             $dataRowCounter = 'data-row-counter="' . $row_count . '"';
@@ -373,7 +390,7 @@ else: ?>
 
                 ?>
                     <tr class="<?=$row_class?>" <?php foreach ($row['attrs'] as $key => $value):?> <?=$key?>="<?=$value?>"<?php endforeach; ?> <?=$dataRowCounter?>>
-                        <?php if (REQ == 'CP' && isset($vertical_layout) && ($vertical_layout !== 'horizontal')):?>
+                        <?php if ($show_item_fieldset_col): ?>
                         <td class="grid-field__item-fieldset" style="display: none;">
                             <div class="grid-field__item-tools grid-field__item-tools--item-open">
                                 <a href class="grid-field__item-tool js-toggle-grid-item">
@@ -403,8 +420,23 @@ else: ?>
                         </td>
                         <?php endif; ?>
 
-                        <?php if (isset($row_counter) && $row_counter): ?>
+                        <?php if ($has_row_counter): ?>
                             <td class="row-counter-column body-row-counter-column js-row-counter-column"><span><?=$rowCounterNumber?></span></td>
+                        <?php endif; ?>
+
+                        <?php if ($show_tools_first): ?>
+                        <td class="grid-field__column--tools">
+                            <div class="grid-field__column-tools">
+                                <?php if ($reorder): ?>
+                                <button type="button" class="button button--small button--default cursor-move js-grid-reorder-handle">
+                                    <span class="grid-field__column-tool"><i class="fal fa-fw fa-arrows-alt"></i></span>
+                                </button>
+                                <?php endif ?>
+                                <button type="button" rel="remove_row" class="button button--small button--default">
+                                    <span class="grid-field__column-tool danger-link" title="<?=lang('remove_row')?>"><i class="fal fa-fw fa-trash-alt"><span class="hidden"><?=lang('remove_row')?></span></i></span>
+                                </button>
+                            </div>
+                        </td>
                         <?php endif; ?>
 
                         <?php foreach ($row['columns'] as $key => $column):
@@ -497,6 +529,7 @@ else: ?>
                             <?php endif ?>
                         <?php endforeach ?>
 
+                        <?php if (! $show_tools_first): ?>
                         <td class="grid-field__column--tools">
                             <div class="grid-field__column-tools">
                                 <?php if ($reorder): ?>
@@ -509,6 +542,7 @@ else: ?>
                                 </button>
                             </div>
                         </td>
+                        <?php endif; ?>
                     </tr>
                 <?php endforeach ?>
             <?php endforeach ?>
@@ -521,7 +555,7 @@ else: ?>
             <?php if (! empty($action_buttons) || ! empty($action_content)): ?>
             <div class="tbl-action">
                 <?php foreach ($action_buttons as $button): ?>
-                    <a class="<?=$button['class']?>" href="<?=$button['url']?>"><?=$button['text']?></a></td>
+                    <a class="<?=$button['class']?>" href="<?=$button['url']?>"><?=$button['text']?></a>
                 <?php endforeach; ?>
                 <?=$action_content?>
             </div>

--- a/system/ee/language/english/fieldtypes_lang.php
+++ b/system/ee/language/english/fieldtypes_lang.php
@@ -237,6 +237,10 @@ $lang = array(
 
     'grid_row_count_title' => 'Show Row Numbers',
 
+    'grid_tools_position_title' => 'Row Controls First',
+
+    'grid_tools_position_desc' => 'Display reorder and trash controls at the start of each row.',
+
     'grid_chars_allowed' => 'Characters allowed.',
 
     'grid_col_instr' => 'Instructions',

--- a/themes/ee/cp/css/common.min.css
+++ b/themes/ee/cp/css/common.min.css
@@ -27443,6 +27443,10 @@ input[type=button].btn-block {
   max-width: 550px;
 }
 
+.modal-wrap.must-interact .dialog__close {
+  display: none;
+}
+
 .modal {
   background-color: var(--ee-bg-0);
   margin-bottom: 40px;
@@ -32006,6 +32010,10 @@ fieldset .field-control #eye {
     transform: none !important;
   }
 }
+.grid-field__table tr td.grid-field__column--tools {
+  max-width: 80px;
+  min-width: 0;
+}
 .grid-field__table tr.ui-sortable-helper {
   box-shadow: var(--ee-shadow-dropdown);
   background: var(--ee-accent-light);
@@ -32071,7 +32079,6 @@ fieldset .field-control #eye {
 #routes .grid-field__table tr {
   background: inherit;
 }
-
 #routes .table-responsive {
   overflow-x: auto;
 }
@@ -32282,7 +32289,7 @@ fieldset .field-control #eye {
   top: 50%;
   transform: translateY(-50%);
 }
-.grid-field.vertical-layout .grid-field__column--tools {
+.grid-field.vertical-layout td.grid-field__column--tools {
   display: none !important;
 }
 .grid-field.vertical-layout .grid-field__column-label {
@@ -32325,16 +32332,14 @@ fieldset .field-control #eye {
   .grid-field:not(.horizontal-layout) .grid-field__table > tbody > tr {
     display: flex;
     flex-direction: column;
-  }
-  .grid-field:not(.horizontal-layout) .grid-field__table > tbody > tr.hidden {
-    display: none;
-  }
-  .grid-field:not(.horizontal-layout) .grid-field__table > tbody > tr {
     position: relative;
     border: 1px solid var(--ee-border);
     margin-bottom: 10px;
     padding-bottom: 15px;
     background-color: var(--ee-bg-blank);
+  }
+  .grid-field:not(.horizontal-layout) .grid-field__table > tbody > tr.hidden {
+    display: none;
   }
   .grid-field:not(.horizontal-layout) .grid-field__table > tbody > tr.no-results {
     padding: 0px;
@@ -32457,8 +32462,8 @@ fieldset .field-control #eye {
   color: var(--ee-text-secondary);
   font-weight: 500;
   white-space: normal;
-  margin-bottom: 10px;
   flex: 0 0 100%;
+  margin-bottom: 10px;
 }
 .live-preview__form-content .grid-field .grid-field__table > tbody > tr:not(.hidden) > td:not(.hidden) .grid-field__column-label label,
 .grid-field.overwidth .grid-field__table > tbody > tr:not(.hidden) > td:not(.hidden) .grid-field__column-label label {
@@ -32467,8 +32472,8 @@ fieldset .field-control #eye {
 }
 .live-preview__form-content .grid-field .grid-field__table > tbody > tr:not(.hidden) > td:not(.hidden) .grid-field__column-label em,
 .grid-field.overwidth .grid-field__table > tbody > tr:not(.hidden) > td:not(.hidden) .grid-field__column-label em {
-  font-style: normal;
   color: var(--ee-text-secondary);
+  font-style: normal;
   margin: 0;
 }
 .live-preview__form-content .grid-field .grid-field__table > tbody > tr:not(.hidden) > td:not(.hidden) .grid-field__column-tools,
@@ -32553,7 +32558,7 @@ fieldset .field-control #eye {
   border: none;
   box-shadow: none;
 }
-.grid-field.overwidth .grid-field__table > tbody > tr:not(.hidden) > td.grid-field__column--tools {
+.grid-field.overwidth .grid-field__table > tbody > tr:not(.hidden) td.grid-field__column--tools {
   display: none !important;
 }
 .grid-field.overwidth .grid-field__table > tbody > tr:not(.hidden) > td.grid-field__item-fieldset {


### PR DESCRIPTION
Improved #4094 
Improved #4554 
Related PR 
#5209 
#5210 
Added a new Grid/File Grid field setting to control row actions position
wired through settings save/load, and updated shared table rendering so reorder/delete controls can appear at the start of each row (after row counter, or first column) for non-vertical layouts while preserving existing vertical behavior. 

closed #4691 