### PR TITLE
Fix a bug when syncing international characters in files

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Files/Uploads.php
+++ b/system/ee/ExpressionEngine/Controller/Files/Uploads.php
@@ -928,7 +928,10 @@ class Uploads extends AbstractFilesController
             ($current_files = ee()->input->post('files')) === false
             && $db_sync != 'y'
         ) {
-            return false;
+            return ee()->output->send_ajax_response([
+                'message_type' => 'failure',
+                'errors' => lang('invalid_action'),
+            ]);
         }
 
         $uploadDestination = ee('Model')->get('UploadDestination', $id)->first();

--- a/system/ee/ExpressionEngine/Model/File/UploadDestination.php
+++ b/system/ee/ExpressionEngine/Model/File/UploadDestination.php
@@ -474,11 +474,13 @@ class UploadDestination extends StructureModel
     {
         foreach ($nestedMap as $key => $val) {
             $flatKey = rtrim($keyPrefix . $key, '/');
-            if (! isset($flatMap[$flatKey])) {
-                $flatMap[$flatKey] = $flatKey;
-            }
             if (is_array($val)) {
-                $flatMap[$flatKey] = $this->flattenDirectoryMap($flatMap, $val, $flatKey . '/');
+                if ($val !== [] && ! isset($flatMap[$flatKey])) {
+                    $flatMap[$flatKey] = $flatKey;
+                }
+                $this->flattenDirectoryMap($flatMap, $val, $flatKey . '/');
+            } elseif (! isset($flatMap[$flatKey])) {
+                $flatMap[$flatKey] = $flatKey;
             }
         }
     }

--- a/themes/ee/asset/javascript/src/cp/files/synchronize.js
+++ b/themes/ee/asset/javascript/src/cp/files/synchronize.js
@@ -108,7 +108,7 @@ EE.file_manager.sync = function(upload_directory_id) {
 			EE.file_manager.sync_running -= 1;
 
 			// Update the progress bar
-			var total_count       = EE.file_manager.sync_file_count,
+			var total_count       = EE.file_manager.sync_file_count || 1,
 				current_count     = EE.file_manager.sync_files.length,
 				already_processed = total_count - current_count;
 
@@ -126,9 +126,13 @@ EE.file_manager.sync = function(upload_directory_id) {
 						EE.file_manager.sync_errors.push("<b>" + key + "</b>: " + data.errors[key]);
 					}
 				} else {
-					EE.file_manager.sync_errors.push("<b>Undefined errors</b>"); d
+					EE.file_manager.sync_errors.push("<b>Undefined errors</b>");
 				}
 			}
+		},
+		error: function(xhr, textStatus, errorThrown) {
+			var msg = (xhr && xhr.status) ? xhr.status + ' ' + xhr.statusText : (textStatus || errorThrown || 'error');
+			EE.file_manager.sync_errors.push("<b>Request failed</b>: " + msg);
 		}
 	});
 };


### PR DESCRIPTION
Had an issue syncing with a file with ö in the name.  Sync would appear to never finish, though the file did end up in the upload directory.  Same file could be uploaded fine.

Looks like there are a few differences in unicode character handling- namely getDirectoryMap() → Flysystem Local adapter + getWithMetadata() + basename() on macOS (darwin) can return decomposed Unicode (NFD) while PHP/DB/Flysystem normalization elsewhere uses composed (NFC). Comparisons like $fileInfo['path'] != $clean_filename or getFileByPath() DB lookups can behave unexpectedly.

This fix does a few things:

* Stray d in sync JS throws ReferenceError on the “undefined errors” branch and can break the sync flow
* doSyncFiles() returning false in a few early cases rather than json
* flattenDirectoryMap() assigning recursive return (null) - bigger change, but I think it's solid.  Wasn't critical to the issue at hand, but now can recurse without overwrite; keep parent paths for non‑empty dirs so subfolders still sync in a sane order