### PR TITLE
Resolved #3998 where cloning an entry with an invalid IP address failed validation

### DIFF
--- a/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
+++ b/system/ee/ExpressionEngine/Controller/Publish/AbstractPublish.php
@@ -385,6 +385,8 @@ abstract class AbstractPublish extends CP_Controller
 
         if (defined('CLONING_MODE') && CLONING_MODE === true && $this->entryCloningEnabled($entry)) {
             $entry->setId(null);
+            // Clone is a new entry: stamp creator IP like Publish::create()
+            $entry->ip_address = ee()->session->userdata['ip_address'] ?: ee()->input->ip_address();
             $word_separator = ee()->config->item('word_separator') != "dash" ? '_' : '-';
             while (true !== $entry->validateUniqueUrlTitle('url_title', $_POST['url_title'], ['channel_id'], null)) {
                 $_POST['url_title'] = 'copy' . $word_separator . $_POST['url_title'];


### PR DESCRIPTION
## Summary

Follow-up to #3998 / #4001. Programmatic entry creation (migrations, Model `make()` without setting `ip_address`, some add-ons) can persist MySQL’s default `0`, which is not a valid IP. Normal Edit/Save still works because partial validation skips an unchanged IP field. **Clone is the known CP friction point**: it `setId(null)`s and full-validates as a new entry while inheriting the source IP, so an invalid source IP blocks clone even though IP is not a form field.

This change stamps the cloner’s session IP during `CLONING_MODE` (same as `Publish::create()`), with a fallback to `ee()->input->ip_address()` if session IP is empty. The **new** cloned row gets a valid IP. The **original** entry’s `ip_address` is not modified.

## How to reproduce

1. Ensure cloning is enabled for a channel.
2. Set any entry’s `exp_channel_titles.ip_address` to `'0'` (simulates programmatic/legacy creates).
3. Clone that entry in the Control Panel.
4. **Before fix:** validation fails with `ip_address: This field must contain a valid IP.`
5. **After fix:** clone succeeds (“Entry Created” / new cloned entry). Source entry IP remains `'0'`; new entry IP is the current CP session IP.

## Test plan

- [x] Clone entry with `ip_address = '0'` succeeds after fix (verified on Exida local)
- [x] New cloned entry gets session IP; original entry IP unchanged
- [ ] Clone of a healthy entry still succeeds; cloned row IP is the cloner session IP
- [ ] Normal Edit/Save of an entry with `ip_address = '0'` does not rewrite IP
- [ ] Create path unchanged

Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/3998


Made with [Cursor](https://cursor.com)