### PR TITLE
Added SameSite setting for PHP session cookies

### DIFF
--- a/system/ee/legacy/libraries/Core.php
+++ b/system/ee/legacy/libraries/Core.php
@@ -163,7 +163,30 @@ class EE_Core
         // don't leak to JS by setting the httpOnly flag
         $secure = bool_config_item('cookie_secure');
         $httpOnly = (ee()->config->item('cookie_httponly')) ? bool_config_item('cookie_httponly') : true;
-        session_set_cookie_params(0, ee()->config->item('cookie_path'), ee()->config->item('cookie_domain'), $secure, $httpOnly);
+        $sameSite = ee()->config->item('cookie_samesite') ?: 'Lax';
+
+        if ($sameSite === 'None') {
+            $secure = true;
+        }
+
+        if (PHP_VERSION_ID < 70300) {
+            session_set_cookie_params(
+                0,
+                ee()->config->item('cookie_path') . '; SameSite=' . $sameSite,
+                ee()->config->item('cookie_domain'),
+                $secure,
+                $httpOnly
+            );
+        } else {
+            session_set_cookie_params([
+                'lifetime' => 0,
+                'path' => ee()->config->item('cookie_path'),
+                'domain' => ee()->config->item('cookie_domain'),
+                'secure' => $secure,
+                'httponly' => $httpOnly,
+                'samesite' => $sameSite,
+            ]);
+        }
 
         // this look backwards, but QUERY_MARKER is only used where we MUST
         // have a ?, and do not want to double up


### PR DESCRIPTION
## Summary

- apply the documented `cookie_samesite` override to native PHP session cookies
- preserve PHP 7.2 compatibility
- make `SameSite=None` force the Secure attribute, matching other ExpressionEngine cookies

## Testing

- `php -l system/ee/legacy/libraries/Core.php`