### PR TITLE
Added a new live preview token for broader web server compatibility

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
+++ b/system/ee/ExpressionEngine/Addons/channel/mod.channel.php
@@ -5434,20 +5434,50 @@ class Channel
 
         // Validate preview token
         $request = ee('Request');
-        $auth_header = null;
-        if (is_object($request) && method_exists($request, 'header')) {
-            $auth_header = $request->header('Authorization');
-        }
-        if (empty($auth_header) && is_object($request) && method_exists($request, 'server')) {
-            $auth_header = $request->server('REDIRECT_HTTP_AUTHORIZATION');
-        }
-        if (empty($auth_header)) {
-            $auth_header = $_SERVER['HTTP_AUTHORIZATION'] ?? ($_SERVER['REDIRECT_HTTP_AUTHORIZATION'] ?? null);
-        }
+        $token_candidates = [
+            'HTTP_AUTHORIZATION',
+            'REDIRECT_HTTP_AUTHORIZATION',
+            'HTTP_EE_LIVE_PREVIEW_TOKEN',
+            'REDIRECT_HTTP_EE_LIVE_PREVIEW_TOKEN',
+        ];
+
+        $extract_token = static function ($candidate, $header_value) {
+            if (!is_string($header_value)) {
+                return null;
+            }
+
+            $header_value = trim($header_value);
+            if ($header_value === '') {
+                return null;
+            }
+
+            if (preg_match('/^\s*Bearer\s+(.+)$/i', $header_value, $matches)) {
+                return trim($matches[1]);
+            }
+
+            if (preg_match('/AUTHORIZATION$/', $candidate)) {
+                return null;
+            }
+
+            return $header_value;
+        };
 
         $preview_token = null;
-        if (!empty($auth_header) && preg_match('/^\s*Bearer\s+(.+)$/i', $auth_header, $matches)) {
-            $preview_token = trim($matches[1]);
+
+        foreach ($token_candidates as $candidate) {
+            $header_value = null;
+            if (is_object($request) && method_exists($request, 'server')) {
+                $header_value = $request->server($candidate);
+            }
+
+            if (is_null($header_value)) {
+                $header_value = $_SERVER[$candidate] ?? null;
+            }
+
+            $preview_token = $extract_token($candidate, $header_value);
+            if (!is_null($preview_token)) {
+                break;
+            }
         }
 
         $token_origin = $from_origin ?: ($origin_header ?: ($referer_header ?: $return));

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Channel/Mod/ChannelLivePreviewTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Channel/Mod/ChannelLivePreviewTest.php
@@ -8,6 +8,9 @@ class ChannelLivePreviewTest extends ChannelTestBase
     {
         parent::setUp();
         unset($_SERVER['HTTP_AUTHORIZATION']);
+        unset($_SERVER['REDIRECT_HTTP_AUTHORIZATION']);
+        unset($_SERVER['HTTP_EE_LIVE_PREVIEW_TOKEN']);
+        unset($_SERVER['REDIRECT_HTTP_EE_LIVE_PREVIEW_TOKEN']);
         ee()->session->set_userdata('session_id', 'test-session');
         $this->setDbRows([
             [
@@ -46,10 +49,22 @@ class ChannelLivePreviewTest extends ChannelTestBase
     {
         if (empty($token)) {
             unset($_SERVER['HTTP_AUTHORIZATION']);
+            unset($_SERVER['REDIRECT_HTTP_AUTHORIZATION']);
             return;
         }
 
         $_SERVER['HTTP_AUTHORIZATION'] = 'Bearer ' . $token;
+    }
+
+    private function setPreviewTokenCompatibilityHeader(?string $token): void
+    {
+        if (empty($token)) {
+            unset($_SERVER['HTTP_EE_LIVE_PREVIEW_TOKEN']);
+            unset($_SERVER['REDIRECT_HTTP_EE_LIVE_PREVIEW_TOKEN']);
+            return;
+        }
+
+        $_SERVER['HTTP_EE_LIVE_PREVIEW_TOKEN'] = $token;
     }
 
     public function testNoPreviewDataEarlyExit()
@@ -191,6 +206,47 @@ class ChannelLivePreviewTest extends ChannelTestBase
         $this->setMock('Permission', new class { public function can($k){ return true; } public function isSuperAdmin(){ return false; } });
         ee()->session->set_userdata('member_id', 1);
         $this->setPreviewTokenHeader($this->issuePreviewToken());
+        $this->setMock('config', (function(){ $c = new FakeConfig(); $c->items['cp_url'] = 'http://localhost/admin.php';
+            $c->items['site_id'] = 1; return $c; })());
+
+        $out = $this->channel->live_preview();
+
+        $this->assertTrue($livePreview->called, 'unexpected error: ' . json_encode($output->last));
+        $this->assertSame('PREVIEW', $out);
+    }
+
+    public function testLivePreviewAllowsValidTokenFromCompatibilityHeader()
+    {
+        $_SERVER['HTTP_ORIGIN'] = 'http://localhost';
+        unset($_SERVER['HTTP_REFERER']);
+        $livePreview = new class {
+            public $called = false;
+            public function preview() { $this->called = true; return 'PREVIEW'; }
+            public function hasEntryData(){ return false; }
+        };
+        $this->setMock('LivePreview', $livePreview);
+
+        $this->setMock('input', new class {
+            public function get_post($k){ if ($k === 'entry_id') { return 3; } if ($k === 'channel_id') { return 1; } return null; }
+            public function get($k){ if ($k==='return'){ return rawurlencode(base64_encode('http://localhost/return')); } if ($k==='prefer_system_preview'){ return 'n'; } return null; }
+        });
+        $this->setMock('Request', new class { public function get($k){ return rawurlencode(base64_encode('http://localhost')); } public function isEncrypted(){ return false; } public function method(){ return 'POST'; } });
+        $this->setMock('Model', new class { public function get($m){ return new class { public function filter(){ return $this; } public function all(){ return new class { public function pluck($k){ return ['http://localhost/']; } }; } }; } });
+        $this->setMock('Config', new class { public function getFile(){ return new class { public function get($k){ return []; } }; } });
+        $this->setMock('lang', new class { public function load($k){} public function line($k){ return $k; } });
+        $output = new class {
+            public $last = null;
+            public function show_user_error(...$args){
+                $this->last = $args;
+                return 'ERR';
+            }
+        };
+        $this->setMock('output', $output);
+        $this->setMock('Permission', new class { public function can($k){ return true; } public function isSuperAdmin(){ return false; } });
+        ee()->session->set_userdata('member_id', 1);
+        $token = $this->issuePreviewToken();
+        $this->setPreviewTokenHeader(null);
+        $this->setPreviewTokenCompatibilityHeader($token);
         $this->setMock('config', (function(){ $c = new FakeConfig(); $c->items['cp_url'] = 'http://localhost/admin.php';
             $c->items['site_id'] = 1; return $c; })());
 

--- a/themes/ee/asset/javascript/src/cp/publish/publish.js
+++ b/themes/ee/asset/javascript/src/cp/publish/publish.js
@@ -289,6 +289,7 @@ $(document).ready(function () {
 					request.setRequestHeader("Access-Control-Allow-Origin", window.location.origin);
 					if (preview_token) {
 						request.setRequestHeader("Authorization", "Bearer " + preview_token);
+						request.setRequestHeader("EE-Live-Preview-Token", preview_token);
 					}
 				},
 				data: publishForm.serialize(),


### PR DESCRIPTION
It turns out that many Apache server configurations are blocking the standard `Authorization` token header (see https://expressionengine.com/forums/topic/254312)  So we are adding an alternative header to help alleviate the need for users to update their server config.