### PR TITLE
Add opt-in Fluid collapse and publish scroll persistence

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -121,6 +121,12 @@ abstract class AbstractPublish extends CP_Controller
             'publish.field.URL' => ee('CP/URL', 'publish/field/' . $channel_id . '/' . $entry_id)->compile(),
             'publish.url_title_prefix' => $entry->Channel->url_title_prefix,
             'publish.which' => ($entry_id) ? 'edit' : 'new',
+            'publish.entry_id' => (int) $entry_id,
+            // Hidden Configuration Variables (y/n):
+            //   fluid_field_persist_collapse - remember Fluid item expand/collapse across Save
+            //   publish_persist_scroll - restore publish form scroll position after Save
+            'publish.fluid_persist_collapse' => bool_config_item('fluid_field_persist_collapse'),
+            'publish.persist_scroll' => bool_config_item('publish_persist_scroll'),
             'publish.word_separator' => ee()->config->item('word_separator') != "dash" ? '_' : '-',
             'publish.has_conditional_fields' => $usesConditionalFields,
             'user.can_edit_html_buttons' => ee('Permission')->can('edit_html_buttons'),

--- a/themes/ee/asset/javascript/src/cp/publish/publish.js
+++ b/themes/ee/asset/javascript/src/cp/publish/publish.js
@@ -54,6 +54,187 @@ $(document).ready(function () {
 		});
 	}
 
+	// Persist publish scroll position across Save when enabled via
+	// Hidden Configuration Variable - publish_persist_scroll => y/n
+	// Uses a Fluid-item anchor + offset (not bare Y) and re-applies until
+	// layout height settles, so late-loading Grid/RTE/images do not shift the viewport.
+	if (EE.publish.persist_scroll && EE.publish.entry_id) {
+		var getPublishScrollKey = function() {
+			var userId = (typeof EE.user_id !== 'undefined' && EE.user_id) ? String(EE.user_id) : 'anon';
+			return ['ee:publishScroll', userId, String(EE.publish.entry_id)].join(':');
+		};
+
+		var getScrollY = function() {
+			return (typeof window.scrollY === 'number') ? window.scrollY : window.pageYOffset;
+		};
+
+		var getPublishFluidItems = function() {
+			return publishForm.find('.fluid .js-sorting-container .fluid__item').filter(function() {
+				return ! $(this).closest('.fluid-field-templates').length;
+			});
+		};
+
+		var getFluidItemIdFromEl = function($item) {
+			var name = $item.find(':input[name*="[fields]"]').first().attr('name') || '';
+			var match = name.match(/\[(field_\d+|new_field_\d+)\]/);
+			return match ? match[1] : null;
+		};
+
+		var capturePublishScrollAnchor = function() {
+			var y = getScrollY();
+			var anchor = {
+				y: Math.max(0, Math.round(y)),
+				itemId: null,
+				offset: null
+			};
+
+			getPublishFluidItems().each(function() {
+				var $item = $(this);
+				var top = $item.offset().top;
+				var bottom = top + $item.outerHeight();
+
+				// Prefer the item that contains the viewport top
+				if (top <= y + 8 && bottom > y) {
+					anchor.itemId = getFluidItemIdFromEl($item);
+					anchor.offset = Math.max(0, Math.round(y - top));
+					return false;
+				}
+
+				// Fallback: last item that starts above the viewport
+				if (top <= y) {
+					anchor.itemId = getFluidItemIdFromEl($item);
+					anchor.offset = Math.max(0, Math.round(y - top));
+				}
+			});
+
+			return anchor;
+		};
+
+		var persistPublishScroll = function() {
+			if (typeof localStorage === 'undefined') {
+				return;
+			}
+
+			try {
+				localStorage.setItem(getPublishScrollKey(), JSON.stringify(capturePublishScrollAnchor()));
+			} catch (err) {}
+		};
+
+		var readPublishScrollAnchor = function() {
+			var raw = localStorage.getItem(getPublishScrollKey());
+
+			if (raw === null || raw === '') {
+				return null;
+			}
+
+			try {
+				var data = JSON.parse(raw);
+
+				if (data && typeof data.y === 'number') {
+					return data;
+				}
+			} catch (err) {}
+
+			return null;
+		};
+
+		var applyPublishScrollAnchor = function(anchor) {
+			if ( ! anchor) {
+				return;
+			}
+
+			if (anchor.itemId) {
+				var $match = null;
+
+				getPublishFluidItems().each(function() {
+					if (getFluidItemIdFromEl($(this)) === anchor.itemId) {
+						$match = $(this);
+						return false;
+					}
+				});
+
+				if ($match && $match.length) {
+					var target = Math.max(0, Math.round($match.offset().top + (anchor.offset || 0)));
+					window.scrollTo(0, target);
+					return;
+				}
+			}
+
+			if (typeof anchor.y === 'number' && anchor.y > 0) {
+				window.scrollTo(0, anchor.y);
+			}
+		};
+
+		var restorePublishScroll = function() {
+			if (typeof localStorage === 'undefined') {
+				return;
+			}
+
+			try {
+				var anchor = readPublishScrollAnchor();
+
+				if ( ! anchor || ! (anchor.y > 0 || anchor.itemId)) {
+					return;
+				}
+
+				var started = Date.now();
+				var lastHeight = 0;
+				var stableFor = 0;
+				var maxWait = 6000;
+				var stableNeed = 400;
+				var pollEvery = 100;
+				var done = false;
+
+				var tick = function() {
+					if (done) {
+						return;
+					}
+
+					var height = document.documentElement.scrollHeight;
+
+					applyPublishScrollAnchor(anchor);
+
+					if (height === lastHeight) {
+						stableFor += pollEvery;
+					} else {
+						stableFor = 0;
+						lastHeight = height;
+					}
+
+					if (stableFor >= stableNeed || (Date.now() - started) >= maxWait) {
+						done = true;
+						applyPublishScrollAnchor(anchor);
+						return;
+					}
+
+					setTimeout(tick, pollEvery);
+				};
+
+				// Allow Fluid collapse restore a chance to run first
+				if (typeof window.requestAnimationFrame === 'function') {
+					window.requestAnimationFrame(function() {
+						window.requestAnimationFrame(tick);
+					});
+				} else {
+					setTimeout(tick, 0);
+				}
+
+				$(window).one('load', function() {
+					if ( ! done) {
+						applyPublishScrollAnchor(anchor);
+					} else {
+						setTimeout(function() {
+							applyPublishScrollAnchor(anchor);
+						}, 50);
+					}
+				});
+			} catch (err) {}
+		};
+
+		publishForm.on('submit', persistPublishScroll);
+		restorePublishScroll();
+	}
+
 	// Emoji
 	if (EE.publish.smileys === true) {
 		$('body').on('click', '.format-options .toolbar .emoji a', function(e) {

--- a/themes/ee/asset/javascript/src/fields/fluid_field/ui.js
+++ b/themes/ee/asset/javascript/src/fields/fluid_field/ui.js
@@ -24,6 +24,187 @@
 			$(this).attr('data-field-count', savedFluidItems);
 		});
 
+		// Persist Fluid expand/collapse across Save when enabled via
+		// Hidden Configuration Variable - fluid_field_persist_collapse => y/n
+		var fluidPersistCollapse = (
+			typeof EE !== 'undefined' &&
+			EE.publish &&
+			EE.publish.fluid_persist_collapse
+		);
+		var persistFluidCollapseState = function() {};
+
+		if (fluidPersistCollapse) {
+			var getEntryId = function() {
+				if (typeof EE !== 'undefined' && EE.publish && EE.publish.entry_id) {
+					return String(EE.publish.entry_id);
+				}
+
+				var href = window.location.href;
+				var match = href.match(/publish\/edit\/entry\/(\d+)/);
+
+				if (match) {
+					return match[1];
+				}
+
+				var action = $('.form-standard > form').attr('action') || '';
+				match = action.match(/publish\/edit\/entry\/(\d+)/);
+
+				return match ? match[1] : null;
+			};
+
+			var getUserId = function() {
+				if (typeof EE !== 'undefined' && EE.user_id) {
+					return String(EE.user_id);
+				}
+
+				return 'anon';
+			};
+
+			var getFluidFieldKey = function($fluid) {
+				var $fieldset = $fluid.closest('fieldset[id^="fieldset-"]');
+
+				if ($fieldset.length) {
+					return $fieldset.attr('id').replace(/^fieldset-/, '');
+				}
+
+				var name = $fluid.find('.js-sorting-container .fluid__item :input[name]').first().attr('name') || '';
+				var match = name.match(/^([^\[\]]+)/);
+
+				return match ? match[1] : 'fluid';
+			};
+
+			// Use descendant query: malformed field-instruction HTML can nest later
+			// Fluid rows under an <em>, so direct-child selectors miss them.
+			var getFluidItems = function($fluid) {
+				return $fluid.find('.js-sorting-container .fluid__item').filter(function() {
+					return ! $(this).closest('.fluid-field-templates').length;
+				});
+			};
+
+			var getFluidItemId = function($item) {
+				var name = $item.find(':input[name*="[fields]"]').first().attr('name') || '';
+				var match = name.match(/\[(field_\d+|new_field_\d+)\]/);
+
+				if (match) {
+					return match[1];
+				}
+
+				// Best-effort fallback: position within this Fluid field (fragile on reorder)
+				var $items = getFluidItems($item.closest('.fluid'));
+				var index = $items.index($item);
+
+				return index >= 0 ? 'index_' + index : null;
+			};
+
+			var getStorageKey = function($fluid) {
+				var entryId = getEntryId();
+
+				if ( ! entryId) {
+					return null;
+				}
+
+				return [
+					'ee:fluidCollapse',
+					getUserId(),
+					entryId,
+					getFluidFieldKey($fluid)
+				].join(':');
+			};
+
+			var readCollapsedIds = function($fluid) {
+				var key = getStorageKey($fluid);
+
+				if ( ! key || typeof localStorage === 'undefined') {
+					return null;
+				}
+
+				try {
+					var raw = localStorage.getItem(key);
+
+					if ( ! raw) {
+						return [];
+					}
+
+					var data = JSON.parse(raw);
+
+					if ($.isArray(data)) {
+						return data;
+					}
+
+					if (data && $.isArray(data.collapsed)) {
+						return data.collapsed;
+					}
+				} catch (err) {}
+
+				return [];
+			};
+
+			var writeCollapsedIds = function($fluid, collapsedIds) {
+				var key = getStorageKey($fluid);
+
+				if ( ! key || typeof localStorage === 'undefined') {
+					return;
+				}
+
+				try {
+					localStorage.setItem(key, JSON.stringify({
+						collapsed: collapsedIds
+					}));
+				} catch (err) {}
+			};
+
+			persistFluidCollapseState = function($fluid) {
+				if ( ! $fluid || ! $fluid.length) {
+					return;
+				}
+
+				var collapsedIds = [];
+
+				getFluidItems($fluid).each(function() {
+					var $item = $(this);
+
+					if ( ! $item.hasClass('fluid__item--collapsed')) {
+						return;
+					}
+
+					var itemId = getFluidItemId($item);
+
+					if (itemId) {
+						collapsedIds.push(itemId);
+					}
+				});
+
+				writeCollapsedIds($fluid, collapsedIds);
+			};
+
+			var restoreFluidCollapseState = function($fluid) {
+				var collapsedIds = readCollapsedIds($fluid);
+
+				if (collapsedIds === null || ! collapsedIds.length) {
+					return;
+				}
+
+				var collapsedMap = {};
+
+				$.each(collapsedIds, function(i, id) {
+					collapsedMap[id] = true;
+				});
+
+				getFluidItems($fluid).each(function() {
+					var $item = $(this);
+					var itemId = getFluidItemId($item);
+
+					if (itemId && collapsedMap[itemId]) {
+						$item.addClass('fluid__item--collapsed');
+					}
+				});
+			};
+
+			$('.fluid').each(function() {
+				restoreFluidCollapseState($(this));
+			});
+		}
+
 		var addField = function(e) {
 			var fluidField   = $(this).closest('.fluid'),
 				fieldToAdd   = $(this).data('field-name'),
@@ -81,7 +262,8 @@
 
 		$('.fluid').on('click', 'a.js-fluid-remove', function(e) {
 			var el = $(this).closest('.fluid__item');
-			var fluidCount = $(this).parents('.fluid').attr('data-field-count');
+			var $fluid = $(this).closest('.fluid');
+			var fluidCount = $fluid.attr('data-field-count');
 
             // If we removed a field group fire 'remove' events on all of its fields
             if ($(el).data('field-type') == 'field_group') {
@@ -95,16 +277,21 @@
 
 			if (fluidCount > 0) {
 				fluidCount--;
-				el.parents('.fluid').attr('data-field-count', fluidCount);
+				$fluid.attr('data-field-count', fluidCount);
 			}
 
 			el.remove();
+			persistFluidCollapseState($fluid);
 			e.preventDefault();
 		});
 
 		// Toggle fluid item
 		$('.fluid').on('click', '.js-toggle-fluid-item', function() {
-			$(this).parents('.fluid__item').toggleClass('fluid__item--collapsed');
+			var $item = $(this).closest('.fluid__item');
+			var $fluid = $(this).closest('.fluid');
+
+			$item.toggleClass('fluid__item--collapsed');
+			persistFluidCollapseState($fluid);
 
 			// Hide the dropdown menu
 			$('.js-dropdown-toggle.dropdown-open').trigger('click');
@@ -114,7 +301,10 @@
 
 		// Hide all fluid items
 		$('.fluid').on('click', '.js-hide-all-fluid-items', function() {
-			$(this).parents('.fluid').find('.js-sorting-container .fluid__item').addClass('fluid__item--collapsed');
+			var $fluid = $(this).closest('.fluid');
+
+			$fluid.find('.js-sorting-container .fluid__item').addClass('fluid__item--collapsed');
+			persistFluidCollapseState($fluid);
 
 			// Hide the dropdown menu
 			$('.js-dropdown-toggle.dropdown-open').trigger('click');
@@ -124,7 +314,10 @@
 
 		// Show all fluid items
 		$('.fluid').on('click', '.js-show-all-fluid-items', function() {
-			$(this).parents('.fluid').find('.js-sorting-container .fluid__item').removeClass('fluid__item--collapsed');
+			var $fluid = $(this).closest('.fluid');
+
+			$fluid.find('.js-sorting-container .fluid__item').removeClass('fluid__item--collapsed');
+			persistFluidCollapseState($fluid);
 
 			// Hide the dropdown menu
 			$('.js-dropdown-toggle.dropdown-open').trigger('click');


### PR DESCRIPTION
## Summary
- Persist Fluid field expand/collapse state across Save (localStorage), gated by hidden config `fluid_field_persist_collapse`
- Restore publish form scroll position after Save using a Fluid-item anchor + settle loop, gated by `publish_persist_scroll`
- Bridge both flags (and `publish.entry_id`) via `AbstractPublish::setGlobalJs`; features default off unless config is `y`

## Test plan
- [ ] With both configs unset/off, Save on a Fluid-heavy entry leaves expand/collapse + scroll behavior unchanged
- [ ] Set `$config['fluid_field_persist_collapse'] = 'y'` and `$config['publish_persist_scroll'] = 'y'`
- [ ] Collapse several top-level Fluid bands, scroll mid-entry, Save — collapsed bands and scroll position restore
- [ ] Reorder Fluid items / expand all / collapse all, Save again — state stays consistent
- [ ] Confirm nested Grid/relationship collapsibles are unchanged (top-level Fluid bands only)


Made with [Cursor](https://cursor.com)