### PR TITLE
Hardening error display information leaks

### DIFF
--- a/system/ee/ExpressionEngine/Boot/boot.common.php
+++ b/system/ee/ExpressionEngine/Boot/boot.common.php
@@ -544,6 +544,22 @@ function _exception_handler($severity, $message, $filepath, $line)
 }
 
 /**
+ * Shutdown handler for web requests.
+ *
+ * @return bool
+ */
+function webShutdownHandler()
+{
+    if (@is_array($error = @error_get_last())) {
+        $_error = load_class('Exceptions', 'core');
+
+        return $_error->handleWebShutdownError($error);
+    }
+
+    return true;
+}
+
+/**
  * Remove Invisible Characters
  *
  * This prevents sandwiching null characters

--- a/system/ee/ExpressionEngine/Boot/boot.php
+++ b/system/ee/ExpressionEngine/Boot/boot.php
@@ -87,6 +87,8 @@
         register_shutdown_function('cliShutdownHandler');
     } else {
         set_error_handler('_exception_handler');
+        ob_start();
+        register_shutdown_function('webShutdownHandler');
     }
 
 /*

--- a/system/ee/legacy/core/Exceptions.php
+++ b/system/ee/legacy/core/Exceptions.php
@@ -17,6 +17,8 @@ class EE_Exceptions
 
     protected $php_errors_output = false;
 
+    protected $generic_public_error_message = 'An unexpected error occurred. Please contact the site administrator if the problem persists.';
+
     /**
      * Constructor
      */
@@ -80,6 +82,10 @@ class EE_Exceptions
     {
         $this->php_errors_output = true;
 
+        if (! $this->shouldShowDetailedWebErrors()) {
+            return;
+        }
+
         list($error_constant, $error_category) = $this->lookupSeverity($severity);
 
         if (REQ == 'CLI') {
@@ -127,6 +133,62 @@ class EE_Exceptions
     public function hasOutputPhpErrors()
     {
         return $this->php_errors_output;
+    }
+
+    /**
+     * Determine whether this web request should receive detailed browser errors.
+     *
+     * @return bool
+     */
+    public function shouldShowDetailedWebErrors()
+    {
+        if (defined('REQ') && REQ === 'CLI') {
+            return true;
+        }
+
+        if (defined('DEBUG') && DEBUG == 1) {
+            return true;
+        }
+
+        $debug = $this->getConfiguredDebugLevel();
+
+        if ($debug > 1) {
+            return true;
+        }
+
+        if ($debug == 1) {
+            return $this->isCurrentUserSuperAdmin() || $this->currentSessionCanDebug();
+        }
+
+        return $this->isCurrentUserSuperAdmin();
+    }
+
+    /**
+     * Public-facing fallback error message for non-superadmins.
+     *
+     * @return string
+     */
+    public function getGenericPublicErrorMessage()
+    {
+        return $this->generic_public_error_message;
+    }
+
+    /**
+     * Render a generic public error response.
+     *
+     * @param int $status_code
+     * @return void
+     */
+    public function showPublicError($status_code = 500)
+    {
+        set_status_header($status_code);
+
+        if (defined('AJAX_REQUEST') && AJAX_REQUEST) {
+            $this->sendGenericAjaxError($status_code);
+        }
+
+        echo $this->renderGenericPublicError($status_code);
+        exit;
     }
 
     /**
@@ -228,6 +290,10 @@ class EE_Exceptions
     {
         set_status_header($status_code);
 
+        if (! $this->shouldShowDetailedWebErrors()) {
+            $this->showPublicError($status_code);
+        }
+
         $error_type = get_class($exception);
 
         $message = $exception->getMessage();
@@ -292,18 +358,7 @@ class EE_Exceptions
             $line = htmlentities($line, ENT_QUOTES, 'UTF-8');
         }
 
-        // We'll only want to show certain information, like file paths, if we're allowed
-        $debug = (bool) (DEBUG or (isset(ee()->config) && ee()->config->item('debug') > 1) or (isset(ee()->session) && ee('Permission')->isSuperAdmin()));
-
-        // Hide sensitive information such as file paths and database information
-        if (! $debug) {
-            $location_parts = explode('/', $location);
-            $location = array_pop($location_parts);
-
-            if (strpos($message, 'SQLSTATE') !== false) {
-                $message = 'There was a database connection error or a problem with a query. Log in as a super admin or enable debugging for more information.';
-            }
-        }
+        $debug = true;
 
         if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) &&
             $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest') {
@@ -346,6 +401,40 @@ class EE_Exceptions
     }
 
     /**
+     * Handle a fatal shutdown error for web requests.
+     *
+     * @param array $error
+     * @return bool
+     */
+    public function handleWebShutdownError($error)
+    {
+        if (! is_array($error) || ! $this->isFatalShutdownError($error['type'] ?? null)) {
+            return false;
+        }
+
+        // We are taking responsibility for rendering the fatal error now.
+        @ini_set('display_errors', 0);
+
+        if (! $this->shouldShowDetailedWebErrors()) {
+            while (ob_get_level() > 0) {
+                ob_end_clean();
+            }
+
+            $this->showPublicError(500);
+        }
+
+        $exception = new \ErrorException(
+            $error['message'] ?? 'Fatal error',
+            0,
+            $error['type'],
+            $error['file'] ?? __FILE__,
+            $error['line'] ?? __LINE__
+        );
+
+        $this->show_exception($exception, 500);
+    }
+
+    /**
      * @return Array of [PHP Severity constant, Human severity name]
      */
     private function lookupSeverity($severity)
@@ -385,6 +474,102 @@ class EE_Exceptions
             default:
                 return array('UNKNOWN', 'Error');
         }
+    }
+
+    /**
+     * @param int $status_code
+     * @return string
+     */
+    private function renderGenericPublicError($status_code)
+    {
+        $heading = 'Error';
+        $message = $this->getGenericPublicErrorMessage();
+
+        if (ob_get_level() > $this->ob_level + 1) {
+            ob_end_flush();
+        }
+
+        ob_start();
+
+        if (file_exists(APPPATH)) {
+            include(APPPATH . 'errors/error_general.php');
+        } else {
+            include(BASEPATH . 'errors/error_general.php');
+        }
+
+        $buffer = ob_get_contents();
+        ob_end_clean();
+
+        return $buffer;
+    }
+
+    /**
+     * @param int $status_code
+     * @return void
+     */
+    private function sendGenericAjaxError($status_code)
+    {
+        set_status_header($status_code);
+        echo json_encode([
+            'messageType' => 'error',
+            'message' => $this->getGenericPublicErrorMessage(),
+        ]);
+        exit;
+    }
+
+    /**
+     * @param int|null $type
+     * @return bool
+     */
+    private function isFatalShutdownError($type)
+    {
+        return in_array($type, [
+            E_ERROR,
+            E_PARSE,
+            E_CORE_ERROR,
+            E_COMPILE_ERROR,
+            E_USER_ERROR,
+        ], true);
+    }
+
+    /**
+     * @return int
+     */
+    private function getConfiguredDebugLevel()
+    {
+        if (! function_exists('ee') || ! ee() || ! isset(ee()->config)) {
+            return 0;
+        }
+
+        return (int) ee()->config->item('debug');
+    }
+
+    /**
+     * @return bool
+     */
+    private function isCurrentUserSuperAdmin()
+    {
+        if (! function_exists('ee') || ! ee() || ! isset(ee()->session) || ! isset(ee()->di)) {
+            return false;
+        }
+
+        try {
+            return ee('Permission')->isSuperAdmin();
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function currentSessionCanDebug()
+    {
+        if (! function_exists('ee') || ! ee() || ! isset(ee()->session)) {
+            return false;
+        }
+
+        return ee()->session->userdata('can_debug') == 'y';
     }
 }
 // END Exceptions Class

--- a/system/ee/legacy/database/DB_driver.php
+++ b/system/ee/legacy/database/DB_driver.php
@@ -874,6 +874,12 @@ class CI_DB_driver
             $message = (! is_array($error)) ? array(str_replace('%s', $swap, $LANG->line($error))) : $error;
         }
 
+        $error_handler = load_class('Exceptions', 'core');
+
+        if (! $error_handler->shouldShowDetailedWebErrors()) {
+            $error_handler->showPublicError(500);
+        }
+
         // Find the most likely culprit of the error by going through
         // the backtrace until the source file is no longer in the
         // database folder.
@@ -899,8 +905,7 @@ class CI_DB_driver
             throw new Exception(implode('<br>', $message));
         }
 
-        $error = load_class('Exceptions', 'core');
-        echo $error->show_error($heading, $message);
+        echo $error_handler->show_error($heading, $message);
         exit;
     }
 

--- a/system/ee/legacy/errors/error_exception.php
+++ b/system/ee/legacy/errors/error_exception.php
@@ -13,7 +13,9 @@
 			<div class="err-wrap error">
 				<h1><?=$error_type?> Caught</h1>
 				<h2><?php echo $message ?></h2>
-				<p><?php echo $location ?></p>
+				<?php if ($location !== ''): ?>
+					<p><?php echo $location ?></p>
+				<?php endif ?>
 
 				<?php if ($debug): ?>
 					<h3>Stack Trace: <i>Please include when reporting this error</i></h3>


### PR DESCRIPTION
This one is tricky.  We have a number of debug settings to handle error display.

admin.php and index.php both have overrides: $debug = 0; 1 overrides all other settings and shows all errors to everyone, logged in or not.

$config['debug'] - 0, 1, 2 - this is the debug setting in the control panel output and debugging.  0 hide all; 1 show only superadmin; 2 show to everyone.  

can_debug - is for superadmin logged in as another user who is not superadmin.

And we can leak errors to users who don't have permission- specifically via:

**Fatal errors / shutdown errors**: if PHP display_errors is on or if output already started. Fatal errors didn't reliably go through EE’s normal exception rendering, so PHP can print file paths/messages directly. This is what the shutdown handler/global buffer is trying to address.

**Caught exceptions via show_exception():** so they couldn't see much here, but they could still see the exception class, the exception message, and a filename/line basename. Nothing really actionable or security related here- but we still don't want to show them This sort of thing:

```
Error Caught
Failed opening required 'ee/ExpressionEngine/Addons/comment/mcp.comment.php' (include_path='.:/usr/share/php')

Addon.php:914
```

So this cleans up a lot of the permissions into 1 function.  And the most important and debatable thing it does is this ob_start(); in boot.  That adds some overhead and behavioral changes, but it's also the only completely reliable way I could come up with to address the fatal-output suppression.  But I don't love it.

I researched alternatives and... I don't have one I love.  So committing this.  But I'm going to commit an alternative as well.

https://github.com/ExpressionEngine/ExpressionEngine/pull/5244 Uses global buffering to catch server level errors we can't 100% get otherwise

https://github.com/ExpressionEngine/ExpressionEngine/pull/5245 ditches the buffering but can't catch all critical errors and just feels a little janky.

https://github.com/ExpressionEngine/ExpressionEngine/pull/5246 ditches buffering, does not try to catch all of those server errors.  Does fix other EE related leaked output, but we'd note in the docs that if you want NO server errors to show, that must be done via server setting.

