### PR TITLE
Fix CP form group toggle serialization

### DIFF
--- a/system/ee/ExpressionEngine/Library/CP/Form/Field.php
+++ b/system/ee/ExpressionEngine/Library/CP/Form/Field.php
@@ -81,6 +81,8 @@ abstract class Field
     }
 
     /**
+     * Convert the field into a shared form definition.
+     *
      * @return array
      */
     public function toArray(): array
@@ -90,6 +92,10 @@ abstract class Field
             if (!is_null($value)) {
                 $return[$key] = $value;
             }
+        }
+
+        if (isset($return['group_toggle']) && is_string($return['group_toggle'])) {
+            $return['group_toggle'] = ['y' => $return['group_toggle']];
         }
 
         return $return;

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Library/CP/Form/FieldTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Library/CP/Form/FieldTest.php
@@ -318,6 +318,19 @@ class FieldTest extends TestCase
     }
 
     /**
+     * Serialize a group toggle into the shared form value map.
+     *
+     * @return void
+     */
+    public function testGroupToggleIsSerializedForSharedForm(): void
+    {
+        $field = $this->_getField();
+        $field->setGroupToggle('test-group-toggle');
+
+        $this->assertSame(['y' => 'test-group-toggle'], $field->toArray()['group_toggle']);
+    }
+
+    /**
      * @depends testSetGroupToggleReturnInstance
      * @param Field $field
      * @return void


### PR DESCRIPTION
## Summary

- Serialize string CP/Form group toggles into the value-to-group map expected by the shared form JavaScript.
- Preserve the documented string setter and getter behavior.
- Add regression coverage for the serialized shared form definition.

## Root cause

`Field::setGroupToggle()` stored the documented group name string, and `Field::toArray()` passed that string directly to the shared form view. The rendered `data-group-toggle` value was therefore a JSON string instead of an object, causing jQuery to throw while iterating it.

A string group toggle now serializes as the enabled toggle mapping (`y` to the target group), matching existing shared form definitions.

## Validation

- PHP 7.4: CP/Form suite, 188 tests and 306 assertions
- PHP 8.3: CP/Form suite, 188 tests and 306 assertions
- Independent PR-style review: no actionable findings

Fixes #4925
