### PR TITLE
Added {fluid:group_id} template variable for stable per-group identification

### DIFF
--- a/system/ee/legacy/libraries/Fluid_field_parser.php
+++ b/system/ee/legacy/libraries/Fluid_field_parser.php
@@ -413,6 +413,7 @@ class Fluid_field_parser
                 $fluid_field_name . ':last_group' => (int) (($g + 1) == $total_groups),
                 $fluid_field_name . ':count_group' => $g + 1,
                 $fluid_field_name . ':index_group' => $g,
+                $fluid_field_name . ':group_id' => min(array_map(function ($f) { return (int) $f->id; }, $group['fields'])),
                 $fluid_field_name . ':current_group_name' => $group['name'],
                 $fluid_field_name . ':current_group_short_name' => $group['short_name'],
                 $fluid_field_name . ':next_group_name' => (($g + 1) < $total_groups) ? $groups[$g + 1]['name'] : '',


### PR DESCRIPTION
Adds `{fluid_field_name:group_id}` meta variable, available inside the Fluid tag pair. Returns the stable autoincrement PK from `exp_fluid_field_data` for the current group (the minimum across the group's sub-field rows, all of which share an insertion lifecycle).

Use case and full discussion: https://github.com/ExpressionEngine/ExpressionEngine/discussions/5228

## Stability properties

- Survives editing of any sub-field value in the group
- Survives reordering groups within the field — `Fluid_field::post_save()` updates `order`/`group` columns rather than re-inserting rows, so `id` is preserved
- Globally unique across all entries' Fluid groups
- Reissued only when a group is deleted and recreated — same semantics as `entry_id` and Grid's `row_id`

## Change

One line addition to `$group_meta` in `Fluid_field_parser::parse()`. `$group['fields']` is already populated with `fluid_field:FluidField` model instances exposing `id`.

## Backward compatibility

Pure addition. No existing tag, schema, or migration touched.

## Documentation

User Guide PR: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1139