### PR TITLE
Fix layout loop indexes after Multi Select rendering

### DIFF
--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/EE_Template/EE_TemplateParseLayoutVariablesTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/legacy/EE_Template/EE_TemplateParseLayoutVariablesTest.php
@@ -71,6 +71,32 @@ class EE_TemplateParseLayoutVariablesTest extends EE_TemplateTestBase
     }
 
     /**
+     * Parse layout loop variables even when a previous loop did not use them.
+     *
+     * @return void
+     */
+    public function testParseLayoutVariablesIgnoresPreviousLoopMissingVariables()
+    {
+        ee()->setMock('Variables/Parser', new \ExpressionEngine\Service\Template\Variables\LegacyParser());
+
+        $this->template->parse_variables_row('{item}', [
+            'item' => 'Rock',
+            'index' => 0,
+            'count' => 1,
+        ]);
+
+        $result = $this->template->parseLayoutVariables(
+            "{layout:labels}{index}:{count}:{value}:{layout:paths index='{index}'};{/layout:labels}",
+            [
+                'labels' => ['Directory', 'Entry'],
+                'paths' => ['directory', 'entry'],
+            ]
+        );
+
+        $this->assertSame('0:1:Directory:directory;1:2:Entry:entry;', $result);
+    }
+
+    /**
      * Test parseLayoutVariables handles undefined variables
      */
     public function testParseLayoutVariablesHandlesUndefinedVariables()

--- a/system/ee/legacy/libraries/Template.php
+++ b/system/ee/legacy/libraries/Template.php
@@ -698,6 +698,7 @@ class EE_Template
     {
         $this->log_item("Layout Variables:", $layout_vars);
         $this->layout_conditionals = [];
+        $this->unfound_vars = [];
         $layout_conditionals = [];
 
         // get all the declared layout variables (excluding layout:contents)


### PR DESCRIPTION
## Summary

- clear the cached missing-variable state when layout parsing starts
- preserve layout loop indexes after a Multi Select pair is rendered without `{index}`
- add regression coverage for layout counters and indexed lookups across multiple rows

## Root cause

Rendering a Multi Select pair without `{index}` leaves a cached "variable not found" entry. A later layout loop then skips its own index, causing indexed lookups into parallel layout arrays to return empty strings.

Fixes #5388

## Validation

- regression confirmed failing before the fix and passing afterward
- layout tests: 17 tests, 25 assertions on PHP 7.4, 8.2, and 8.5
- adjacent parser tests: 58 tests, 100 assertions on PHP 8.2
- six isolated diagnostics using the real Multi Select and template parsing methods on PHP 8.2
- independent review found no actionable issues
- `git diff --check` passed

Full browser rendering and the full test suite were not run.
