### PR TITLE
Fix 8.5 deprecations and null joins causing them

### DIFF
--- a/system/ee/ExpressionEngine/Service/Model/Query/Result.php
+++ b/system/ee/ExpressionEngine/Service/Model/Query/Result.php
@@ -94,6 +94,10 @@ class Result
                 $pkey = $this->primary_keys[$alias];
                 $value = $row[$pkey];
 
+                if ($value === null) {
+                    continue;
+                }
+
                 if (isset($this->objects[$alias][$value])) {
                     $object = $this->objects[$alias][$value];
                     $row_object_ids[$alias] = $object->getId();
@@ -122,15 +126,20 @@ class Result
             $object->emit('beforeLoad'); // do not add 'afterLoad' to this method, it must happen *after* relationships are matched
             $object->fill($model_data);
 
-            // store for results and reuse
-            $this->objects[$alias][$object->getId()] = $object;
-
             // on the first pass, memoize primary key names
             if (! isset($this->primary_keys[$alias])) {
                 $this->primary_keys[$alias] = $alias . '__' . $object->getPrimaryKey();
             }
 
-            $row_object_ids[$alias] = $object->getId();
+            $id = $object->getId();
+            if ($id === null) {
+                continue;
+            }
+
+            // store for results and reuse
+            $this->objects[$alias][$id] = $object;
+
+            $row_object_ids[$alias] = $id;
         }
 
         // connect ids

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Model/Query/ResultTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Service/Model/Query/ResultTest.php
@@ -77,6 +77,37 @@ class ResultTest extends TestCase
         $this->assertSame(2, $association->fills[0][0]->getId());
     }
 
+    public function testAllDoesNotAttachNullPrimaryKeyRelatedRows()
+    {
+        $relation = m::mock();
+        $relation->shouldReceive('getName')->once()->andReturn('Children');
+
+        $rows = array(
+            array(
+                'root__id' => 1,
+                'root__title' => 'Root',
+                'child__id' => null,
+                'child__title' => null,
+            ),
+        );
+
+        $result = new Result(
+            $rows,
+            array('root' => 'RootModel', 'child' => 'ChildModel'),
+            array('child' => array('root' => $relation))
+        );
+
+        $result->setFacade(new ResultFacadeStub());
+        $collection = $result->all();
+
+        $this->assertCount(1, $collection);
+        $root = $collection->first();
+        $association = $root->getAssociation('Children');
+
+        $this->assertCount(1, $association->fills);
+        $this->assertCount(0, $association->fills[0]);
+    }
+
     public function testFirstReturnsFirstModelWhenRowsExist()
     {
         $rows = array(


### PR DESCRIPTION
 left-joined “no related row” data can become a null-id/empty-key related object - and the null throws deprecation warnings.

This fix needs good oversight as it may have wider implications.  Approach in the fix- when an alias’s primary key is known and the row has NULL for it, skip that alias entirely; when the key is first learned after hydration, do not store or relate the object if getId() is NULL. This removes the phantom relation while still allowing real 0 or non-null IDs to behave normally.

Tests have been added, but this changes the data.  The implementation now skips null primary-key aliases instead of storing them under an empty string.

See the minimal fix in this pr: https://github.com/ExpressionEngine/ExpressionEngine/pull/5334

It eliminates the deprecation message and preserves existing behavior (where without the deprecation it treated it as a string) BUT do we really want to preserve that existing behavior? Probably not- which is what this pr does.