### PR TITLE
Resolved 4901 cached webp files not updated

### DIFF
--- a/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
+++ b/system/ee/ExpressionEngine/Model/File/FileSystemEntity.php
@@ -400,8 +400,18 @@ class FileSystemEntity extends ContentModel
             // Manipulations that are generated on-the-fly have unique hashes after the prefix.
             // The md5 hash that is appended is always 32 characters long so we will filter
             // filename based on length to avoid removing other files that share a prefix
-            $dynamicFilePrefix = "{$filesystem->filename($this->file_name)}_{$manipulation}_";
-            $dynamicFilenameLength = strlen("{$dynamicFilePrefix}.{$filesystem->extension($this->file_name)}") + 32;
+            $baseFilename = $filesystem->filename($this->file_name);
+            $baseExtension = $filesystem->extension($this->file_name);
+            $dynamicExtension = $baseExtension;
+            $dynamicFilePrefix = "{$baseFilename}_{$manipulation}_";
+
+            // WebP/AVIF include the source extension in the generated basename.
+            if (in_array($manipulation, ['webp', 'avif'])) {
+                $dynamicFilePrefix = "{$baseFilename}_.{$baseExtension}_{$manipulation}_";
+                $dynamicExtension = $manipulation;
+            }
+
+            $dynamicFilenameLength = strlen("{$dynamicFilePrefix}.{$dynamicExtension}") + 32;
 
             foreach($filesystem->filesMatchingPrefix("{$directory}/{$dynamicFilePrefix}") as $file) {
                 if(strlen("{$file['filename']}.{$file['extension']}") == $dynamicFilenameLength) {


### PR DESCRIPTION
https://github.com/ExpressionEngine/ExpressionEngine/issues/4901

If you're using a file manipulation to create a webp file and then you go change the file to a new one, it does clear out those cached modified files, BUT it was missing webp because the format of the modified file names differs from what it was expecting.  So the webp file just stayed a manip of the old, now replaced file.
