### PR TITLE
bugfix/post-max-size-fail-http-response

### DIFF
--- a/system/ee/ExpressionEngine/Addons/filepicker/mcp.filepicker.php
+++ b/system/ee/ExpressionEngine/Addons/filepicker/mcp.filepicker.php
@@ -317,6 +317,24 @@ class Filepicker_mcp
         $subfolder_id = (int) ee('Request')->post('directory_id');
 
         if (empty($dir_id)) {
+            ee()->load->helper('number_helper');
+            ee()->lang->loadfile('upload');
+
+            $contentLength = (int) ee()->input->server('CONTENT_LENGTH');
+            $postMax = get_bytes(ini_get('post_max_size'));
+
+            // If POST body is larger than post_max_size, PHP drops POST/FILES.
+            // In that case, return a useful upload limit error instead of 404.
+            if ($contentLength > 0 && $postMax > 0 && $contentLength > $postMax) {
+                return [
+                    'ajax' => true,
+                    'body' => [
+                        'status' => 'error',
+                        'error' => lang('upload_file_exceeds_limit')
+                    ]
+                ];
+            }
+
             show_404();
         }
 

--- a/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.es6
+++ b/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.es6
@@ -207,6 +207,8 @@ class DragAndDropUpload extends React.Component {
       let xhr = new XMLHttpRequest()
       xhr.open('POST', EE.dragAndDrop.endpoint, true)
       xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+      xhr.setRequestHeader('X-CSRF-TOKEN', EE.CSRF_TOKEN);
+      xhr.setRequestHeader('X-EEXID', EE.CSRF_TOKEN);
 
       xhr.upload.addEventListener('progress', (e) => {
         if ( $('.file-upload-widget').hasClass('open-dd') ) {
@@ -277,7 +279,9 @@ class DragAndDropUpload extends React.Component {
               reject(file)
               break
             default:
-              if (typeof(response.message) !== 'undefined') {
+              if (typeof(response.error) !== 'undefined') {
+                file.error = this.stripTags(response.error);
+              } else if (typeof(response.message) !== 'undefined') {
                 file.error = response.message;
               } else {
                 file.error = EE.lang.file_dnd_unexpected_error;

--- a/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.js
+++ b/themes/ee/asset/javascript/src/fields/file/drag_and_drop_upload.js
@@ -316,6 +316,8 @@ var DragAndDropUpload = /*#__PURE__*/function (_React$Component) {
         var xhr = new XMLHttpRequest();
         xhr.open('POST', EE.dragAndDrop.endpoint, true);
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+        xhr.setRequestHeader('X-CSRF-TOKEN', EE.CSRF_TOKEN);
+        xhr.setRequestHeader('X-EEXID', EE.CSRF_TOKEN);
         xhr.upload.addEventListener('progress', function (e) {
           if ($('.file-upload-widget').hasClass('open-dd')) {
             $('.file-upload-widget').css({
@@ -390,7 +392,9 @@ var DragAndDropUpload = /*#__PURE__*/function (_React$Component) {
                 reject(file);
                 break;
               default:
-                if (typeof _response.message !== 'undefined') {
+                if (typeof _response.error !== 'undefined') {
+                  file.error = _this3.stripTags(_response.error);
+                } else if (typeof _response.message !== 'undefined') {
                   file.error = _response.message;
                 } else {
                   file.error = EE.lang.file_dnd_unexpected_error;


### PR DESCRIPTION
This was driving me to distraction.  Was testing uploading a file that was larger than max post size- and I get the max post size error.  But I discovered ANY fail seems to get it.  Like- if I die with 'what up' in the file manager constructor?  Max post size error.  

But- ignoring THAT- in the response header I'm getting a csrf error.
<img width="1605" height="421" alt="Screenshot 2026-04-02 at 11 00 35 AM" src="https://github.com/user-attachments/assets/6786a472-09a0-4fd8-82a8-041d35effcc7" />

This did not give me joy.  So basically- this fixes that.  But definitely needs eyeballs since I was very focused on fixing the specific thing that was making my life harder.

But as far as the fix:
fix(file-upload): surface post_max_size errors instead of CSRF expiry in file picker uploads
- add filepicker ajaxUpload() guard for oversized requests where PHP drops POST/FILES and upload_location_id is missing
- return upload_file_exceeds_limit JSON error instead of falling through to show_404()
- send CSRF token in upload XHR headers (X-CSRF-TOKEN and X-EEXID) so token validation is resilient when POST body is
- update drag/drop uploader fallback to prefer server error payloads in default response handling



