### PR TITLE
Restore frontend router after loading member form libraries

### DIFF
--- a/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_register.php
@@ -52,9 +52,14 @@ class Member_register extends Member
             ->order_by('m_field_order')
             ->get('member_fields');
 
+        // Temporarily masquerade as CP so these libraries can initialize, then
+        // restore router state so downstream template/layout parsing keeps the
+        // original front-end context.
+        $original_router_class = ee()->router->fetch_class();
         ee()->router->set_class('cp');
         ee()->load->library('cp');
         ee()->load->library('javascript');
+        ee()->router->set_class($original_router_class);
         ee()->load->helper('form');
 
         $fields = [];

--- a/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
+++ b/system/ee/ExpressionEngine/Addons/member/mod.member_settings.php
@@ -712,10 +712,14 @@ class Member_settings extends Member
         // Load the form helper
         ee()->load->helper('form');
 
-        // UGH- we need these 3 to get the data js or it throws a Legacy\Facade error
+        // Temporarily masquerade as CP so these libraries can initialize, then
+        // restore router state so downstream template/layout parsing keeps the
+        // original front-end context.
+        $original_router_class = ee()->router->fetch_class();
         ee()->router->set_class('cp');
         ee()->load->library('cp');
         ee()->load->library('javascript');
+        ee()->router->set_class($original_router_class);
 
         /** ----------------------------------------
         /**  Build the custom profile fields

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/member/Mod/MemberRegisterCoverageTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/member/Mod/MemberRegisterCoverageTest.php
@@ -1,6 +1,19 @@
 <?php
 
 require_once __DIR__ . '/MemberRegisterTestBase.php';
+require_once rtrim(PATH_ADDONS, '/') . '/member/mod.member_settings.php';
+
+class MemberEditProfileRouterFixture extends Member_settings
+{
+    public function __construct()
+    {
+    }
+
+    public function _load_element($which)
+    {
+        throw new RuntimeException('profile fields reached');
+    }
+}
 
 class MemberRegisterCoverageTest extends MemberRegisterTestBase
 {
@@ -270,6 +283,38 @@ class MemberRegisterCoverageTest extends MemberRegisterTestBase
         $this->assertStringNotContainsString('{custom_fields}', $result);
         $this->assertStringNotContainsString('<captcha>', $result);
         $this->assertStringContainsString('</form>', $result);
+    }
+
+    public function testRegistrationFormRestoresFrontendRouterAfterLoadingCpLibraries()
+    {
+        ee()->TMPL->tagdata = '<p>Registration</p>';
+        ee()->TMPL->setMap([
+            'include_assets' => 'n',
+            'error_handling' => '',
+        ]);
+
+        $this->subject->registration_form();
+
+        $this->assertSame('ee', $this->router->class);
+        $this->assertSame(['cp', 'ee'], $this->router->history);
+    }
+
+    public function testEditProfileRestoresFrontendRouterAfterLoadingCpLibraries()
+    {
+        ee()->TMPL->tagdata = '<p>Profile fields</p>';
+        $subject = (new ReflectionClass(MemberEditProfileRouterFixture::class))->newInstanceWithoutConstructor();
+
+        try {
+            $subject->edit_profile();
+            $this->fail('Expected the fixture to stop after router initialization.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('profile fields reached', $exception->getMessage());
+        }
+
+        $this->assertSame('ee', $this->router->class);
+        $this->assertSame(['cp', 'ee'], $this->router->history);
+        $this->assertSame(['form'], $this->load->helpers);
+        $this->assertSame(['cp', 'javascript'], $this->load->libraries);
     }
 
     public function testRegistrationFormAppendsAssetsWhenRequested()

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/member/Mod/MemberRegisterTestBase.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/member/Mod/MemberRegisterTestBase.php
@@ -74,6 +74,7 @@ abstract class MemberRegisterTestBase extends TestCase
     protected $modelService;
     protected $load;
     protected $functions;
+    protected $router;
 
     protected function setUp(): void
     {
@@ -406,11 +407,22 @@ abstract class MemberRegisterTestBase extends TestCase
         };
         ee()->setMock('output', $this->output);
 
-        ee()->setMock('router', new class {
+        $this->router = new class {
+            public $class = 'ee';
+            public $history = [];
+
+            public function fetch_class()
+            {
+                return $this->class;
+            }
+
             public function set_class($class)
             {
+                $this->class = $class;
+                $this->history[] = $class;
             }
-        });
+        };
+        ee()->setMock('router', $this->router);
 
         $this->load = new class {
             public $helpers = [];


### PR DESCRIPTION
Prevent member edit and registration tags from leaving the router in the control panel context, which can break subsequent frontend layout parsing. Add regression coverage for both forms.

## Why this matters

The router is shared for the entire request. These frontend Member tags temporarily change it to `cp` so they can load Control Panel form libraries:

- `{exp:member:edit_profile}`
- `{exp:member:registration_form}`

Previously, they never changed it back. Anything parsed after the tag could therefore incorrectly believe it was running inside the Control Panel.

For example:

```
{layout="site:_layouts/wrapper"}

{exp:member:edit_profile}
    {field:company_name}
{/exp:member:edit_profile}
```

After rendering the member form, ExpressionEngine still reported the router class as cp. This could interfere with subsequent layout and template processing, especially on an MSM installation.
Observed symptoms included:
Nested layouts failing with Template Not Found, resulting in a blank page.

Site-specific template variables remaining unparsed, such as:

```
{var_licenses-table_styles_2024}
When this unresolved variable was placed in <head>, the browser moved the text into <body>, causing it to appear visibly above the site header.

Other code executed later in the request—including add-ons and extensions—could also choose the wrong behavior if it checks the router to distinguish frontend and Control Panel requests.
The fix records the original router class, temporarily switches to cp, loads the required libraries, and then restores the original value. It restores rather than hard-codes ee, preserving whichever context initiated the request.
```
{var_licenses-table_styles_2024}
```
When this unresolved variable was placed in <head>, the browser moved the text into <body>, causing it to appear visibly above the site header.

Other code executed later in the request—including add-ons and extensions—could also choose the wrong behavior if it checks the router to distinguish frontend and Control Panel requests.

The fix records the original router class, temporarily switches to cp, loads the required libraries, and then restores the original value. It restores rather than hard-codes ee, preserving whichever context initiated the request.

## Longer-term fix

Frontend Member forms should not need to mutate the global router to load field rendering and JavaScript dependencies. The shared form functionality should be extracted from the CP-only library or made explicitly usable in a frontend context.

That would remove the temporary `cp` masquerade entirely. The save-and-restore change in this PR is a safe short-term fix while preserving the existing library behavior.
