### PR TITLE
pro_license_check_instructions lang double ..

### DIFF
--- a/system/ee/language/english/pro_lang.php
+++ b/system/ee/language/english/pro_lang.php
@@ -107,7 +107,7 @@ $lang = array(
     'pro_license_error_invalid' => 'The ExpressionEngine Pro license is not valid for this site.',
     'pro_license_error_expired' => 'The ExpressionEngine Pro license has expired.',
 
-    'pro_license_check_instructions' => 'Since this site has multiple members, it will also require a purchased license. %s.<br><br>Please verify your <a href="%s">Site License Key</a> and visit <a href="https://expressionengine.com/store/licenses" target="_blank">Licenses</a> section at ExpressionEngine.com',
+    'pro_license_check_instructions' => 'Since this site has multiple members, it will also require a purchased license. %s<br><br>Please verify your <a href="%s">Site License Key</a> and visit <a href="https://expressionengine.com/store/licenses" target="_blank">Licenses</a> section at ExpressionEngine.com',
 
     'pro_license_check_trial_instructions' => '%s<br><br>Please verify your <a href="%s">Site License Key</a> and visit <a href="https://expressionengine.com/store/licenses" target="_blank">Licenses</a> section at ExpressionEngine.com',
 


### PR DESCRIPTION
End up with a double period without fix

<!--

What's in this pull request?

The title of the pull request should look like the change log line, with reference to the corresponding issue number if available. For example:
  - Resolved #1234 where <something> was causing template parsing error 
(or)
  - Added ability to <do something new>; #1234

In the pull request body, give a good description of what the nature of the change is, and the reasoning behind it. Provide links to external references/discussions if appropriate.

If this pull request resolves a project issue, provide a link with a closing keyword. For example:
  Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/1235

Assign this PR the appropriate label depending on what it does, e.g. 'Bug:Accepted', or 'enhancement'

If documentation update is needed, provide a link to the corresponding pull request in the ExpressionEngine-User-Guide repo. For example:
  User Guide Pull Request: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1235

-->
