### PR TITLE
Added some missing mime equivilants

### DIFF
--- a/system/ee/ExpressionEngine/Config/mimes.php
+++ b/system/ee/ExpressionEngine/Config/mimes.php
@@ -20,7 +20,9 @@
 return array(
     'img' => array(
         'application/x-photoshop', // .psd
+        'image/vnd.adobe.photoshop', // .psd
         'image/bmp', // .bmp
+        'image/x-ms-bmp', // .bmp
         'image/gif', // .gif
         'image/jpeg', // .jpg, .jpe, .jpeg
         'image/pjpeg', // .jpg, .jpe, .jpeg
@@ -108,9 +110,13 @@ return array(
     ),
     'archive' => array(
         'application/x-gtar', // .gtar
+        'application/gzip', // .gz
         'application/x-gzip', // .gz
+        'application/vnd.rar', // .rar
+        'application/x-rar', // .rar
         'application/x-rar-compressed', // .rar
         'application/x-stuffit', // .sit
+        'application/tar', // .tar, .tgz
         'application/x-tar', // .tar, .tgz
         'application/x-zip', // .zip
         'application/x-zip-compressed', // .zip
@@ -118,7 +124,9 @@ return array(
     ),
     'audio' => array(
         'audio/flac', // .flac
+        'audio/x-flac', // .flac
         'audio/m4a', // .m4a
+        'audio/mp4a-latm', // .m4a, .m4p
         'audio/x-m4a', // m4a
         'audio/midi', // .mid, .midi
         'audio/mp4', // .mp4
@@ -129,11 +137,14 @@ return array(
         'audio/x-pn-realaudio', // .ram, .rm
         'audio/x-pn-realaudio-plugin', // .rpm
         'audio/x-realaudio', // .ra
+        'audio/wav', // .wav
+        'audio/wave', // .wav
         'audio/x-wav', // .wav
     ),
     'video' => array(
         'application/ogg', // .ogv
         'video/m4v', // .m4v
+        'video/x-m4v', // .m4v
         'video/mp4', // .mp4
         'video/mpeg', // .mpe, .mpeg, .mpg
         'video/ogg', // .ogv


### PR DESCRIPTION
This came up because a gzip wouldn't upload due to failing allowed mime check.  However, we do allow gzip by default.

Looking at the native mimes.php config, it appears some newer equivilant mime types were missing.

In this case, 'application/x-gzip', // .gz was present, however the mime type on the file was reading as application/gzip so it was failing.  I had codex review for other missing but equivalent mime types.  

I did ask it to eval security concerns:

The only additions I’d look at harder are the RAR aliases:

application/vnd.rar
application/x-rar

They are equivalent labels for .rar, which is already allowed via application/x-rar-compressed, so they do not conceptually expand allowed file extensions. But archive formats are inherently higher risk than images/audio/docs because they can contain anything. EE’s current check only says “the uploaded blob is an allowed archive MIME,” not “the archive contents are safe.” Since RAR was already allowed, this does not create that risk from scratch, but it makes RAR acceptance more reliable across MIME detectors.

So basically- if we want to allow rar files, then this is fine.  If we don't, then we shouldn't include the existing one.