### PR TITLE
Fixed a bug where 2 stats tags on same template could have cache issue

### DIFF
--- a/system/ee/ExpressionEngine/Addons/stats/mod.stats.php
+++ b/system/ee/ExpressionEngine/Addons/stats/mod.stats.php
@@ -21,6 +21,7 @@ class Stats
     public function __construct()
     {
         ee()->stats->load_stats();
+        $statdata = ee()->stats->statdata();
 
         // Limit stats by channel or status
         // You can limit the stats by any combination of channels
@@ -89,16 +90,11 @@ class Stats
                         }
                     }
 
-                    foreach ($sdata as $key => $val) {
-                        ee()->stats->set_statdata($key, $val);
-
-                        ee()->stats->stats_cache[$cache_sql][$key] = $val;
-                    }
+                    ee()->stats->stats_cache[$cache_sql] = $sdata;
+                    $statdata = array_merge($statdata, $sdata);
                 }
             } else {
-                foreach (ee()->stats->stats_cache[$cache_sql] as $key => $val) {
-                    ee()->stats->set_statdata($key, $val);
-                }
+                $statdata = array_merge($statdata, ee()->stats->stats_cache[$cache_sql]);
             }
         }
 
@@ -110,8 +106,9 @@ class Stats
 
         foreach ($fields as $field) {
             if (isset(ee()->TMPL->var_single[$field])) {
-                $cond[$field] = ee()->stats->statdata($field);
-                ee()->TMPL->tagdata = ee()->TMPL->swap_var_single($field, ee()->stats->statdata($field), ee()->TMPL->tagdata);
+                $value = isset($statdata[$field]) ? $statdata[$field] : false;
+                $cond[$field] = $value;
+                ee()->TMPL->tagdata = ee()->TMPL->swap_var_single($field, $value, ee()->TMPL->tagdata);
             }
         }
 
@@ -126,13 +123,14 @@ class Stats
         foreach (ee()->TMPL->var_single as $key => $val) {
             foreach ($dates as $date) {
                 if (strncmp($key, $date, strlen($date)) == 0) {
+                    $date_value = isset($statdata[$date]) ? $statdata[$date] : false;
                     ee()->TMPL->tagdata = ee()->TMPL->swap_var_single(
                         $key,
-                        (! ee()->stats->statdata($date)
-                                                    or ee()->stats->statdata($date) == 0) ? '--' :
+                        (! $date_value
+                                                    or $date_value == 0) ? '--' :
                                                 ee()->localize->format_date(
                                                     $val,
-                                                    ee()->stats->statdata($date)
+                                                    $date_value
                                                 ),
                         ee()->TMPL->tagdata
                     );
@@ -144,7 +142,7 @@ class Stats
 
         $names = '';
 
-        if (ee()->stats->statdata('current_names')) {
+        if (! empty($statdata['current_names'])) {
             $chunk = ee()->TMPL->fetch_data_between_var_pairs(
                 ee()->TMPL->tagdata,
                 'member_names'
@@ -177,7 +175,7 @@ class Stats
             $member_path = str_replace("'", "", $member_path);
             $member_path = trim_slashes($member_path);
 
-            foreach (ee()->stats->statdata('current_names') as $k => $v) {
+            foreach ($statdata['current_names'] as $k => $v) {
                 $temp = $chunk;
 
                 if (empty($temp)) {

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Stats/Mod/StatsStatusFilterTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Stats/Mod/StatsStatusFilterTest.php
@@ -133,8 +133,12 @@ class StatsStatusFilterStatsMock
         $this->data[$key] = $value;
     }
 
-    public function statdata($key)
+    public function statdata($key = null)
     {
+        if (! $key) {
+            return $this->data;
+        }
+
         return $this->data[$key] ?? false;
     }
 }


### PR DESCRIPTION
Put a stats tag on the template and specify the channel.  Put a second tag and don't specify the channel.  The results of the first tag will be duplicated in the second, despite the unlimited tag having more entries etc.

The issue was request-local state bleed. The first channel-filtered {exp:stats channel="blog"} tag was overwriting shared ee()->stats values, so the later plain {exp:stats} reused the blog values.

Note- had to tweak the test file as well, because it assumed ee()->stats->statdata() would have an argument and now it doesn't.  So needed to allow for that.