### PR TITLE
Remove default URL http fake placeholder in comment module

### DIFF
--- a/system/ee/ExpressionEngine/Addons/comment/mod.comment.php
+++ b/system/ee/ExpressionEngine/Addons/comment/mod.comment.php
@@ -901,10 +901,6 @@ class Comment
 
                 $url = ee()->functions->encode_ee_tags($url, true);
 
-                if ($url == '') {
-                    $url = 'http://';
-                }
-
                 $tagdata = ee()->TMPL->swap_var_single($key, form_prep($url), $tagdata);
             }
 


### PR DESCRIPTION
Removed default URL assignment when the URL is empty.  

We should just let them use a placeholder via html, so I went with removing it vs changing it to https

