### PR TITLE
Mysql 8 regex changes and word boundary weirdness branch

### DIFF
--- a/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_fields.php
+++ b/system/ee/ExpressionEngine/Addons/pro_search/libraries/Pro_search_fields.php
@@ -434,9 +434,7 @@ class Pro_search_fields
             // whole word? Regexp search
             if (substr($item, -2) == '\W') {
                 $operand = $exclude ? 'NOT REGEXP' : 'REGEXP';
-                $item = preg_quote(substr($item, 0, -2));
-                $item = str_replace("'", "\'", $item);
-                $item = "'[[:<:]]{$item}[[:>:]]'";
+                $item = "'" . ee()->db->escape_str(ee()->db->word_boundary_regex(substr($item, 0, -2))) . "'";
             } else {
                 if (preg_match('/^([<>]=?)([\d\.]+)$/', $item, $match)) {
                     // Numeric operator!

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Pro_search/Library/ProSearchFieldsTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Pro_search/Library/ProSearchFieldsTest.php
@@ -460,6 +460,37 @@ class ProSearchFieldsTest extends ProSearchTestBase
         $sql = $this->fields->sql('field_id_5', 'val1|val2');
         $this->assertStringContainsString('LIKE', $sql);
     }
+
+    public function testSqlFullWordSearchUsesDatabaseWordBoundaryHelper()
+    {
+        $db = new class extends ProSearchFakeDb {
+            public $wordBoundaryTerms = [];
+
+            public function word_boundary_regex($term)
+            {
+                $this->wordBoundaryTerms[] = $term;
+
+                return '(\\b|^)' . preg_quote((string) $term) . '(\\b|$)';
+            }
+        };
+        ee()->setMock('db', $db);
+
+        $sql = $this->fields->sql('field_id_5', 'term\W');
+
+        $this->assertSame(['term'], $db->wordBoundaryTerms);
+        $this->assertSame("(field_id_5 REGEXP '(\\\\b|^)term(\\\\b|$)')", $sql);
+    }
+
+    public function testSqlFullWordSearchUsesLegacyBoundaryForMariaDb()
+    {
+        $db = new ProSearchFakeDb();
+        $db->versionString = '10.6.18-MariaDB';
+        ee()->setMock('db', $db);
+
+        $sql = $this->fields->sql('field_id_5', 'term\W');
+
+        $this->assertSame("(field_id_5 REGEXP '([[:<:]]|^)term([[:>:]]|$)')", $sql);
+    }
     
     public function testInvalidMethodCall()
     {
@@ -473,4 +504,3 @@ class ProSearchFieldsTest extends ProSearchTestBase
         $this->fields->is_native();
     }
 }
-

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Pro_search/ProSearchTestBase.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Pro_search/ProSearchTestBase.php
@@ -144,6 +144,7 @@ if (!class_exists('Pagination_test')) {
 class ProSearchFakeDb extends FakeDb
 {
     public $dbprefix = 'exp_';
+    public $versionString = false;
 
     public function get($table = null)
     {
@@ -160,6 +161,30 @@ class ProSearchFakeDb extends FakeDb
     public function escape_like_str($str)
     {
         return addcslashes($str, '%_');
+    }
+
+    public function escape_str($str, $like = false)
+    {
+        return addslashes($str);
+    }
+
+    public function version()
+    {
+        return $this->versionString;
+    }
+
+    public function word_boundary_regex($term)
+    {
+        $term = preg_quote((string) $term);
+
+        if (is_string($this->versionString)
+            && stripos($this->versionString, 'mariadb') === false
+            && preg_match('/\d+(?:\.\d+){1,2}/', $this->versionString, $match)
+            && version_compare($match[0], '8.0.4', '>=')) {
+            return '(\\b|^)' . $term . '(\\b|$)';
+        }
+
+        return '([[:<:]]|^)' . $term . '([[:>:]]|$)';
     }
 }
 

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Models/ChannelModelFieldSearchTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Models/ChannelModelFieldSearchTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../eeObjectMock.php';
+require_once SYSPATH . 'ee/legacy/database/DB_driver.php';
+
+if (! class_exists('CI_Model')) {
+    require_once BASEPATH . 'core/Model.php';
+}
+
+require_once BASEPATH . 'models/channel_model.php';
+
+class ChannelModelFieldSearchTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        ee()->resetMocks();
+    }
+
+    public function testFullWordFieldSearchUsesIcuBoundaryForMysqlEight(): void
+    {
+        ee()->setMock('db', new ChannelModelFieldSearchDbStub('8.0.44'));
+
+        $sql = (new Channel_model())->field_search_sql('\Wterm', 'field_id_1');
+
+        $this->assertStringContainsString('REGEXP "(\\\\b|^)term(\\\\b|$)"', $sql);
+        $this->assertStringNotContainsString('[[:<:]]', $sql);
+        $this->assertStringNotContainsString('[[:>:]]', $sql);
+    }
+
+    public function testFullWordFieldSearchUsesLegacyBoundaryForMariaDb(): void
+    {
+        ee()->setMock('db', new ChannelModelFieldSearchDbStub('5.5.5-10.6.18-MariaDB'));
+
+        $sql = (new Channel_model())->field_search_sql('\Wterm', 'field_id_1');
+
+        $this->assertStringContainsString('REGEXP "([[:<:]]|^)term([[:>:]]|$)"', $sql);
+    }
+
+    public function testNegatedFullWordFieldSearchKeepsNullFallback(): void
+    {
+        ee()->setMock('db', new ChannelModelFieldSearchDbStub('8.0.44'));
+
+        $sql = (new Channel_model())->field_search_sql('not \Wterm', 'field_id_1');
+
+        $this->assertStringContainsString('NOT REGEXP "(\\\\b|^)term(\\\\b|$)"', $sql);
+        $this->assertStringContainsString('OR (field_id_1 IS NULL)', $sql);
+    }
+}
+
+class ChannelModelFieldSearchDbStub extends CI_DB_driver
+{
+    private $versionString;
+
+    public function __construct($versionString)
+    {
+        $this->versionString = $versionString;
+
+        parent::__construct([]);
+    }
+
+    public function version()
+    {
+        return $this->versionString;
+    }
+
+    public function escape_str($str, $like = false)
+    {
+        return addslashes($str);
+    }
+}

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/database/DBDriverTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/database/DBDriverTest.php
@@ -106,6 +106,50 @@ class DBDriverTest extends TestCase
         $this->assertSame('8.0.0', $driver->version());
     }
 
+    /**
+     * @dataProvider wordBoundaryRegexProvider
+     */
+    public function testWordBoundaryRegexUsesDatabaseCompatibleBoundaries($version, $expected): void
+    {
+        $driver = new DBDriverMethodHarness([]);
+        $driver->queryResponse = new DBDriverQueryResultStub(1, [], (object) ['ver' => $version], []);
+
+        $this->assertSame($expected, $driver->word_boundary_regex('term'));
+    }
+
+    public function wordBoundaryRegexProvider()
+    {
+        return [
+            'mysql 8.0.4' => ['8.0.4', '(\\b|^)term(\\b|$)'],
+            'mysql 8.0.44' => ['8.0.44', '(\\b|^)term(\\b|$)'],
+            'mysql 8.0.44 suffix' => ['8.0.44-commercial', '(\\b|^)term(\\b|$)'],
+            'mysql 8.0.3' => ['8.0.3', '([[:<:]]|^)term([[:>:]]|$)'],
+            'mysql 5.7' => ['5.7.44', '([[:<:]]|^)term([[:>:]]|$)'],
+            'mariadb' => ['10.6.18-MariaDB', '([[:<:]]|^)term([[:>:]]|$)'],
+            'prefixed mariadb' => ['5.5.5-10.6.18-MariaDB', '([[:<:]]|^)term([[:>:]]|$)'],
+            'unknown' => ['', '([[:<:]]|^)term([[:>:]]|$)'],
+        ];
+    }
+
+    public function testWordBoundaryRegexEscapesTermAndFallsBackWhenVersionUnsupported(): void
+    {
+        $driver = new DBDriverMethodHarness([]);
+        $driver->versionSql = false;
+        $driver->db_debug = false;
+
+        $this->assertSame('([[:<:]]|^)term\\.one([[:>:]]|$)', $driver->word_boundary_regex('term.one'));
+    }
+
+    public function testWordBoundaryRegexCachesVersionDetection(): void
+    {
+        $driver = new DBDriverMethodHarness([]);
+        $driver->queryResponse = new DBDriverQueryResultStub(1, [], (object) ['ver' => '8.0.44'], []);
+
+        $this->assertSame('(\\b|^)one(\\b|$)', $driver->word_boundary_regex('one'));
+        $this->assertSame('(\\b|^)two(\\b|$)', $driver->word_boundary_regex('two'));
+        $this->assertCount(1, $driver->querySqls);
+    }
+
     public function testQueryHandlesEmptySqlFailureWriteAndReadPaths(): void
     {
         $driver = new DBDriverQueryHarness([]);

--- a/system/ee/ExpressionEngine/Tests/eeObjectMock.php
+++ b/system/ee/ExpressionEngine/Tests/eeObjectMock.php
@@ -445,6 +445,11 @@ class eeDbArMock
         return $this->last_query ?? '';
     }
 
+    public function word_boundary_regex($term)
+    {
+        return '([[:<:]]|^)' . preg_quote((string) $term) . '([[:>:]]|$)';
+    }
+
     public function count_all_results($table = '')
     {
         // Simple implementation - return count of filtered rows
@@ -866,6 +871,11 @@ class FakeDb
     public function escape_str($str)
     {
         return addslashes($str);
+    }
+
+    public function word_boundary_regex($term)
+    {
+        return '([[:<:]]|^)' . preg_quote((string) $term) . '([[:>:]]|$)';
     }
 
     public function get($table = null)

--- a/system/ee/legacy/database/DB_driver.php
+++ b/system/ee/legacy/database/DB_driver.php
@@ -74,6 +74,7 @@ class CI_DB_driver
     public $limit_used;
 
     protected $_escape_char = '"';
+    protected $_regexp_uses_icu_word_boundaries = null;
 
     /**
      * Constructor.  Accepts one parameter containing the database
@@ -150,6 +151,56 @@ class CI_DB_driver
         }
 
         return $this->query($sql)->row('ver');
+    }
+
+    /**
+     * Build a whole-word REGEXP pattern for the active database.
+     *
+     * MySQL 8.0.4+ uses ICU regular expressions, which do not support the
+     * Spencer word-boundary markers used by older MySQL and MariaDB.
+     *
+     * @param string $term
+     * @return string
+     */
+    public function word_boundary_regex($term)
+    {
+        $term = preg_quote((string) $term);
+
+        if ($this->_uses_icu_regexp_word_boundaries()) {
+            return '(\\b|^)' . $term . '(\\b|$)';
+        }
+
+        return '([[:<:]]|^)' . $term . '([[:>:]]|$)';
+    }
+
+    /**
+     * Determine whether the active database uses ICU REGEXP word boundaries.
+     *
+     * @return bool
+     */
+    protected function _uses_icu_regexp_word_boundaries()
+    {
+        if ($this->_regexp_uses_icu_word_boundaries !== null) {
+            return $this->_regexp_uses_icu_word_boundaries;
+        }
+
+        $this->_regexp_uses_icu_word_boundaries = false;
+
+        try {
+            $version = $this->version();
+        } catch (Throwable $e) {
+            return $this->_regexp_uses_icu_word_boundaries;
+        }
+
+        if (! is_string($version) || $version === '' || stripos($version, 'mariadb') !== false) {
+            return $this->_regexp_uses_icu_word_boundaries;
+        }
+
+        if (preg_match('/\d+(?:\.\d+){1,2}/', $version, $match)) {
+            $this->_regexp_uses_icu_word_boundaries = version_compare($match[0], '8.0.4', '>=');
+        }
+
+        return $this->_regexp_uses_icu_word_boundaries;
     }
 
     /**

--- a/system/ee/legacy/models/channel_model.php
+++ b/system/ee/legacy/models/channel_model.php
@@ -557,8 +557,7 @@ class Channel_model extends CI_Model
                 $search_sql .= $not ? ' AND ' : ' OR ';
                 $search_sql .= $col_name . str_replace('  ', ' ', ' IS ' . ($not ?: '') . ' NULL) ');
             } elseif (strpos($term, '\W') !== false) { // full word only, no partial matches
-                // Note: MySQL's nutty POSIX regex word boundary is [[:>:]]
-                $term = '([[:<:]]|^)' . preg_quote(str_replace('\W', '', $term)) . '([[:>:]]|$)';
+                $term = ee()->db->word_boundary_regex(str_replace('\W', '', $term));
 
                 $search_sql .= ' (' . $col_name . ' ' . $not . ' REGEXP "' . ee()->db->escape_str($term) . '") ';
             } else {


### PR DESCRIPTION
https://dev.mysql.com/doc/refman/8.0/en/regexp.html

doc change: https://github.com/ExpressionEngine/ExpressionEngine-User-Guide/pull/1149

Basically? The word boundary changed.  Goobering channel entry search param and some pro search code.  This adds a helper to juggle that based on mysql version and type- aka maria.

User ran into an issue on mysql 8 specifically with /system/ee/legacy/models/channel_model.php and 'Note: MySQL's nutty POSIX regex word boundary is [[:>:]]' which is no longer necessarily true.  Also spotted the issue in pro search.

So this:

- Adds a database helper for building whole-word `REGEXP` patterns compatible with MySQL 8.0.4+ ICU regex behavior.
- Updates channel field search and Pro Search full-word matching to use the helper instead of hardcoded Spencer word-boundary markers.
- Preserves legacy `[[:<:]]` / `[[:>:]]` behavior for MariaDB, older MySQL versions, and unknown database versions.

And added some tests for the above.  Need to go make some docs additions to go along with this....



