### PR TITLE
Fix null model result array keys

### DIFF
--- a/system/ee/ExpressionEngine/Service/Model/Query/Result.php
+++ b/system/ee/ExpressionEngine/Service/Model/Query/Result.php
@@ -96,7 +96,7 @@ class Result
 
                 if (isset($this->objects[$alias][$value])) {
                     $object = $this->objects[$alias][$value];
-                    $row_object_ids[$alias] = $object->getId();
+                    $row_object_ids[$alias] = $object->getId() ?? '';
 
                     continue;
                 }
@@ -136,6 +136,7 @@ class Result
 
         // connect ids
         foreach ($row_object_ids as $alias => $id) {
+            $id = $id ?? '';
             $related = $row_object_ids;
             unset($related[$alias]);
 

--- a/system/ee/ExpressionEngine/Service/Model/Query/Result.php
+++ b/system/ee/ExpressionEngine/Service/Model/Query/Result.php
@@ -92,7 +92,7 @@ class Result
             // joins that pull in a duplicate data (e.g. Templates with TemplateGroup).
             if (isset($this->primary_keys[$alias])) {
                 $pkey = $this->primary_keys[$alias];
-                $value = $row[$pkey];
+                $value = $row[$pkey] ?? '';
 
                 if (isset($this->objects[$alias][$value])) {
                     $object = $this->objects[$alias][$value];
@@ -123,14 +123,15 @@ class Result
             $object->fill($model_data);
 
             // store for results and reuse
-            $this->objects[$alias][$object->getId()] = $object;
+            $id = $object->getId() ?? '';
+            $this->objects[$alias][$id] = $object;
 
             // on the first pass, memoize primary key names
             if (! isset($this->primary_keys[$alias])) {
                 $this->primary_keys[$alias] = $alias . '__' . $object->getPrimaryKey();
             }
 
-            $row_object_ids[$alias] = $object->getId();
+            $row_object_ids[$alias] = $id;
         }
 
         // connect ids


### PR DESCRIPTION
> Front end load error that shows for several line numbers:
> 
> Deprecated Using null as an array offset is deprecated, use an empty string instead ee/ExpressionEngine/Service/Model/Query/Result.php, line 126

This is the absolute minimal fix for a PHP 8.5 deprecation notice in model query result hydration and should preserve existing behavior from older php versions.  BUT it's probably not the best fix. The best fix is likely https://github.com/ExpressionEngine/ExpressionEngine/pull/5337

But for a short term fix, someone can plop this change in and ditch the warnings and have the behavior the same as before.

details....

The warning can occur in `ExpressionEngine\Service\Model\Query\Result` when a hydrated model has a `null` primary key value and that value is used as an array key.

The more semantic fix would be to skip hydrating empty related models from `LEFT JOIN` results when the joined model’s primary key is `NULL`. That would better represent “no related model exists.”

However, relationship hydration is sensitive, and changing that behavior could affect how model results are assembled in edge cases.

This PR takes the safer, minimal approach: it preserves PHP’s historical behavior by explicitly normalizing `null` array keys to an empty string before using them as offsets. This avoids the PHP 8.5 deprecation without changing the broader result hydration flow.


