### PR TITLE
Fix/db fixes

### DIFF
--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/database/DBDriverTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/database/DBDriverTest.php
@@ -353,36 +353,8 @@ class DBDriverTest extends TestCase
     {
         $driver = new DBDriverMethodHarness(['dbdriver' => 'db_driver_test']);
 
-        $demoResult = null;
-        $demoException = null;
-        try {
-            $demoResult = $driver->call_function('demo');
-        } catch (Throwable $exception) {
-            $demoException = $exception;
-        }
-
-        if ($demoException instanceof Throwable) {
-            $this->assertStringContainsString('call_user_func_array', $demoException->getMessage());
-        } else {
-            $this->assertTrue($demoResult === 'demo:' || $demoResult === null);
-        }
-
-        $helperResult = null;
-        $helperException = null;
-        try {
-            $helperResult = $driver->call_function('helper', 2, 3);
-        } catch (Throwable $exception) {
-            $helperException = $exception;
-        }
-
-        if ($helperException instanceof Throwable) {
-            $this->assertTrue(
-                strpos($helperException->getMessage(), 'array_splice') !== false
-                || strpos($helperException->getMessage(), 'Cannot pass parameter 1 by reference') !== false
-            );
-        } else {
-            $this->assertSame(5, $helperResult);
-        }
+        $this->assertSame('demo:', $driver->call_function('demo'));
+        $this->assertSame(5, $driver->call_function('helper', 2, 3));
 
         $driver->db_debug = false;
         $this->assertFalse($driver->call_function('missing'));

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/database/DBDriverTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/database/DBDriverTest.php
@@ -440,7 +440,7 @@ class DBDriverTest extends TestCase
         ee()->setMock('session', null);
 
         try {
-            $driver->display_error(['native message'], '', true);
+            $driver->display_error('native message', '', true);
             $this->fail('Expected exception.');
         } catch (Exception $exception) {
             $this->assertStringContainsString('native message', $exception->getMessage());

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/database/DBUtilityTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/database/DBUtilityTest.php
@@ -223,17 +223,17 @@ class DBUtilityTest extends TestCase
         $db->tables = ['exp_members'];
         $utility = new DBUtilityTestable($db);
 
-        try {
-            $utility->backup('exp_members');
-        } catch (Throwable $exception) {
-            $this->assertStringContainsString('count()', $exception->getMessage());
-        }
+        $this->assertSame(gzencode('SQLDATA'), $utility->backup('exp_members'));
+        $this->assertSame('exp_members', $utility->backupPrefs[0]['tables'][0]);
 
         $gzip = $utility->backup(['format' => 'gzip', 'tables' => ['exp_members']]);
         $this->assertSame(gzencode('SQLDATA'), $gzip);
 
         $txt = $utility->backup(['format' => 'txt', 'tables' => ['exp_members']]);
         $this->assertSame('SQLDATA', $txt);
+
+        $txtFromStringTablePreference = $utility->backup(['format' => 'txt', 'tables' => 'exp_members']);
+        $this->assertSame('SQLDATA', $txtFromStringTablePreference);
 
         $txtFromInvalidFormat = $utility->backup(['format' => 'invalid', 'tables' => ['exp_members']]);
         $this->assertSame('SQLDATA', $txtFromInvalidFormat);
@@ -252,6 +252,35 @@ class DBUtilityTest extends TestCase
         $this->assertSame('ZIP_BINARY', $zipData);
         $this->assertSame(['zip'], $load->libraries);
         $this->assertSame([['backup.sql', 'SQLDATA']], $zip->data);
+    }
+
+    public function testBackupUsesSingleTableNameForDefaultZipFilename(): void
+    {
+        $db = new DBUtilityDbStub();
+        $utility = new DBUtilityTestable($db);
+
+        $load = new DBUtilityLoadStub();
+        $zip = new DBUtilityZipStub();
+        ee()->setMock('load', $load);
+        ee()->setMock('zip', $zip);
+
+        $utility->backup([
+            'format' => 'zip',
+            'filename' => '',
+            'tables' => ['exp_members'],
+        ]);
+
+        $this->assertCount(1, $zip->data);
+        $this->assertMatchesRegularExpression('/^exp_members_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}\\.sql$/', $zip->data[0][0]);
+
+        $utility->backup([
+            'format' => 'zip',
+            'filename' => '',
+            'tables' => 'exp_members',
+        ]);
+
+        $this->assertCount(2, $zip->data);
+        $this->assertMatchesRegularExpression('/^exp_members_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}\\.sql$/', $zip->data[1][0]);
     }
 
     public function testBackupGeneratesDefaultZipFilenameWhenMissing(): void

--- a/system/ee/legacy/database/DB_driver.php
+++ b/system/ee/legacy/database/DB_driver.php
@@ -777,12 +777,10 @@ class CI_DB_driver
     }
 
     /**
-     * Enables a native PHP function to be run, using a platform agnostic wrapper.
+     * Run a driver-specific native PHP function through a common wrapper.
      *
-     * @access	public
-     * @param	string	the function name
-     * @param	mixed	any parameters needed by the function
-     * @return	mixed
+     * @param string $function The native function name without the driver prefix.
+     * @return mixed
      */
     public function call_function($function)
     {
@@ -798,11 +796,12 @@ class CI_DB_driver
             }
 
             return false;
-        } else {
-            $args = (func_num_args() > 1) ? array_splice(func_get_args(), 1) : null;
-
-            return call_user_func_array($function, $args);
         }
+
+        $args = func_get_args();
+        array_shift($args);
+
+        return call_user_func_array($function, $args);
     }
 
     /**

--- a/system/ee/legacy/database/DB_driver.php
+++ b/system/ee/legacy/database/DB_driver.php
@@ -844,13 +844,13 @@ class CI_DB_driver
     }
 
     /**
-     * Display an error message
+     * Display or throw a database error message.
      *
-     * @access	public
-     * @param	string	the error message
-     * @param	string	any "swap" values
-     * @param	boolean	whether to localize the message
-     * @return	string	sends the application/error_db.php template
+     * @param string|array $error The error message or language key.
+     * @param string $swap Replacement text for localized messages.
+     * @param bool $native Whether the message is already formatted.
+     * @return void
+     * @throws Exception
      */
     public function display_error($error = '', $swap = '', $native = false)
     {
@@ -868,7 +868,7 @@ class CI_DB_driver
         }
 
         if ($native == true) {
-            $message = $error;
+            $message = (array) $error;
         } else {
             $message = (! is_array($error)) ? array(str_replace('%s', $swap, $LANG->line($error))) : $error;
         }

--- a/system/ee/legacy/database/DB_utility.php
+++ b/system/ee/legacy/database/DB_utility.php
@@ -239,10 +239,10 @@ class CI_DB_utility extends CI_DB_forge
     }
 
     /**
-     * Database Backup
+     * Build a database backup using the requested format and table selection.
      *
-     * @access	public
-     * @return	void
+     * @param array|string $params Backup preferences or a single table name.
+     * @return string|null
      */
     public function backup($params = array())
     {
@@ -250,7 +250,7 @@ class CI_DB_utility extends CI_DB_forge
         // array then we know that it is simply the table
         // name, which is a valid short cut.
         if (is_string($params)) {
-            $params = array('tables' => $params);
+            $params = array('tables' => array($params));
         }
 
         // ------------------------------------------------------
@@ -273,6 +273,10 @@ class CI_DB_utility extends CI_DB_forge
                     $prefs[$key] = $params[$key];
                 }
             }
+        }
+
+        if (is_string($prefs['tables'])) {
+            $prefs['tables'] = array($prefs['tables']);
         }
 
         // ------------------------------------------------------
@@ -307,7 +311,8 @@ class CI_DB_utility extends CI_DB_forge
 
         // Set the filename if not provided - Only needed with Zip files
         if ($prefs['filename'] == '' and $prefs['format'] == 'zip') {
-            $prefs['filename'] = (count($prefs['tables']) == 1) ? $prefs['tables'] : $this->db->database;
+            $tables = array_values($prefs['tables']);
+            $prefs['filename'] = (count($tables) == 1) ? $tables[0] : $this->db->database;
             $prefs['filename'] .= '_' . date('Y-m-d_H-i', time());
         }
 


### PR DESCRIPTION
Fixes three PHP 8+ compatibility issues in the legacy database layer:

- Normalize string table shortcuts in `CI_DB_utility::backup()` before calling `count()`
- Forward `CI_DB_driver::call_function()` arguments using a real local array instead of `array_splice(func_get_args(), 1)`
- Ensure native `CI_DB_driver::display_error()` messages are array-shaped before appending file and line details

Also updates the existing legacy database tests so they assert the fixed behavior instead of tolerating the previous PHP 8 failures.
