### PR TITLE
If legacy member templates are disabled, ignore member profile_trigger

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_auth.php
@@ -826,8 +826,11 @@ class Member_auth extends Member
             if (substr($reset_url, 0, 4) !== 'http') {
                 $reset_url = reduce_double_slashes(ee()->functions->fetch_site_index(0, 0) . '/' . $reset_url);
             }
+        } elseif (ee('Config')->getFile()->getBoolean('legacy_member_templates')) {
+            $profile_trigger = ee()->config->item('profile_trigger');
+            $reset_url = reduce_double_slashes(ee()->functions->fetch_site_index(0, 0) . '/' . $profile_trigger . '/reset_password');
         } else {
-            $reset_url = reduce_double_slashes(ee()->functions->fetch_site_index(0, 0) . '/' . ee()->config->item('profile_trigger') . '/reset_password');
+            return ee()->output->show_user_error('general', array(lang('mbr_missing_password_reset_url')));
         }
 
         // Add the reset code and possible forum_id to the reset pass url.

--- a/system/ee/ExpressionEngine/Service/Template/Variables/StandardGlobals.php
+++ b/system/ee/ExpressionEngine/Service/Template/Variables/StandardGlobals.php
@@ -110,8 +110,11 @@ class StandardGlobals extends Variables
     {
         if (isset(ee()->session) && ee()->session->userdata('member_id') != 0) {
             $name = (ee()->session->userdata['screen_name'] == '') ? ee()->session->userdata['username'] : ee()->session->userdata['screen_name'];
+            $profile_trigger = ee('Config')->getFile()->getBoolean('legacy_member_templates')
+                ? ee()->config->item('profile_trigger')
+                : '';
 
-            $path = "<a href='" . ee()->functions->create_url(ee()->config->item('profile_trigger') . '/' . ee()->session->userdata('member_id')) . "'>" . $name . "</a>";
+            $path = "<a href='" . ee()->functions->create_url($profile_trigger . '/' . ee()->session->userdata('member_id')) . "'>" . $name . "</a>";
 
             return $path;
         }

--- a/system/ee/language/english/member_lang.php
+++ b/system/ee/language/english/member_lang.php
@@ -621,6 +621,8 @@ We reserve the right to remove, edit, or move any messages for any reason.',
 
     'mbr_missing_password' => 'Please enter a new password.',
 
+    'mbr_missing_password_reset_url' => 'Unable to send a password reset link because no reset URL is configured. Specify the `password_reset_url` parameter or enable legacy member templates.',
+
     'mbr_password_changed' => 'Password Successfully Changed',
 
     'mbr_reset_password' => 'Please enter a new password',

--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -728,7 +728,9 @@ class EE_Core
         // This permits the forum to be more light-weight as the template engine is
         // not needed under normal circumstances.
         $forum_trigger = (ee()->config->item('forum_is_installed') == "y") ? ee()->config->item('forum_trigger') : '';
-        $profile_trigger = ee()->config->item('profile_trigger');
+        $profile_trigger = ee('Config')->getFile()->getBoolean('legacy_member_templates')
+            ? ee()->config->item('profile_trigger')
+            : '';
 
         if (
             $forum_trigger &&

--- a/system/ee/legacy/libraries/api/Api_template_structure.php
+++ b/system/ee/legacy/libraries/api/Api_template_structure.php
@@ -216,8 +216,12 @@ class Api_template_structure extends Api
             $this->reserved_names[] = ee()->config->item("forum_trigger");
         }
 
-        if (ee()->config->item("profile_trigger") != '') {
-            $this->reserved_names[] = ee()->config->item("profile_trigger");
+        $profile_trigger = ee('Config')->getFile()->getBoolean('legacy_member_templates')
+            ? ee()->config->item("profile_trigger")
+            : '';
+
+        if ($profile_trigger != '') {
+            $this->reserved_names[] = $profile_trigger;
         }
     }
 


### PR DESCRIPTION
Basically- legacy_member_templates set to 'n' the member profile trigger setting in the cp disappears.  HOWEVER the trigger was still active and hitting it sends you to the member profile template with a message they are disabled.  It doesn't help that some member tags use them as defaults.

Case in point- validation error logging got the

'This page is not accessible because legacy member templates are not enabled.'

Another case- forgotten password- if you don't set the return it goes to the member template reset - and throws the 'legacy not enabled' error.

Needs testing- plus scan says:

There are still several member-tag paths that default to legacy template elements.

{exp:member:login} path:
{exp:member:forgot_password} path:
{exp:member:reset_password} path:

Registration/member profile related tag methods with “empty tagdata => legacy fallback when enabled”:

The safest modern tags are the explicit *_form variants (login_form, forgot_password_form, reset_password_form, registration_form with tagdata).

SO need to go through the docs and ponder whether this is actually a concern.