### PR TITLE
Resolved #5372 where a watermark image manipulation contaminated the shared source temp file, watermarking auto-generated thumbnails

### DIFF
--- a/system/ee/legacy/libraries/Filemanager.php
+++ b/system/ee/legacy/libraries/Filemanager.php
@@ -1319,7 +1319,16 @@ class Filemanager
                     ($prefs['width'] < $size['width'] && $prefs['height'] < $size['height'])
                 ) or
                 $size['resize_type'] == 'none') {
-                $config['new_image'] = $config['source_image'];
+                  // Copy into this manipulation's own temp file rather than aliasing onto                                                                                                                                                                   
+                  // the shared source, otherwise the in-place watermark below contaminates                                                                                                                                                                  
+                  // the source that every later manipulation (including 'thumbs') resizes from.                                                                                                                                                             
+                  if (! @copy($config['source_image'], $new['path'])) {                                                                                                                                                                                      
+                      log_message('error', 'Image Copy Failed: ' . $prefs['file_name']);                                                                                                                                                                     
+                                                                                                                                                                                                                                                             
+                      return false;                                                                                                                                                                                                                          
+                  }                                                                                                                                                                                                                                          
+                                                                                                                                                                                                                                                             
+                  $config['new_image'] = $new['path'];
             } elseif (isset($size['resize_type']) and $size['resize_type'] == 'crop') {
                 // Scale the larger dimension up so only one dimension of our
                 // image fits within the desired dimension


### PR DESCRIPTION
When an upload directory has an image manipulation with a watermark whose target dimensions exceed the uploaded image in both dimensions, `create_thumb()` aliases `$config['new_image']` onto the single shared temp copy of the source (`Filemanager.php:1322`). `create_watermark()` sets only `source_image` and writes in place, so the watermark is burned into the temp file that every subsequent manipulation resizes from — including the `thumbs` entry appended last, which hardcodes `watermark_id => 0`.

Result: `_thumbs/` and any no-watermark manipulation that also takes the copy-rather-than-upsize path come out watermarked, while the original upload is untouched — which is what makes it easy to miss.

This copies into the manipulation's own temp file instead, preserving the existing "copy rather than upsize" behaviour without mutating the shared source.

Verified on a production install: 2,260 of 2,979 images in one upload directory were affected (watermark manipulations at 2000x2000, masters ranging from 200x200 up). After the fix, `_thumbs` is clean, a no-watermark copy-path manipulation is byte-identical to its source, and each watermark manipulation contains only its own watermark.

Note for reproduction: this requires a **fresh upload**. Re-syncing an existing file masks it, because pre-existing manipulations are skipped when `$missing_only = true`, so nothing contaminates the shared temp copy.

Resolves https://github.com/ExpressionEngine/ExpressionEngine/issues/5372