### PR TITLE
Fix dynamic post-install copyright year

### DIFF
--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Installer/Schema/MysqlSchemaTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Installer/Schema/MysqlSchemaTest.php
@@ -169,6 +169,19 @@ class MysqlSchemaTest extends TestCase
         );
     }
 
+    /**
+     * Ensure fresh installations store a year that is resolved at render time.
+     *
+     * @return void
+     */
+    public function testPostInstallMessageTemplateUsesDynamicCopyrightYear()
+    {
+        $template = \post_install_message_template();
+
+        $this->assertStringContainsString('&copy;{current_time format="%Y"}', $template);
+        $this->assertDoesNotMatchRegularExpression('/&copy;\d{4}/', $template);
+    }
+
     private function makeSchemaFixture(MysqlSchemaDbMock $db): \EE_Schema
     {
         $schema = new class extends \EE_Schema {

--- a/system/ee/language/english/email_data.php
+++ b/system/ee/language/english/email_data.php
@@ -934,7 +934,7 @@ if (! function_exists('post_install_message_template')) {
 			</div>
 			<section class="bar">
 				<p style="float: left;"><a href="https://expressionengine.com/" rel="external"><b>ExpressionEngine</b></a></p>
-				<p style="float: right;">&copy;2023 <a href="https://packettide.com/" rel="external">Packet Tide</a>, LLC</p>
+				<p style="float: right;">&copy;{current_time format="%Y"} <a href="https://packettide.com/" rel="external">Packet Tide</a>, LLC</p>
 			</section>
 		</section>
 


### PR DESCRIPTION
## Summary

- render the post-install copyright year dynamically when fresh installations seed the template
- add regression coverage ensuring the new-install template contains the dynamic year tag and no hard-coded copyright year
- leave all existing persisted post-install templates untouched

Closes #5367

## Validation

- `MysqlSchemaTest`: 4 tests, 11 assertions
- unchanged `EE_TemplateParseTemplateUriTest`: 22 tests, 34 assertions
- PHP 7.4 lint passed for both changed PHP files
- independent PHP 8.5 lint passed
- `git diff --check` passed
