### PR TITLE
Fixed custom CKEditor text replacements

### DIFF
--- a/system/ee/ExpressionEngine/Addons/rte/Service/CkeditorService.php
+++ b/system/ee/ExpressionEngine/Addons/rte/Service/CkeditorService.php
@@ -176,34 +176,8 @@ class CkeditorService extends AbstractRteService implements RteService
             'Rte.configs.' . $configHandle => $config
         ]);
 
-        // some config values are regular expressions, re-decleare those as such
-        $configRegex = [];
-        if (isset($config['htmlSupport']) && isset($config['htmlSupport']->allow)) {
-            foreach ($config['htmlSupport'] as $property => $htmlSupport) {
-                foreach ($htmlSupport as $i => $allowDisallow) {
-                    foreach ($allowDisallow as $key => $value) {
-                        if (is_string($value) && strpos($value, '/') === 0 && strrpos($value, '/') === strlen($value) - 1) {
-                            $configRegex[] = 'EE.Rte.configs.' . $configHandle . '.htmlSupport.' . $property . '[' . $i . '].' . $key . ' = new RegExp(' . $value . ');';
-                        } elseif (is_array($value)) {
-                            foreach ($value as $j => $v) {
-                                if (is_string($v) && strpos($v, '/') === 0 && strrpos($v, '/') === strlen($v) - 1) {
-                                    $configRegex[] = 'EE.Rte.configs.' . $configHandle . '.htmlSupport.' . $property . '[' . $i . '].' . $key . '[' . $j . '] = new RegExp(' . $v . ');';
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        if (isset($config['typing']) && isset($config['typing']->transformations) && isset($config['typing']->transformations->extra)) {
-            foreach ($config['typing']->transformations->extra as $i => $extra) {
-                foreach ($extra as $key => $value) {
-                    if (is_string($value) && strpos($value, '/') === 0 && strrpos($value, '/') === strlen($value) - 1) {
-                        $configRegex[] = 'EE.Rte.configs.typing.transformations.extra[' . $i . '].' . $key . ' = new RegExp(' . $value . ');';
-                    }
-                }
-            }
-        }
+        // some config values are regular expressions, re-declare those as such
+        $configRegex = $this->buildConfigRegex($config, $configHandle);
 
         if (!empty($configRegex)) {
             ee()->cp->add_to_foot('<script type="text/javascript">
@@ -228,6 +202,39 @@ class CkeditorService extends AbstractRteService implements RteService
         }
 
         return $configHandle;
+    }
+
+    protected function buildConfigRegex($config, $configHandle)
+    {
+        $configRegex = [];
+        if (isset($config['htmlSupport']) && isset($config['htmlSupport']->allow)) {
+            foreach ($config['htmlSupport'] as $property => $htmlSupport) {
+                foreach ($htmlSupport as $i => $allowDisallow) {
+                    foreach ($allowDisallow as $key => $value) {
+                        if (is_string($value) && strpos($value, '/') === 0 && strrpos($value, '/') === strlen($value) - 1) {
+                            $configRegex[] = 'EE.Rte.configs.' . $configHandle . '.htmlSupport.' . $property . '[' . $i . '].' . $key . ' = new RegExp(' . $value . ');';
+                        } elseif (is_array($value)) {
+                            foreach ($value as $j => $v) {
+                                if (is_string($v) && strpos($v, '/') === 0 && strrpos($v, '/') === strlen($v) - 1) {
+                                    $configRegex[] = 'EE.Rte.configs.' . $configHandle . '.htmlSupport.' . $property . '[' . $i . '].' . $key . '[' . $j . '] = new RegExp(' . $v . ');';
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (isset($config['typing']) && isset($config['typing']->transformations) && isset($config['typing']->transformations->extra)) {
+            foreach ($config['typing']->transformations->extra as $i => $extra) {
+                foreach ($extra as $key => $value) {
+                    if (is_string($value) && strpos($value, '/') === 0 && strrpos($value, '/') === strlen($value) - 1) {
+                        $configRegex[] = 'EE.Rte.configs.' . $configHandle . '.typing.transformations.extra[' . $i . '].' . $key . ' = new RegExp(' . $value . ');';
+                    }
+                }
+            }
+        }
+
+        return $configRegex;
     }
 
     public function buildToolbarConfig($config)

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Rte/CkeditorServiceTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/Rte/CkeditorServiceTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace ExpressionEngine\Tests\Addons\Rte;
+
+require_once PATH_ADDONS . 'rte/Service/RteService.php';
+require_once PATH_ADDONS . 'rte/Service/AbstractRteService.php';
+require_once PATH_ADDONS . 'rte/Service/CkeditorService.php';
+
+use ExpressionEngine\Addons\Rte\Service\CkeditorService;
+use PHPUnit\Framework\TestCase;
+
+class CkeditorServiceTest extends TestCase
+{
+    public function testConfigRegexUsesToolsetHandleForAllConfigPaths()
+    {
+        $config = [
+            'htmlSupport' => (object) [
+                'allow' => [
+                    (object) [
+                        'name' => '/^(div|span)$/',
+                        'attributes' => ['/^data-[\\w-]+$/', 'title'],
+                    ],
+                ],
+            ],
+            'typing' => (object) [
+                'transformations' => (object) [
+                    'extra' => [
+                        (object) [
+                            'from' => '/^(foo)$/',
+                            'to' => ['bar'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $service = new TestableCkeditorService();
+
+        $this->assertSame(
+            [
+                'EE.Rte.configs.Smart_Quotes5.htmlSupport.allow[0].name = new RegExp(/^(div|span)$/);',
+                'EE.Rte.configs.Smart_Quotes5.htmlSupport.allow[0].attributes[0] = new RegExp(/^data-[\\w-]+$/);',
+                'EE.Rte.configs.Smart_Quotes5.typing.transformations.extra[0].from = new RegExp(/^(foo)$/);',
+            ],
+            $service->buildConfigRegexForTest($config, 'Smart_Quotes5')
+        );
+    }
+}
+
+class TestableCkeditorService extends CkeditorService
+{
+    public function buildConfigRegexForTest($config, $configHandle)
+    {
+        return $this->buildConfigRegex($config, $configHandle);
+    }
+}


### PR DESCRIPTION
## Issue

Advanced RTE configuration accepts regular-expression rules for custom CKEditor typing transformations. When ExpressionEngine restores these rules in JavaScript, the generated configuration path omits the active toolset handle.

## Problem

The generated script targets EE.Rte.configs.typing instead of the selected toolset configuration. This produces a JavaScript error and leaves the rule as a plain string, so custom text replacements such as smart punctuation do not run.

## Fix

- Scope typing-transformation regular-expression paths to the active RTE toolset.
- Move regular-expression path generation into a focused helper shared by the existing HTML-support and typing-configuration handling.
- Add a regression test confirming every generated path includes the toolset handle.

## Testing

- RTE PHPUnit suite: 105 tests, 105 assertions.
- PHP syntax checks pass for both changed files.
- Git diff validation passes.