### PR TITLE
Align template PHP settings on save

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Design/Template.php
+++ b/system/ee/ExpressionEngine/Controller/Design/Template.php
@@ -597,6 +597,11 @@ class Template extends AbstractDesignController
             $_POST['template_engine'] = null;
         }
 
+        if (! ee('Permission')->isSuperAdmin()) {
+            $_POST['allow_php'] = $template->isNew() ? 'n' : $template->allow_php;
+            $_POST['php_parse_location'] = $template->isNew() ? 'o' : $template->php_parse_location;
+        }
+
         $template->set($_POST);
         $template->edit_date = ee()->localize->now;
         $template->last_author_id = ee()->session->userdata('member_id');

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Controllers/Design/TemplateTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Controllers/Design/TemplateTest.php
@@ -10,13 +10,55 @@
 
 namespace ExpressionEngine\Tests\Controllers\Design;
 
+use ExpressionEngine\Model\Template\Template as TemplateModel;
+use ExpressionEngine\Service\Validation\Result as ValidationResult;
 use PHPUnit\Framework\TestCase;
 
 class TemplateTest extends TestCase
 {
+    /** @var \ExpressionEngine\Controller\Design\Template */
+    private $controller;
+
     public static function setUpBeforeClass(): void
     {
         require_once(APPPATH . 'core/Controller.php');
+    }
+
+    /**
+     * Reset shared state and create the controller without its constructor.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        ee()->resetMocks();
+        ee()->session->resetUserdata();
+        ee()->session->setUserdata('member_id', 10);
+        ee()->setMock('input', new class {
+            public function post($key)
+            {
+                return $_POST[$key] ?? null;
+            }
+        });
+        ee()->setMock('localize', (object) ['now' => 1234567890]);
+
+        $_POST = [];
+
+        $reflection = new \ReflectionClass('ExpressionEngine\Controller\Design\Template');
+        $this->controller = $reflection->newInstanceWithoutConstructor();
+    }
+
+    /**
+     * Reset shared request and dependency state.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        $_POST = [];
+        ee()->resetMocks();
+        ee()->session->resetUserdata();
+        $this->controller = null;
     }
 
     public function testRoutableMethods()
@@ -33,5 +75,126 @@ class TemplateTest extends TestCase
         sort($controller_methods);
 
         $this->assertEquals(array('create', 'edit', 'search', 'searchtemplates', 'settings'), $controller_methods);
+    }
+
+    public function testNonSuperAdminCannotChangeExistingPhpSettings()
+    {
+        $this->setSuperAdmin(false);
+
+        $template = new TestTemplateModel([
+            'allow_php' => 'n',
+            'php_parse_location' => 'o',
+        ]);
+        $template->markPersisted();
+
+        $_POST = [
+            'allow_php' => 'y',
+            'php_parse_location' => 'i',
+        ];
+
+        $this->validateTemplate($template);
+
+        $this->assertFalse($template->allow_php);
+        $this->assertSame('o', $template->php_parse_location);
+    }
+
+    public function testNonSuperAdminNewTemplateUsesSafePhpDefaults()
+    {
+        $this->setSuperAdmin(false);
+
+        $template = new TestTemplateModel([
+            'allow_php' => 'y',
+            'php_parse_location' => 'i',
+        ]);
+
+        $_POST = ['template_name' => 'example'];
+
+        $this->validateTemplate($template);
+
+        $this->assertFalse($template->allow_php);
+        $this->assertSame('o', $template->php_parse_location);
+    }
+
+    public function testSuperAdminCanChangePhpSettings()
+    {
+        $this->setSuperAdmin(true);
+
+        $template = new TestTemplateModel([
+            'allow_php' => 'n',
+            'php_parse_location' => 'o',
+        ]);
+
+        $_POST = [
+            'allow_php' => 'y',
+            'php_parse_location' => 'i',
+        ];
+
+        $this->validateTemplate($template);
+
+        $this->assertTrue($template->allow_php);
+        $this->assertSame('i', $template->php_parse_location);
+    }
+
+    /**
+     * Configure the current member's Super Admin state.
+     *
+     * @param bool $isSuperAdmin
+     * @return void
+     */
+    private function setSuperAdmin($isSuperAdmin)
+    {
+        ee()->setMock('Permission', new class($isSuperAdmin) {
+            private $isSuperAdmin;
+
+            public function __construct($isSuperAdmin)
+            {
+                $this->isSuperAdmin = $isSuperAdmin;
+            }
+
+            public function isSuperAdmin()
+            {
+                return $this->isSuperAdmin;
+            }
+        });
+    }
+
+    /**
+     * Validate the template through the controller's save boundary.
+     *
+     * @param TemplateModel $template
+     * @return ValidationResult
+     */
+    private function validateTemplate(TemplateModel $template)
+    {
+        $method = new \ReflectionMethod($this->controller, 'validateTemplate');
+        \TestReflectionHelper::makeAccessible($method);
+
+        return $method->invoke($this->controller, $template);
+    }
+}
+
+/**
+ * Template model double with isolated validation behavior.
+ */
+class TestTemplateModel extends TemplateModel
+{
+    /**
+     * Return a successful validation result without external model services.
+     *
+     * @return ValidationResult
+     */
+    public function validate()
+    {
+        return new ValidationResult();
+    }
+
+    /**
+     * Mark this template as an existing database record.
+     *
+     * @return void
+     */
+    public function markPersisted()
+    {
+        $this->_new = false;
     }
 }


### PR DESCRIPTION
## Summary

- Keep existing template PHP settings unchanged during non-Super Admin saves.
- Apply disabled/output defaults when those members create templates.
- Add regression coverage for existing templates, new templates, and Super Admin saves.

## Why

Template PHP controls are conditionally displayed, while save handling previously processed posted values independently of that form state. This keeps server-side save behavior aligned with the displayed settings and preserves existing values.

## Impact

Template editors retain their normal create and edit workflow. Super Admins can continue updating template PHP settings as before.

## Validation

- `system/ee/ExpressionEngine/Tests/vendor/bin/phpunit -c system/ee/ExpressionEngine/Tests/phpunit.xml system/ee/ExpressionEngine/Tests/ExpressionEngine/Controllers/Design/TemplateTest.php` — 4 tests, 7 assertions
- PHP syntax checks for both changed files
- `git diff --check`