### PR TITLE
Add IDs to Channel Form file inputs

### DIFF
--- a/system/ee/ExpressionEngine/Addons/file/ft.file.php
+++ b/system/ee/ExpressionEngine/Addons/file/ft.file.php
@@ -153,9 +153,10 @@ class File_ft extends EE_Fieldtype implements ColumnInterface
     }
 
     /**
-     * Show the publish field
+     * Render the publish field for the current request.
      *
-     * @access  public
+     * @param mixed $data Stored file field data
+     * @return string Rendered file field
      */
     public function display_field($data)
     {
@@ -188,7 +189,8 @@ class File_ft extends EE_Fieldtype implements ColumnInterface
             $allowed_file_dirs,
             $content_type,
             $filebrowser,
-            ($show_existing == 'y') ? $existing_limit : null
+            ($show_existing == 'y') ? $existing_limit : null,
+            ($this->content_type() === 'channel') ? $this->field_name : null
         );
     }
 

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtDisplayFieldTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtDisplayFieldTest.php
@@ -137,6 +137,7 @@ class FileFtDisplayFieldTest extends FileFtTestBase
                 'content_type' => 'all',
                 'filebrowser' => false,
                 'existing_limit' => null,
+                'input_id' => 'feature_file',
             ],
         ], $this->fileFieldMock->fieldCalls);
     }
@@ -173,6 +174,40 @@ class FileFtDisplayFieldTest extends FileFtTestBase
                 'content_type' => 'all',
                 'filebrowser' => false,
                 'existing_limit' => 9,
+                'input_id' => 'asset_file',
+            ],
+        ], $this->fileFieldMock->fieldCalls);
+    }
+
+    /**
+     * Assert Grid file inputs do not receive duplicate IDs before namespacing.
+     *
+     * @return void
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testDisplayFieldOmitsInputIdForGridFields()
+    {
+        define('REQ', 'PAGE');
+
+        $fieldtype = $this->makeFieldtype([], 0, 'col_id_2', FileFtDisplayFieldSpy::class);
+        $fieldtype->_init(['content_type' => 'grid']);
+        $this->fileFieldMock->fieldReturn = '<grid file picker>';
+
+        $result = $fieldtype->display_field('');
+
+        $this->assertSame('<grid file picker>', $result);
+        $this->assertSame(1, $fieldtype->frontendJsCalls);
+        $this->assertSame([
+            [
+                'field_name' => 'col_id_2',
+                'data' => '',
+                'allowed_file_dirs' => 'all',
+                'content_type' => 'all',
+                'filebrowser' => false,
+                'existing_limit' => null,
+                'input_id' => null,
             ],
         ], $this->fileFieldMock->fieldCalls);
     }

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtTestBase.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/file/FT/FileFtTestBase.php
@@ -399,9 +399,10 @@ namespace {
          * @param string $contentType
          * @param bool $filebrowser
          * @param int|null $existingLimit
+         * @param string|null $inputId
          * @return string
          */
-        public function field($fieldName, $data, $allowedFileDirs, $contentType, $filebrowser, $existingLimit)
+        public function field($fieldName, $data, $allowedFileDirs, $contentType, $filebrowser, $existingLimit, $inputId)
         {
             $this->fieldCalls[] = [
                 'field_name' => $fieldName,
@@ -410,6 +411,7 @@ namespace {
                 'content_type' => $contentType,
                 'filebrowser' => $filebrowser,
                 'existing_limit' => $existingLimit,
+                'input_id' => $inputId,
             ];
 
             return $this->fieldReturn;

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/FileFieldFieldTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/Libraries/FileFieldFieldTest.php
@@ -3243,7 +3243,7 @@ class FileFieldFieldTest extends TestCase
             'file_name' => '',
         ];
 
-        $result = $this->subject->field('asset_file', '{filedir_9}spec%20sheet.pdf', 'all', 'image');
+        $result = $this->subject->field('asset_file', '{filedir_9}spec%20sheet.pdf', 'all', 'image', true, null, 'asset_file');
 
         $this->assertSame('<rendered-output>', $result);
         $this->assertSame(['filemanager'], $this->loadMock->libraries);
@@ -3269,6 +3269,7 @@ class FileFieldFieldTest extends TestCase
         $this->assertStringContainsString('data-directory="all"', $vars['upload_link']);
         $this->assertStringContainsString('name="asset_file_hidden_file"', $vars['hidden']);
         $this->assertStringContainsString('value="spec sheet.pdf"', $vars['hidden']);
+        $this->assertStringContainsString('id="asset_file"', $vars['upload']);
     }
 
     /**

--- a/system/ee/legacy/libraries/File_field.php
+++ b/system/ee/legacy/libraries/File_field.php
@@ -32,9 +32,12 @@ class File_field
      *              Either 'all' or ONE directory ID
      * @param string $content_type The content type allowed.
      *              Either 'all' or 'image'
+     * @param bool $filebrowser Whether the file browser is available
+     * @param int|null $existing_limit Maximum number of existing files to show
+     * @param string|null $input_id ID for the rendered upload input
      * @return string Fully rendered file field
      */
-    public function field($field_name, $data = '', $allowed_file_dirs = 'all', $content_type = 'all', $filebrowser = true, $existing_limit = null)
+    public function field($field_name, $data = '', $allowed_file_dirs = 'all', $content_type = 'all', $filebrowser = true, $existing_limit = null, $input_id = null)
     {
         // Load necessary library, helper, model and langfile
         ee()->load->library('filemanager');
@@ -93,12 +96,18 @@ class File_field
 
         // Create a standard file upload field and dropdown for folks
         // without javascript
-        $vars['upload'] = form_upload(array(
+        $upload_attributes = array(
             'name' => $field_name,
             'value' => $vars['filename'],
             'data-content-type' => $content_type,
             'data-directory' => $specified_directory
-        ));
+        );
+
+        if ($input_id !== null) {
+            $upload_attributes['id'] = $input_id;
+        }
+
+        $vars['upload'] = form_upload($upload_attributes);
 
         $vars['allowed_file_dirs'] = $allowed_file_dirs;
         $vars['directory'] = form_hidden($field_name . '_directory', $vars['upload_location_id']);


### PR DESCRIPTION
## What changed

- give standard Channel Form File field upload inputs an ID matching the field short name
- keep Grid and other namespaced File field inputs unchanged to avoid duplicate IDs across rows
- add regression coverage for both the Channel Form and Grid rendering contracts

## Why

Generated Channel Form templates render labels whose `for` attribute targets the field short name. The frontend File field upload input rendered the same value as its `name`, but did not expose it as an `id`, leaving the label without an associated control.

This restores the expected label-to-input association for accessibility without changing nested File field markup.

Fixes #4897

## Validation

- File fieldtype suite: 187 tests, 531 assertions
- legacy File field suite: 77 tests, 443 assertions
- PHP syntax checks for all changed PHP files
- `git diff --check`
- independent PR-style review with no remaining actionable findings
