### PR TITLE
Fix date filter null key lookup

### DIFF
--- a/system/ee/ExpressionEngine/Service/Filter/Date.php
+++ b/system/ee/ExpressionEngine/Service/Filter/Date.php
@@ -119,9 +119,10 @@ class Date extends Filter
 
         $value = $this->display_value;
         if (is_null($value)) {
-            $value = (array_key_exists($this->value(), $this->options)) ?
-                $this->options[$this->value()] :
-                $this->value();
+            $current_value = $this->value();
+            $value = ($current_value !== null && array_key_exists($current_value, $this->options)) ?
+                $this->options[$current_value] :
+                $current_value;
         }
 
         // Create a filter URL without this filter (per-filter clear).


### PR DESCRIPTION
## Summary

Fixes the remaining PHP deprecation reported in #5297 when loading the member manager without a selected join date filter.

`Date::render()` could pass `null` directly to `array_key_exists()` while resolving the display value. This now caches the current filter value and only checks the options array when the value is non-null.

## Notes

The related `Filter.php` warning from the issue was already fixed in the latest release. This handles the remaining `Date.php` warning on `7.dev`.

Fixes #5297

