### PR TITLE
Minimal hardening fix for php error handling

### DIFF
--- a/system/ee/legacy/core/Exceptions.php
+++ b/system/ee/legacy/core/Exceptions.php
@@ -295,6 +295,17 @@ class EE_Exceptions
         // We'll only want to show certain information, like file paths, if we're allowed
         $debug = (bool) (DEBUG or (isset(ee()->config) && ee()->config->item('debug') > 1) or (isset(ee()->session) && ee('Permission')->isSuperAdmin()));
 
+        // If the request came from the cli, show an appropriate message
+        if (defined('REQ') && REQ === 'CLI') {
+            echo "$error_type caught:\n";
+            echo html_entity_decode($message) . "\n";
+            echo html_entity_decode($location) . "\n";
+            foreach ($trace as $stackItem) {
+                echo html_entity_decode($stackItem) . "\n";
+            }
+            exit;
+        }
+
         // Hide sensitive information such as file paths and database information
         if (! $debug) {
             $location_parts = explode('/', $location);
@@ -325,17 +336,6 @@ class EE_Exceptions
                 'trace' => $trace
             ];
             echo json_encode($return);
-            exit;
-        }
-
-        // If the request came from the cli, show an appropriate message
-        if (defined('REQ') && REQ === 'CLI') {
-            echo "$error_type caught:\n";
-            echo html_entity_decode($message) . "\n";
-            echo html_entity_decode($location) . "\n";
-            foreach ($trace as $stackItem) {
-                echo html_entity_decode($stackItem) . "\n";
-            }
             exit;
         }
 

--- a/system/ee/legacy/core/Exceptions.php
+++ b/system/ee/legacy/core/Exceptions.php
@@ -303,6 +303,10 @@ class EE_Exceptions
             if (strpos($message, 'SQLSTATE') !== false) {
                 $message = 'There was a database connection error or a problem with a query. Log in as a super admin or enable debugging for more information.';
             }
+
+            if (! isset(ee()->session) || ee()->session->userdata('member_id') == 0) {
+                exit;
+            }
         }
 
         if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) &&

--- a/system/ee/legacy/core/Exceptions.php
+++ b/system/ee/legacy/core/Exceptions.php
@@ -304,7 +304,15 @@ class EE_Exceptions
                 $message = 'There was a database connection error or a problem with a query. Log in as a super admin or enable debugging for more information.';
             }
 
-            if (! isset(ee()->session) || ee()->session->userdata('member_id') == 0) {
+            if ((! defined('INSTALLER') || ! INSTALLER) && (! isset(ee()->session) || ee()->session->userdata('member_id') == 0)) {
+                log_message('error', "{$error_type}: {$exception->getMessage()} in {$exception->getFile()}:{$exception->getLine()}");
+
+                if (isset($_SERVER['HTTP_X_REQUESTED_WITH']) && $_SERVER['HTTP_X_REQUESTED_WITH'] == 'XMLHttpRequest') {
+                    echo json_encode(['messageType' => 'error', 'message' => 'An unexpected error occurred.']);
+                } else {
+                    echo 'An unexpected error occurred. Please contact the site administrator if the problem persists.';
+                }
+
                 exit;
             }
         }


### PR DESCRIPTION
Alternative to https://github.com/ExpressionEngine/ExpressionEngine/pull/5246

Non-debug + no session / member_id == 0: exits before rendering error_exception.php, so guests no longer see Exception Caught.
Debug override / config debug > 1: unchanged, still shows details.
Logged-in users: existing behavior preserved.

