### PR TITLE
Add status filtering to stats tag

### DIFF
--- a/system/ee/ExpressionEngine/Addons/stats/mod.stats.php
+++ b/system/ee/ExpressionEngine/Addons/stats/mod.stats.php
@@ -22,22 +22,47 @@ class Stats
     {
         ee()->stats->load_stats();
 
-        // Limit stats by channel
+        // Limit stats by channel or status
         // You can limit the stats by any combination of channels
 
         if (! isset(ee()->TMPL)) {
             return;
         }
 
-        if ($channel_name = ee()->TMPL->fetch_param('channel')) {
-            $sql = "SELECT	total_entries,
-							total_comments,
-							last_entry_date,
-							last_comment_date
-					FROM exp_channels
-					WHERE site_id IN ('" . implode("','", ee()->TMPL->site_ids) . "') ";
+        $channel_name = ee()->TMPL->fetch_param('channel');
+        $status = ee()->TMPL->fetch_param('status');
+        $filter_by_status = ($status !== false && $status != '');
 
-            $sql .= ee()->functions->sql_andor_string($channel_name, 'exp_channels.channel_name');
+        if ($channel_name || $filter_by_status) {
+            if ($filter_by_status) {
+                $now = ee()->localize->now;
+
+                $sql = "SELECT	COUNT(exp_channel_titles.entry_id) AS total_entries,
+								COALESCE(SUM(exp_channel_titles.comment_total), 0) AS total_comments,
+								MAX(exp_channel_titles.entry_date) AS last_entry_date,
+								MAX(exp_channel_titles.recent_comment_date) AS last_comment_date
+						FROM exp_channel_titles
+						INNER JOIN exp_channels
+							ON exp_channel_titles.channel_id = exp_channels.channel_id
+						WHERE exp_channel_titles.site_id IN ('" . implode("','", ee()->TMPL->site_ids) . "') ";
+
+                if ($channel_name) {
+                    $sql .= ee()->functions->sql_andor_string($channel_name, 'exp_channels.channel_name');
+                }
+
+                $sql .= $this->statusSql($status);
+                $sql .= " AND exp_channel_titles.entry_date < " . $now . " ";
+                $sql .= " AND (exp_channel_titles.expiration_date = 0 OR exp_channel_titles.expiration_date > " . $now . ") ";
+            } else {
+                $sql = "SELECT	total_entries,
+								total_comments,
+								last_entry_date,
+								last_comment_date
+						FROM exp_channels
+						WHERE site_id IN ('" . implode("','", ee()->TMPL->site_ids) . "') ";
+
+                $sql .= ee()->functions->sql_andor_string($channel_name, 'exp_channels.channel_name');
+            }
 
             $cache_sql = md5($sql);
 
@@ -196,6 +221,24 @@ class Stats
         }
 
         $this->return_data = ee()->TMPL->tagdata;
+    }
+
+    /**
+     * Build the SQL clause for status-filtered stats.
+     *
+     * @param string $status Entry status parameter.
+     * @return string
+     */
+    private function statusSql($status)
+    {
+        $status = str_replace(array('Open', 'Closed'), array('open', 'closed'), $status);
+        $sstr = ee()->functions->sql_andor_string($status, 'exp_channel_titles.status');
+
+        if (stristr($sstr, "'closed'") === false) {
+            $sstr .= " AND exp_channel_titles.status != 'closed' ";
+        }
+
+        return $sstr;
     }
 
     /**

--- a/system/ee/ExpressionEngine/Addons/stats/mod.stats.php
+++ b/system/ee/ExpressionEngine/Addons/stats/mod.stats.php
@@ -21,6 +21,7 @@ class Stats
     public function __construct()
     {
         ee()->stats->load_stats();
+        $statdata = ee()->stats->statdata();
 
         // Limit stats by channel or status
         // You can limit the stats by any combination of channels
@@ -89,16 +90,11 @@ class Stats
                         }
                     }
 
-                    foreach ($sdata as $key => $val) {
-                        ee()->stats->set_statdata($key, $val);
-
-                        ee()->stats->stats_cache[$cache_sql][$key] = $val;
-                    }
+                    ee()->stats->stats_cache[$cache_sql] = $sdata;
+                    $statdata = array_merge($statdata, $sdata);
                 }
             } else {
-                foreach (ee()->stats->stats_cache[$cache_sql] as $key => $val) {
-                    ee()->stats->set_statdata($key, $val);
-                }
+                $statdata = array_merge($statdata, ee()->stats->stats_cache[$cache_sql]);
             }
         }
 
@@ -110,8 +106,9 @@ class Stats
 
         foreach ($fields as $field) {
             if (isset(ee()->TMPL->var_single[$field])) {
-                $cond[$field] = ee()->stats->statdata($field);
-                ee()->TMPL->tagdata = ee()->TMPL->swap_var_single($field, ee()->stats->statdata($field), ee()->TMPL->tagdata);
+                $value = isset($statdata[$field]) ? $statdata[$field] : false;
+                $cond[$field] = $value;
+                ee()->TMPL->tagdata = ee()->TMPL->swap_var_single($field, $value, ee()->TMPL->tagdata);
             }
         }
 
@@ -126,13 +123,14 @@ class Stats
         foreach (ee()->TMPL->var_single as $key => $val) {
             foreach ($dates as $date) {
                 if (strncmp($key, $date, strlen($date)) == 0) {
+                    $date_value = isset($statdata[$date]) ? $statdata[$date] : false;
                     ee()->TMPL->tagdata = ee()->TMPL->swap_var_single(
                         $key,
-                        (! ee()->stats->statdata($date)
-                                                    or ee()->stats->statdata($date) == 0) ? '--' :
+                        (! $date_value
+                                                    or $date_value == 0) ? '--' :
                                                 ee()->localize->format_date(
                                                     $val,
-                                                    ee()->stats->statdata($date)
+                                                    $date_value
                                                 ),
                         ee()->TMPL->tagdata
                     );
@@ -144,7 +142,7 @@ class Stats
 
         $names = '';
 
-        if (ee()->stats->statdata('current_names')) {
+        if (! empty($statdata['current_names'])) {
             $chunk = ee()->TMPL->fetch_data_between_var_pairs(
                 ee()->TMPL->tagdata,
                 'member_names'
@@ -177,7 +175,7 @@ class Stats
             $member_path = str_replace("'", "", $member_path);
             $member_path = trim_slashes($member_path);
 
-            foreach (ee()->stats->statdata('current_names') as $k => $v) {
+            foreach ($statdata['current_names'] as $k => $v) {
                 $temp = $chunk;
 
                 if (empty($temp)) {

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Stats/Mod/StatsStatusFilterTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Stats/Mod/StatsStatusFilterTest.php
@@ -1,0 +1,204 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once PATH_ADDONS . 'stats/mod.stats.php';
+
+class StatsStatusFilterTest extends TestCase
+{
+    private $db;
+
+    protected function tearDown(): void
+    {
+        ee()->resetMocks();
+
+        parent::tearDown();
+    }
+
+    public function testChannelOnlyUsesCachedChannelStats()
+    {
+        $stats = $this->makeStats([
+            'channel' => 'catalogue',
+        ], [
+            [
+                'total_entries' => 5,
+                'total_comments' => 2,
+                'last_entry_date' => 800,
+                'last_comment_date' => 700,
+            ],
+        ]);
+
+        $this->assertSame('5:2', $stats->return_data);
+        $this->assertStringContainsString('FROM exp_channels', $this->db->queries[0]);
+        $this->assertStringNotContainsString('exp_channel_titles.status', $this->db->queries[0]);
+    }
+
+    public function testStatusFiltersUseEntryStatsAndKeepClosedOutByDefault()
+    {
+        $stats = $this->makeStats([
+            'channel' => 'catalogue',
+            'status' => 'open',
+        ], [
+            [
+                'total_entries' => 3,
+                'total_comments' => 7,
+                'last_entry_date' => 900,
+                'last_comment_date' => 800,
+            ],
+        ]);
+
+        $this->assertSame('3:7', $stats->return_data);
+        $this->assertStringContainsString('FROM exp_channel_titles', $this->db->queries[0]);
+        $this->assertStringContainsString("exp_channels.channel_name = 'catalogue'", $this->db->queries[0]);
+        $this->assertStringContainsString("exp_channel_titles.status = 'open'", $this->db->queries[0]);
+        $this->assertStringContainsString("exp_channel_titles.status != 'closed'", $this->db->queries[0]);
+    }
+
+    public function testExplicitClosedStatusCanBeCounted()
+    {
+        $this->makeStats([
+            'status' => 'closed',
+        ], [
+            [
+                'total_entries' => 1,
+                'total_comments' => 0,
+                'last_entry_date' => 900,
+                'last_comment_date' => 0,
+            ],
+        ]);
+
+        $this->assertStringContainsString("exp_channel_titles.status = 'closed'", $this->db->queries[0]);
+        $this->assertStringNotContainsString("exp_channel_titles.status != 'closed'", $this->db->queries[0]);
+    }
+
+    private function makeStats(array $params, array $rows)
+    {
+        ee()->resetMocks();
+
+        $this->db = new StatsStatusFilterDbMock($rows);
+
+        ee()->setMock('db', $this->db);
+        ee()->setMock('stats', new StatsStatusFilterStatsMock());
+        ee()->setMock('TMPL', new StatsStatusFilterTemplateMock($params));
+        ee()->setMock('functions', new StatsStatusFilterFunctionsMock());
+        ee()->setMock('localize', new class {
+            public $now = 1000;
+        });
+
+        return new Stats();
+    }
+}
+
+class StatsStatusFilterTemplateMock
+{
+    public $site_ids = [1];
+    public $tagdata = '{total_entries}:{total_comments}';
+    public $var_single = [
+        'total_entries' => '',
+        'total_comments' => '',
+    ];
+    private $params;
+
+    public function __construct(array $params)
+    {
+        $this->params = $params;
+    }
+
+    public function fetch_param($key, $default = false)
+    {
+        return array_key_exists($key, $this->params) ? $this->params[$key] : $default;
+    }
+
+    public function swap_var_single($variable, $replacement, $source)
+    {
+        return str_replace('{' . $variable . '}', $replacement, $source);
+    }
+}
+
+class StatsStatusFilterStatsMock
+{
+    public $stats_cache = [];
+    private $data = [
+        'current_names' => false,
+        'total_comments' => 0,
+        'total_entries' => 0,
+    ];
+
+    public function load_stats()
+    {
+    }
+
+    public function set_statdata($key, $value)
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function statdata($key)
+    {
+        return $this->data[$key] ?? false;
+    }
+}
+
+class StatsStatusFilterDbMock
+{
+    public $queries = [];
+    private $rows;
+
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    public function query($sql)
+    {
+        $this->queries[] = $sql;
+
+        return new StatsStatusFilterDbResultMock($this->rows);
+    }
+}
+
+class StatsStatusFilterDbResultMock
+{
+    private $rows;
+
+    public function __construct(array $rows)
+    {
+        $this->rows = $rows;
+    }
+
+    public function num_rows()
+    {
+        return count($this->rows);
+    }
+
+    public function result_array()
+    {
+        return $this->rows;
+    }
+
+    public function row_array()
+    {
+        return $this->rows[0] ?? [];
+    }
+}
+
+class StatsStatusFilterFunctionsMock
+{
+    public function prep_conditionals($str, $vars = [])
+    {
+        return $str;
+    }
+
+    public function sql_andor_string($str, $field)
+    {
+        if (strncasecmp($str, 'not ', 4) == 0) {
+            return "AND {$field} != '" . trim(substr($str, 4)) . "'";
+        }
+
+        if (strpos($str, '|') !== false) {
+            return "AND {$field} IN ('" . str_replace('|', "','", $str) . "')";
+        }
+
+        return "AND {$field} = '{$str}'";
+    }
+}

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Stats/Mod/StatsStatusFilterTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Stats/Mod/StatsStatusFilterTest.php
@@ -133,8 +133,12 @@ class StatsStatusFilterStatsMock
         $this->data[$key] = $value;
     }
 
-    public function statdata($key)
+    public function statdata($key = null)
     {
+        if (! $key) {
+            return $this->data;
+        }
+
         return $this->data[$key] ?? false;
     }
 }


### PR DESCRIPTION
## Summary
- Add `status=` support to `{exp:stats}` for entry totals, comment totals, and latest entry/comment dates.
- Preserve the existing default behavior when `status=` is omitted: channel-scoped stats continue using cached `exp_channels` totals, which count active non-closed entries.
- Add focused unit coverage for channel-only stats, explicit open status filtering, and explicit closed status filtering.

Refs #5301.

## Validation
- `system/ee/ExpressionEngine/Tests/vendor/bin/phpunit -c system/ee/ExpressionEngine/Tests/phpunit.xml system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Stats/Mod/StatsStatusFilterTest.php`
- `system/ee/ExpressionEngine/Tests/vendor/bin/phpunit -c system/ee/ExpressionEngine/Tests/phpunit.xml system/ee/ExpressionEngine/Tests/ExpressionEngine/Controllers/Utilities/StatsTest.php`
- `php -l system/ee/ExpressionEngine/Addons/stats/mod.stats.php`
- `php -l system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Stats/Mod/StatsStatusFilterTest.php`
- `git diff --check`