### PR TITLE
added license_notice_seen cookie registration

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro/addon.setup.php
+++ b/system/ee/ExpressionEngine/Addons/pro/addon.setup.php
@@ -15,10 +15,14 @@ return array(
     ],
     'cookies.functionality' => [
         'frontedit',
+        'license_notice_seen',
     ],
     'cookie_settings' => [
         'frontedit' => [
             'description' => 'lang:cookie_frontedit_desc'
+        ],
+        'license_notice_seen' => [
+            'description' => 'lang:cookie_license_notice_seen_desc'
         ],
     ],
     'models'       => [

--- a/system/ee/language/english/pro_lang.php
+++ b/system/ee/language/english/pro_lang.php
@@ -47,6 +47,7 @@ $lang = array(
     // Pro Cookies
     'cookie_frontedit' => 'Front-end editing',
     'cookie_frontedit_desc' => 'Determines whether ExpressionEngine front-end editing features should be enabled.',
+    'cookie_license_notice_seen_desc' => 'Tracks whether the Pro license notice has been acknowledged in the Control Panel.',
 
     'export_consent_log' => 'Export Consent Audit Logs',
     'exported_consent_log' => 'Exported Consent Audit Logs',


### PR DESCRIPTION
It was showing up in logs as unregistered.  cp cookie indicates that the license notice was seen.
