### PR TITLE
Enable Redis TLS and ACL Auth connections in Redis cache driver

### DIFF
--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/Cache/RedisDriverTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/Cache/RedisDriverTest.php
@@ -210,6 +210,163 @@ class RedisDriverTest extends CacheTestBase
         $expectedKey = md5('127.0.0.1' . APPPATH) . ':global_key';
         $this->assertEquals($expectedKey, $this->redisStub->lastSetexKey);
     }
+
+    public function testSetupRedisDoesNotPassContextToLegacyConnect()
+    {
+        $redis = new RedisSetupLegacyConnectStub();
+        $driver = $this->makeRedisSetupDriver($redis);
+
+        ee()->config->setItem('redis', [
+            'host' => 'redis.example.com',
+            'port' => 6380,
+            'timeout' => 1.5,
+            'scheme' => 'tls',
+            'context' => [
+                'stream' => [
+                    'verify_peer' => false,
+                    'cafile' => '/etc/ssl/redis-ca.pem',
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($driver->setupRedisForTest());
+        $this->assertCount(3, $redis->connectArgs);
+        $this->assertSame('tls://redis.example.com', $redis->connectArgs[0]);
+        $this->assertSame(6380, $redis->connectArgs[1]);
+        $this->assertSame(1.5, $redis->connectArgs[2]);
+    }
+
+    public function testSetupRedisMergesTlsContextOptions()
+    {
+        $redis = new RedisSetupContextConnectStub();
+        $driver = $this->makeRedisSetupDriver($redis);
+
+        ee()->config->setItem('redis', [
+            'host' => 'redis.example.com',
+            'port' => 6380,
+            'timeout' => 1.5,
+            'scheme' => 'tls',
+            'context' => [
+                'stream' => [
+                    'verify_peer' => false,
+                    'peer_name' => 'cache.internal',
+                    'cafile' => '/etc/ssl/redis-ca.pem',
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($driver->setupRedisForTest());
+        $this->assertCount(7, $redis->connectArgs);
+        $this->assertSame('tls://redis.example.com', $redis->connectArgs[0]);
+
+        $context = $redis->connectArgs[6];
+        $this->assertSame(false, $context['stream']['verify_peer']);
+        $this->assertSame(true, $context['stream']['verify_peer_name']);
+        $this->assertSame('cache.internal', $context['stream']['peer_name']);
+        $this->assertSame('/etc/ssl/redis-ca.pem', $context['stream']['cafile']);
+    }
+
+    public function testSetupRedisAuthenticatesWithAclCredentials()
+    {
+        $redis = new RedisSetupLegacyConnectStub();
+        $driver = $this->makeRedisSetupDriver($redis);
+
+        ee()->config->setItem('redis', [
+            'username' => 'default',
+            'password' => 'secret',
+        ]);
+
+        $this->assertTrue($driver->setupRedisForTest());
+        $this->assertSame(['default', 'secret'], $redis->authArg);
+    }
+
+    private function makeRedisSetupDriver($redis)
+    {
+        return new class($redis) extends \EE_Cache_redis {
+            private $redis;
+
+            public function __construct($redis)
+            {
+                $this->redis = $redis;
+            }
+
+            public function setupRedisForTest()
+            {
+                return $this->_setup_redis();
+            }
+
+            protected function _new_redis()
+            {
+                return $this->redis;
+            }
+        };
+    }
+}
+
+class RedisSetupLegacyConnectStub
+{
+    public $connectArgs = [];
+    public $authArg;
+    public $selectedDatabase;
+
+    public function connect($host, $port = 6379, $timeout = 0, $reserved = null, $retry_interval = 0, $read_timeout = 0)
+    {
+        $this->connectArgs = func_get_args();
+
+        return true;
+    }
+
+    public function auth($auth)
+    {
+        $this->authArg = $auth;
+
+        return true;
+    }
+
+    public function select($database)
+    {
+        $this->selectedDatabase = $database;
+
+        return true;
+    }
+
+    public function close()
+    {
+        return true;
+    }
+}
+
+class RedisSetupContextConnectStub
+{
+    public $connectArgs = [];
+    public $authArg;
+    public $selectedDatabase;
+
+    public function connect($host, $port = 6379, $timeout = 0, $reserved = null, $retry_interval = 0, $read_timeout = 0, $context = [])
+    {
+        $this->connectArgs = func_get_args();
+
+        return true;
+    }
+
+    public function auth($auth)
+    {
+        $this->authArg = $auth;
+
+        return true;
+    }
+
+    public function select($database)
+    {
+        $this->selectedDatabase = $database;
+
+        return true;
+    }
+
+    public function close()
+    {
+        return true;
+    }
 }
 
 /**

--- a/system/ee/legacy/libraries/Cache/drivers/Cache_redis.php
+++ b/system/ee/legacy/libraries/Cache/drivers/Cache_redis.php
@@ -198,25 +198,34 @@ class EE_Cache_redis extends CI_Driver
             $config = array_merge($config, $user_config);
         }
 
-        $this->_redis = new Redis();
+        $this->_redis = $this->_new_redis();
 
         // Our return value which we will update as we setup Redis; if it's
         // TRUE at the end, allow Redis to be used
         $result = false;
 
         try {
+            $context = is_array($config['context']) ? $config['context'] : [];
+
             if (! empty($config['scheme']) && $config['scheme'] === 'tls') {
-                $config['context'] = [
+                $peer_name = (strpos($config['host'], 'tls://') === 0) ? substr($config['host'], 6) : $config['host'];
+
+                $context = array_replace_recursive([
                     'stream' => [
                         'verify_peer'      => $config['verify_peer'],
                         'verify_peer_name' => $config['verify_peer_name'],
-                        'peer_name'        => $config['host'],
+                        'peer_name'        => $peer_name,
                     ]
-                ];
-                $config['host'] = 'tls://' . $config['host'];
+                ], $context);
+
+                if (strpos($config['host'], 'tls://') !== 0) {
+                    $config['host'] = 'tls://' . $config['host'];
+                }
             }
 
-            $result = $this->_redis->connect($config['host'], $config['port'], $config['timeout'], null, 0, 0, $config['context']);
+            $result = (! empty($context) && $this->_redis_supports_connection_context())
+                ? $this->_redis->connect($config['host'], $config['port'], $config['timeout'], null, 0, 0, $context)
+                : $this->_redis->connect($config['host'], $config['port'], $config['timeout']);
         } catch (RedisException $e) {
             log_message('debug', 'Redis connection refused: ' . $e->getMessage());
             $this->_redis = false;
@@ -248,6 +257,32 @@ class EE_Cache_redis extends CI_Driver
         }
 
         return $result;
+    }
+
+    /**
+     * Create a Redis connection instance.
+     *
+     * @return Redis
+     */
+    protected function _new_redis()
+    {
+        return new Redis();
+    }
+
+    /**
+     * Check whether the installed Redis extension supports connect context.
+     *
+     * @return bool
+     */
+    protected function _redis_supports_connection_context()
+    {
+        try {
+            $method = new ReflectionMethod($this->_redis, 'connect');
+
+            return $method->isVariadic() || $method->getNumberOfParameters() >= 7;
+        } catch (ReflectionException $e) {
+            return false;
+        }
     }
 
     /**

--- a/system/ee/legacy/libraries/Cache/drivers/Cache_redis.php
+++ b/system/ee/legacy/libraries/Cache/drivers/Cache_redis.php
@@ -188,7 +188,7 @@ class EE_Cache_redis extends CI_Driver
             'port' => 6379,
             'timeout' => 0,
             'database' => 0,
-            'scheme' => 'tcp',
+            'scheme' => null,
             'verify_peer' => true,
             'verify_peer_name' => true,
             'context' => []
@@ -205,7 +205,7 @@ class EE_Cache_redis extends CI_Driver
         $result = false;
 
         try {
-            if ($config['scheme'] === 'tls') {
+            if (! empty($config['scheme']) && $config['scheme'] === 'tls') {
                 $config['context'] = [
                     'stream' => [
                         'verify_peer'      => $config['verify_peer'],

--- a/system/ee/legacy/libraries/Cache/drivers/Cache_redis.php
+++ b/system/ee/legacy/libraries/Cache/drivers/Cache_redis.php
@@ -184,9 +184,14 @@ class EE_Cache_redis extends CI_Driver
         $config = array(
             'host' => '127.0.0.1',
             'password' => null,
+            'username' => null,
             'port' => 6379,
             'timeout' => 0,
-            'database' => 0
+            'database' => 0,
+            'scheme' => 'tcp',
+            'verify_peer' => true,
+            'verify_peer_name' => true,
+            'context' => []
         );
 
         if (($user_config = ee()->config->item('redis')) !== false) {
@@ -200,7 +205,18 @@ class EE_Cache_redis extends CI_Driver
         $result = false;
 
         try {
-            $result = $this->_redis->connect($config['host'], $config['port'], $config['timeout']);
+            if ($config['scheme'] === 'tls') {
+                $config['context'] = [
+                    'stream' => [
+                        'verify_peer'      => $config['verify_peer'],
+                        'verify_peer_name' => $config['verify_peer_name'],
+                        'peer_name'        => $config['host'],
+                    ]
+                ];
+                $config['host'] = 'tls://' . $config['host'];
+            }
+
+            $result = $this->_redis->connect($config['host'], $config['port'], $config['timeout'], null, 0, 0, $config['context']);
         } catch (RedisException $e) {
             log_message('debug', 'Redis connection refused: ' . $e->getMessage());
             $this->_redis = false;
@@ -218,7 +234,10 @@ class EE_Cache_redis extends CI_Driver
 
         // If a password is set, attempt to authenticate
         if (! empty($config['password']) && $result) {
-            $result = $this->_redis->auth($config['password']);
+            $auth = ! empty($config['username'])
+                ? [$config['username'], $config['password']]
+                : $config['password'];
+            $result = $this->_redis->auth($auth);
         }
 
         // If a database is specified, attempt to use it


### PR DESCRIPTION
Added ability to ; #5280 Enable Redis TLS and ACL Auth connections in Redis cache driver
