### PR TITLE
Fix #5242 WEBP/AVIF alpha preservation in GD image manipulations

### DIFF
--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/ImageLibAlphaPreservationTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/ImageLibAlphaPreservationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace ExpressionEngine\Tests\ExpressionEngine\legacy\Libraries;
+
+require_once __DIR__ . '/../../../eeObjectMock.php';
+require_once SYSPATH . 'ee/legacy/libraries/Image_lib.php';
+
+use PHPUnit\Framework\TestCase;
+
+class ImageLibAlphaPreservationTest extends TestCase
+{
+    /**
+     * Reset singleton mocks before each test.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        ee()->resetMocks();
+    }
+
+    /**
+     * Reset singleton mocks after each test.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        ee()->resetMocks();
+    }
+
+    /**
+     * Ensure WEBP images initialize a transparent destination canvas.
+     *
+     * @return void
+     */
+    public function testImagePreserveAlphaPreservesWebpTransparency(): void
+    {
+        $this->skipWhenGdImageFunctionsAreUnavailable();
+
+        $sourceImage = $this->createTransparentSourceImage();
+        $destinationImage = imagecreatetruecolor(4, 4);
+
+        $imageLib = new \EE_Image_lib();
+        $imageLib->image_type = 18;
+        $imageLib->image_preserve_alpha($destinationImage, $sourceImage);
+
+        imagecopyresampled($destinationImage, $sourceImage, 0, 0, 0, 0, 4, 4, 4, 4);
+
+        $this->assertSame(127, $this->getAlphaValueForPixel($destinationImage, 0, 0));
+
+        imagedestroy($sourceImage);
+        imagedestroy($destinationImage);
+    }
+
+    /**
+     * Ensure AVIF images initialize a transparent destination canvas.
+     *
+     * @return void
+     */
+    public function testImagePreserveAlphaPreservesAvifTransparency(): void
+    {
+        $this->skipWhenGdImageFunctionsAreUnavailable();
+
+        $sourceImage = $this->createTransparentSourceImage();
+        $destinationImage = imagecreatetruecolor(4, 4);
+
+        $imageLib = new \EE_Image_lib();
+        $imageLib->image_type = 19;
+        $imageLib->image_preserve_alpha($destinationImage, $sourceImage);
+
+        imagecopyresampled($destinationImage, $sourceImage, 0, 0, 0, 0, 4, 4, 4, 4);
+
+        $this->assertSame(127, $this->getAlphaValueForPixel($destinationImage, 0, 0));
+
+        imagedestroy($sourceImage);
+        imagedestroy($destinationImage);
+    }
+
+    /**
+     * Build an in-memory fully transparent source image.
+     *
+     * @return resource
+     */
+    private function createTransparentSourceImage()
+    {
+        $sourceImage = imagecreatetruecolor(4, 4);
+        imagealphablending($sourceImage, false);
+        imagesavealpha($sourceImage, true);
+
+        $transparentColor = imagecolorallocatealpha($sourceImage, 0, 0, 0, 127);
+        imagefill($sourceImage, 0, 0, $transparentColor);
+
+        return $sourceImage;
+    }
+
+    /**
+     * Read alpha value for a single pixel.
+     *
+     * @param resource $image Image resource to inspect.
+     * @param int $x Horizontal pixel coordinate.
+     * @param int $y Vertical pixel coordinate.
+     * @return int
+     */
+    private function getAlphaValueForPixel($image, int $x, int $y): int
+    {
+        $pixel = imagecolorat($image, $x, $y);
+        $channels = imagecolorsforindex($image, $pixel);
+
+        return $channels['alpha'];
+    }
+
+    /**
+     * Skip the test class when required GD functions are unavailable.
+     *
+     * @return void
+     */
+    private function skipWhenGdImageFunctionsAreUnavailable(): void
+    {
+        if (! function_exists('imagecreatetruecolor')) {
+            $this->markTestSkipped('GD extension is required for alpha-preservation tests.');
+        }
+
+        if (! function_exists('imagecopyresampled')) {
+            $this->markTestSkipped('GD resampling functions are required for alpha-preservation tests.');
+        }
+
+        if (! function_exists('imagecolorallocatealpha')) {
+            $this->markTestSkipped('GD alpha color allocation is required for alpha-preservation tests.');
+        }
+    }
+}

--- a/system/ee/legacy/libraries/Image_lib.php
+++ b/system/ee/legacy/libraries/Image_lib.php
@@ -829,7 +829,10 @@ class EE_Image_lib
             }
         }
 
-        if (! in_array($this->image_type, [IMAGETYPE_PNG, 18, 19], true)) {
+        // If the image is not a PNG, WEBP or AVIF we will skip handling alpha channel support.
+        // Note: IMAGETYPE_AVIF was introduced in PHP 8.1.0 so the value 19 is used here instead.
+        $imagetype_avif = defined('IMAGETYPE_AVIF') ? IMAGETYPE_AVIF : 19;
+        if (! in_array($this->image_type, [IMAGETYPE_PNG, IMAGETYPE_WEBP, $imagetype_avif], true)) {
             return;
         }
 

--- a/system/ee/legacy/libraries/Image_lib.php
+++ b/system/ee/legacy/libraries/Image_lib.php
@@ -796,18 +796,15 @@ class EE_Image_lib
     }
 
     /**
-     * Preserves transparencies when working with GIFs and PNGs
+     * Preserve source transparency on a destination GD image resource.
      *
-     * Provided a new image and source image resource, it works with those
-     * already-allocated resources, so it returns void
-     *
-     * @access  public
-     * @param   resource $new_img Destination image resource, will have alpha applied to this
-     * @param   resource $src_img Source image resource for reference
+     * @param resource $new_img Destination image resource that will receive transparency setup.
+     * @param resource $src_img Source image resource used to inspect transparency metadata.
+     * @return void
      */
     public function image_preserve_alpha($new_img, $src_img)
     {
-        // Preserve transparancies for GIFs and PNGs
+        // Preserve transparancies for GIFs and PNGs.
         if ($this->image_type == IMAGETYPE_GIF || $this->image_type == IMAGETYPE_PNG) {
             $src_alpha_index = imagecolortransparent($src_img);
 
@@ -827,17 +824,23 @@ class EE_Image_lib
                 // Set alpha color as background color and make it transparent
                 imagefill($new_img, 0, 0, $alpha_index);
                 imagecolortransparent($new_img, $alpha_index);
-            } elseif ($this->image_type == IMAGETYPE_PNG) {
-                imagealphablending($new_img, false);
 
-                // Create a new transparent color for image
-                $alpha_color = imagecolorallocatealpha($new_img, 0, 0, 0, 127);
-
-                // Set alpha color as background color and save alpha state
-                imagefill($new_img, 0, 0, $alpha_color);
-                imagesavealpha($new_img, true);
+                return;
             }
         }
+
+        if (! in_array($this->image_type, [IMAGETYPE_PNG, 18, 19], true)) {
+            return;
+        }
+
+        imagealphablending($new_img, false);
+
+        // Create a new transparent color for image
+        $alpha_color = imagecolorallocatealpha($new_img, 0, 0, 0, 127);
+
+        // Set alpha color as background color and save alpha state
+        imagefill($new_img, 0, 0, $alpha_color);
+        imagesavealpha($new_img, true);
     }
 
     /**


### PR DESCRIPTION
Fix transparency for WEBP and AVIF #5242