### PR TITLE
7x/error display hardening alt 1

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -117,6 +117,7 @@
         @ini_set('display_errors', 1);
     } else {
         error_reporting(0);
+        @ini_set('display_errors', 0);
     }
 
 /*

--- a/index.php
+++ b/index.php
@@ -146,6 +146,7 @@
         @ini_set('display_errors', 1);
     } else {
         error_reporting(0);
+        @ini_set('display_errors', 0);
     }
 
 /*

--- a/system/ee/ExpressionEngine/Boot/boot.common.php
+++ b/system/ee/ExpressionEngine/Boot/boot.common.php
@@ -544,6 +544,22 @@ function _exception_handler($severity, $message, $filepath, $line)
 }
 
 /**
+ * Shutdown handler for web requests.
+ *
+ * @return bool
+ */
+function webShutdownHandler()
+{
+    if (@is_array($error = @error_get_last())) {
+        $_error = load_class('Exceptions', 'core');
+
+        return $_error->handleWebShutdownError($error);
+    }
+
+    return true;
+}
+
+/**
  * Remove Invisible Characters
  *
  * This prevents sandwiching null characters

--- a/system/ee/ExpressionEngine/Boot/boot.php
+++ b/system/ee/ExpressionEngine/Boot/boot.php
@@ -87,6 +87,8 @@
         register_shutdown_function('cliShutdownHandler');
     } else {
         set_error_handler('_exception_handler');
+        ob_start();
+        register_shutdown_function('webShutdownHandler');
     }
 
 /*

--- a/system/ee/ExpressionEngine/Boot/boot.php
+++ b/system/ee/ExpressionEngine/Boot/boot.php
@@ -87,7 +87,6 @@
         register_shutdown_function('cliShutdownHandler');
     } else {
         set_error_handler('_exception_handler');
-        ob_start();
         register_shutdown_function('webShutdownHandler');
     }
 

--- a/system/ee/legacy/core/Exceptions.php
+++ b/system/ee/legacy/core/Exceptions.php
@@ -17,6 +17,8 @@ class EE_Exceptions
 
     protected $php_errors_output = false;
 
+    protected $generic_public_error_message = 'An unexpected error occurred. Please contact the site administrator if the problem persists.';
+
     /**
      * Constructor
      */
@@ -80,6 +82,10 @@ class EE_Exceptions
     {
         $this->php_errors_output = true;
 
+        if (! $this->shouldShowDetailedWebErrors()) {
+            return;
+        }
+
         list($error_constant, $error_category) = $this->lookupSeverity($severity);
 
         if (REQ == 'CLI') {
@@ -127,6 +133,62 @@ class EE_Exceptions
     public function hasOutputPhpErrors()
     {
         return $this->php_errors_output;
+    }
+
+    /**
+     * Determine whether this web request should receive detailed browser errors.
+     *
+     * @return bool
+     */
+    public function shouldShowDetailedWebErrors()
+    {
+        if (defined('REQ') && REQ === 'CLI') {
+            return true;
+        }
+
+        if (defined('DEBUG') && DEBUG == 1) {
+            return true;
+        }
+
+        $debug = $this->getConfiguredDebugLevel();
+
+        if ($debug > 1) {
+            return true;
+        }
+
+        if ($debug == 1) {
+            return $this->isCurrentUserSuperAdmin() || $this->currentSessionCanDebug();
+        }
+
+        return $this->isCurrentUserSuperAdmin();
+    }
+
+    /**
+     * Public-facing fallback error message for non-superadmins.
+     *
+     * @return string
+     */
+    public function getGenericPublicErrorMessage()
+    {
+        return $this->generic_public_error_message;
+    }
+
+    /**
+     * Render a generic public error response.
+     *
+     * @param int $status_code
+     * @return void
+     */
+    public function showPublicError($status_code = 500)
+    {
+        set_status_header($status_code);
+
+        if (defined('AJAX_REQUEST') && AJAX_REQUEST) {
+            $this->sendGenericAjaxError($status_code);
+        }
+
+        echo $this->renderGenericPublicError($status_code);
+        exit;
     }
 
     /**
@@ -228,6 +290,10 @@ class EE_Exceptions
     {
         set_status_header($status_code);
 
+        if (! $this->shouldShowDetailedWebErrors()) {
+            $this->showPublicError($status_code);
+        }
+
         $error_type = get_class($exception);
 
         $message = $exception->getMessage();
@@ -292,18 +358,7 @@ class EE_Exceptions
             $line = htmlentities($line, ENT_QUOTES, 'UTF-8');
         }
 
-        // We'll only want to show certain information, like file paths, if we're allowed
-        $debug = (bool) (DEBUG or (isset(ee()->config) && ee()->config->item('debug') > 1) or (isset(ee()->session) && ee('Permission')->isSuperAdmin()));
-
-        // Hide sensitive information such as file paths and database information
-        if (! $debug) {
-            $location_parts = explode('/', $location);
-            $location = array_pop($location_parts);
-
-            if (strpos($message, 'SQLSTATE') !== false) {
-                $message = 'There was a database connection error or a problem with a query. Log in as a super admin or enable debugging for more information.';
-            }
-        }
+        $debug = true;
 
         if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) &&
             $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest') {
@@ -346,6 +401,40 @@ class EE_Exceptions
     }
 
     /**
+     * Handle a fatal shutdown error for web requests.
+     *
+     * @param array $error
+     * @return bool
+     */
+    public function handleWebShutdownError($error)
+    {
+        if (! is_array($error) || ! $this->isFatalShutdownError($error['type'] ?? null)) {
+            return false;
+        }
+
+        // We are taking responsibility for rendering the fatal error now.
+        @ini_set('display_errors', 0);
+
+        if (! $this->shouldShowDetailedWebErrors()) {
+            while (ob_get_level() > 0) {
+                ob_end_clean();
+            }
+
+            $this->showPublicError(500);
+        }
+
+        $exception = new \ErrorException(
+            $error['message'] ?? 'Fatal error',
+            0,
+            $error['type'],
+            $error['file'] ?? __FILE__,
+            $error['line'] ?? __LINE__
+        );
+
+        $this->show_exception($exception, 500);
+    }
+
+    /**
      * @return Array of [PHP Severity constant, Human severity name]
      */
     private function lookupSeverity($severity)
@@ -385,6 +474,102 @@ class EE_Exceptions
             default:
                 return array('UNKNOWN', 'Error');
         }
+    }
+
+    /**
+     * @param int $status_code
+     * @return string
+     */
+    private function renderGenericPublicError($status_code)
+    {
+        $heading = 'Error';
+        $message = $this->getGenericPublicErrorMessage();
+
+        if (ob_get_level() > $this->ob_level + 1) {
+            ob_end_flush();
+        }
+
+        ob_start();
+
+        if (file_exists(APPPATH)) {
+            include(APPPATH . 'errors/error_general.php');
+        } else {
+            include(BASEPATH . 'errors/error_general.php');
+        }
+
+        $buffer = ob_get_contents();
+        ob_end_clean();
+
+        return $buffer;
+    }
+
+    /**
+     * @param int $status_code
+     * @return void
+     */
+    private function sendGenericAjaxError($status_code)
+    {
+        set_status_header($status_code);
+        echo json_encode([
+            'messageType' => 'error',
+            'message' => $this->getGenericPublicErrorMessage(),
+        ]);
+        exit;
+    }
+
+    /**
+     * @param int|null $type
+     * @return bool
+     */
+    private function isFatalShutdownError($type)
+    {
+        return in_array($type, [
+            E_ERROR,
+            E_PARSE,
+            E_CORE_ERROR,
+            E_COMPILE_ERROR,
+            E_USER_ERROR,
+        ], true);
+    }
+
+    /**
+     * @return int
+     */
+    private function getConfiguredDebugLevel()
+    {
+        if (! function_exists('ee') || ! ee() || ! isset(ee()->config)) {
+            return 0;
+        }
+
+        return (int) ee()->config->item('debug');
+    }
+
+    /**
+     * @return bool
+     */
+    private function isCurrentUserSuperAdmin()
+    {
+        if (! function_exists('ee') || ! ee() || ! isset(ee()->session) || ! isset(ee()->di)) {
+            return false;
+        }
+
+        try {
+            return ee('Permission')->isSuperAdmin();
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function currentSessionCanDebug()
+    {
+        if (! function_exists('ee') || ! ee() || ! isset(ee()->session)) {
+            return false;
+        }
+
+        return ee()->session->userdata('can_debug') == 'y';
     }
 }
 // END Exceptions Class

--- a/system/ee/legacy/core/Exceptions.php
+++ b/system/ee/legacy/core/Exceptions.php
@@ -174,6 +174,21 @@ class EE_Exceptions
     }
 
     /**
+     * Write an internal error that is hidden from the browser.
+     *
+     * @param string $message
+     * @return void
+     */
+    public function logHiddenError($message)
+    {
+        try {
+            log_message('error', $message);
+        } catch (\Throwable $e) {
+            @error_log($message);
+        }
+    }
+
+    /**
      * Render a generic public error response.
      *
      * @param int $status_code
@@ -291,6 +306,7 @@ class EE_Exceptions
         set_status_header($status_code);
 
         if (! $this->shouldShowDetailedWebErrors()) {
+            $this->logExceptionObject($exception);
             $this->showPublicError($status_code);
         }
 
@@ -416,6 +432,8 @@ class EE_Exceptions
         @ini_set('display_errors', 0);
 
         if (! $this->shouldShowDetailedWebErrors()) {
+            $this->logFatalShutdownError($error);
+
             while (ob_get_level() > 0) {
                 ob_end_clean();
             }
@@ -570,6 +588,46 @@ class EE_Exceptions
         }
 
         return ee()->session->userdata('can_debug') == 'y';
+    }
+
+    /**
+     * @param \Throwable|\Exception $exception
+     * @return void
+     */
+    private function logExceptionObject($exception)
+    {
+        $message = sprintf(
+            '%s: %s in %s on line %s',
+            get_class($exception),
+            $exception->getMessage(),
+            $exception->getFile(),
+            $exception->getLine()
+        );
+
+        $trace = $exception->getTraceAsString();
+
+        if ($trace !== '') {
+            $message .= "\nStack trace:\n" . $trace;
+        }
+
+        $this->logHiddenError($message);
+    }
+
+    /**
+     * @param array $error
+     * @return void
+     */
+    private function logFatalShutdownError(array $error)
+    {
+        list($error_constant) = $this->lookupSeverity($error['type'] ?? 0);
+
+        $this->logHiddenError(sprintf(
+            'Fatal shutdown error (%s): %s in %s on line %s',
+            $error_constant,
+            $error['message'] ?? 'Fatal error',
+            $error['file'] ?? 'unknown',
+            $error['line'] ?? 'unknown'
+        ));
     }
 }
 // END Exceptions Class

--- a/system/ee/legacy/database/DB_driver.php
+++ b/system/ee/legacy/database/DB_driver.php
@@ -876,24 +876,39 @@ class CI_DB_driver
 
         $error_handler = load_class('Exceptions', 'core');
 
-        if (! $error_handler->shouldShowDetailedWebErrors()) {
-            $error_handler->showPublicError(500);
-        }
-
         // Find the most likely culprit of the error by going through
         // the backtrace until the source file is no longer in the
         // database folder.
 
         $trace = debug_backtrace();
+        $source = null;
 
         foreach ($trace as $call) {
             if (isset($call['file']) && strpos($call['file'], APPPATH . 'database') === false) {
-                // Found it - use a relative path for safety
-                $message[] = '<b>File location</b>: ' . str_replace(array(BASEPATH, APPPATH), '', $call['file']);
-                $message[] = '<b>Line number</b>: ' . $call['line'];
+                $source = [
+                    'file' => $call['file'],
+                    'line' => $call['line'],
+                ];
 
                 break;
             }
+        }
+
+        if (! $error_handler->shouldShowDetailedWebErrors()) {
+            $log_message = $heading . ': ' . (is_array($message) ? implode(' ', $message) : $message);
+
+            if ($source !== null) {
+                $log_message .= ' in ' . $source['file'] . ' on line ' . $source['line'];
+            }
+
+            $error_handler->logHiddenError(strip_tags($log_message));
+            $error_handler->showPublicError(500);
+        }
+
+        if ($source !== null) {
+            // Found it - use a relative path for safety
+            $message[] = '<b>File location</b>: ' . str_replace(array(BASEPATH, APPPATH), '', $source['file']);
+            $message[] = '<b>Line number</b>: ' . $source['line'];
         }
 
         // Optional exception handling for DB errors

--- a/system/ee/legacy/database/DB_driver.php
+++ b/system/ee/legacy/database/DB_driver.php
@@ -874,6 +874,12 @@ class CI_DB_driver
             $message = (! is_array($error)) ? array(str_replace('%s', $swap, $LANG->line($error))) : $error;
         }
 
+        $error_handler = load_class('Exceptions', 'core');
+
+        if (! $error_handler->shouldShowDetailedWebErrors()) {
+            $error_handler->showPublicError(500);
+        }
+
         // Find the most likely culprit of the error by going through
         // the backtrace until the source file is no longer in the
         // database folder.
@@ -899,8 +905,7 @@ class CI_DB_driver
             throw new Exception(implode('<br>', $message));
         }
 
-        $error = load_class('Exceptions', 'core');
-        echo $error->show_error($heading, $message);
+        echo $error_handler->show_error($heading, $message);
         exit;
     }
 

--- a/system/ee/legacy/errors/error_exception.php
+++ b/system/ee/legacy/errors/error_exception.php
@@ -13,7 +13,9 @@
 			<div class="err-wrap error">
 				<h1><?=$error_type?> Caught</h1>
 				<h2><?php echo $message ?></h2>
-				<p><?php echo $location ?></p>
+				<?php if ($location !== ''): ?>
+					<p><?php echo $location ?></p>
+				<?php endif ?>
 
 				<?php if ($debug): ?>
 					<h3>Stack Trace: <i>Please include when reporting this error</i></h3>

--- a/system/index.php
+++ b/system/index.php
@@ -121,6 +121,7 @@
         @ini_set('display_errors', 1);
     } else {
         error_reporting(0);
+        @ini_set('display_errors', 0);
     }
 
 /*


### PR DESCRIPTION
So I don't love the global output buffering, so this is an alternative.  I also don't love it- some fatal errors could get through, but it's a solid compromise.

https://github.com/ExpressionEngine/ExpressionEngine/pull/5244 Uses global buffering to catch server level errors we can't 100% get otherwise

https://github.com/ExpressionEngine/ExpressionEngine/pull/5245 ditches the buffering but can't catch all critical errors and just feels a little janky.

https://github.com/ExpressionEngine/ExpressionEngine/pull/5246 ditches buffering, does not try to catch all of those server errors.  Does fix other EE related leaked output, but we'd note in the docs that if you want NO server errors to show, that must be done via server setting.

The goal is to prevent accidental error detail leakage to users who are not allowed to see debug output, while preserving EE’s existing intentional debug behavior:

- `DEBUG == 1` in `index.php`, `admin.php`, or `system/index.php` still shows full errors to anyone.
- Site config `debug > 1` still allows broad detailed error output.
- Site config `debug == 1` still limits detailed output to Super Admin / `can_debug` users.
- Non-debug users receive a generic public error response.
- Hidden exceptions, fatal shutdown errors, and DB errors are logged.

## What Changed

- Sets `display_errors = 0` early when `DEBUG != 1`, reducing PHP-native fatal error leakage before EE can render a controlled response.
- Keeps the web shutdown handler so fatal shutdown errors can be detected and handled.
- Removes the top-level global output buffer, avoiding buffering every web request.
- Logs hidden caught exceptions before showing the generic response.
- Logs hidden fatal shutdown errors before showing the generic response.
- Logs hidden DB errors before showing the generic response.
- Keeps `DEBUG == 1` as the explicit developer escape hatch for reproducing guest-only/front-end errors.

## Pros Compared To The Other Branch

- Lower runtime impact: does not buffer every web response.
- Less behavior risk for streaming, large responses, downloads, feeds, exports, or code that expects output flushing.
- Preserves existing EE debug semantics more closely.
- Keeps the important early guard by disabling PHP `display_errors` unless explicit `DEBUG == 1`.
- Adds logging for hidden errors, so sensitive details are withheld from the browser but still available for debugging.
- Smaller conceptual change: hardens display behavior without changing all normal response output handling.

## Cons Compared To The Other Branch

- Does not fully protect against already-sent output in every fatal-error scenario.
- Without a top-level buffer, if output was sent before a fatal error, EE cannot retract those bytes.
- Relies more heavily on `display_errors = 0` for non-debug requests and server/PHP behavior.
- The shutdown handler can render a generic response only when PHP/headers/output state still allows it.

## Pros Of The Other Branch

- Stronger fatal-output suppression because global buffering lets EE discard partial output and replace it with a generic error page.
- Better coverage for fatal errors that happen after some output has been generated.
- More deterministic browser response for fatal failures.

## Cons Of The Other Branch

- Buffers every web request, not just error requests.
- Higher memory use for large responses.
- Potential behavior changes for streaming/flushing/download-style responses.
- Broader runtime change than needed for normal catchable exception and DB error paths.
- Needs clear justification because it changes output handling globally.

## Tradeoff

This branch favors preserving current runtime behavior and debug workflows while closing the common accidental leak paths. The other branch favors stronger fatal-error containment at the cost of globally changing output buffering behavior.