### PR TITLE
Remove outdated link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ ExpressionEngine separates your content from your design, enabling you to make s
 If you're new to ExpressionEngine, check out:
 
 - [The Big Picture](https://docs.expressionengine.com/latest/getting-started/the-big-picture.html)
-- [Building a Simple News Site from Start to Finish](https://docs.expressionengine.com/latest/how_to/building_a_simple_news_site.html)
 - [10-minute ExpressionEngine Primer](https://www.youtube.com/watch?v=qKaOirMRz2s) on ExpressionEngineTV
 
 ## How to Contribute


### PR DESCRIPTION
Removed a link to 'Building a Simple News Site from Start to Finish' from the README, since this page doesn't exist anymore