### PR TITLE
Fixed #5378 where RTE page links are not resolved when an RTE field is used through Pro Variables

### DIFF
--- a/system/ee/ExpressionEngine/Addons/rte/ft.rte.php
+++ b/system/ee/ExpressionEngine/Addons/rte/ft.rte.php
@@ -509,6 +509,20 @@ class Rte_ft extends EE_Fieldtype
     }
 
     /**
+     * Replace a Pro Variables tag.
+     *
+     * @param string $data field data
+     * @param array $params field parameters
+     * @param string $tagdata template data
+     *
+     * @return string $data parsed field data
+     */
+    public function var_replace_tag($data, $params = array(), $tagdata = false)
+    {
+        return $this->replace_tag($this->pre_process($data), $params, $tagdata);
+    }
+
+    /**
      * Returns true if content type is accepted.
      *
      * @param string $name


### PR DESCRIPTION
Fixed #5378 where RTE page links are not resolved when an RTE field is used through Pro Variables