### PR TITLE
Fixed a PHP deprecation warning when PDO keys are specified in config

### DIFF
--- a/system/ee/legacy/database/DB_driver.php
+++ b/system/ee/legacy/database/DB_driver.php
@@ -49,6 +49,21 @@ class CI_DB_driver
     public $CACHE; // The cache class object
     public $dbcollat_default; // true if the collation is not in the config or is default
 
+    // PDO MYSQL_ATTR_* options that can be passed in database config
+    public $MYSQL_ATTR_LOCAL_INFILE;
+    public $MYSQL_ATTR_LOCAL_INFILE_DIRECTORY;
+    public $MYSQL_ATTR_READ_DEFAULT_FILE;
+    public $MYSQL_ATTR_READ_DEFAULT_GROUP;
+    public $MYSQL_ATTR_MAX_BUFFER_SIZE;
+    public $MYSQL_ATTR_INIT_COMMAND;
+    public $MYSQL_ATTR_COMPRESS;
+    public $MYSQL_ATTR_SSL_CA;
+    public $MYSQL_ATTR_SSL_CAPATH;
+    public $MYSQL_ATTR_SSL_CERT;
+    public $MYSQL_ATTR_SSL_CIPHER;
+    public $MYSQL_ATTR_SSL_KEY;
+    public $MYSQL_ATTR_SSL_VERIFY_SERVER_CERT;
+
     // Private variables
     public $_protect_identifiers = true;
     public $_reserved_identifiers = array('*'); // Identifiers that should NOT be escaped


### PR DESCRIPTION
 Deprecated
Creation of dynamic property ExpressionEngine\Service\Database\Query::$MYSQL_ATTR_SSL_KEY is deprecated ee/legacy/database/DB_driver.php, line 73

