### PR TITLE
Resolved #5335 where Channel Form {field_data} was not always parsed

### DIFF
--- a/system/ee/ExpressionEngine/Addons/channel/libraries/channel_form/Channel_form_lib.php
+++ b/system/ee/ExpressionEngine/Addons/channel/libraries/channel_form/Channel_form_lib.php
@@ -1113,10 +1113,12 @@ GRID_FALLBACK;
      */
     private function _swap_custom_field_variables($custom_field_variables_row, $tagdata)
     {
+        $integer_variables = array('field_id', 'field_data', 'rows', 'maxlength');
+
         foreach ($custom_field_variables_row as $key => $value) {
             if (is_array($value)) {
                 $tagdata = $this->swap_var_pair($key, $value, $tagdata);
-            } elseif ($key === 'field_id') {
+            } elseif (in_array($key, $integer_variables, true)) {
                 $tagdata = ee()->TMPL->swap_var_single($key, (string) $value, $tagdata);
             } elseif (! is_int($value)) {
                 // don't use our conditionals as vars

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Channel/Library/ChannelFormLibFieldVariablesTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Channel/Library/ChannelFormLibFieldVariablesTest.php
@@ -4,11 +4,14 @@ require_once __DIR__ . '/ChannelFormLibTestBase.php';
 
 class ChannelFormLibFieldVariablesTest extends ChannelFormLibTestBase
 {
-    public function testCustomFieldsLoopSwapsIntegerFieldIdButNotIntegerConditionals()
+    public function testCustomFieldsLoopSwapsIntegerSingleVariablesButNotIntegerConditionals()
     {
         $customFieldVariables = [
             'field_id' => 9,
             'field_name' => 'title_ar',
+            'field_data' => 300,
+            'rows' => 8,
+            'maxlength' => 256,
             'field_type' => 'text',
             'textinput' => 1,
         ];
@@ -20,10 +23,10 @@ class ChannelFormLibFieldVariablesTest extends ChannelFormLibTestBase
         $result = $method->invoke(
             $this->channelFormLib,
             $customFieldVariables,
-            '[{field_id} : {field_name} : {textinput}]'
+            '[{field_id} : {field_name} : {field_data} : {rows} : {maxlength} : {textinput}]'
         );
 
-        $this->assertSame('[9 : title_ar : {textinput}]', $result);
+        $this->assertSame('[9 : title_ar : 300 : 8 : 256 : {textinput}]', $result);
     }
 
     public function testBuildCustomFieldVariablesReturnsEmptyArrayForNoFields()


### PR DESCRIPTION
Resolved #5335 where Channel Form {field_data} was not always parsed