### PR TITLE
Fix Grid column reassignment when retrying a clone

### DIFF
--- a/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
+++ b/system/ee/ExpressionEngine/Addons/grid/libraries/Grid_lib.php
@@ -705,7 +705,7 @@ class Grid_lib
      * Given POSTed column settings, adds new columns to the database and
      * figures out if any columns need deleting
      *
-     * @param array POSTed column settings from field settings page
+     * @param array $settings POSTed column settings from the field settings page.
      * @return void
      */
     public function apply_settings($settings)
@@ -725,9 +725,8 @@ class Grid_lib
 
         // Go through ALL posted columns for this field
         foreach ($settings['grid']['cols'] as $col_field => $column) {
-            // Attempt to get the column ID; if the field name contains 'new_',
-            // it's a new field, otherwise extract column ID
-            if (defined('CLONING_MODE') && CLONING_MODE === true) {
+            // Clone retries can lose CLONING_MODE, but new tables still need independent columns.
+            if ($new_field || (defined('CLONING_MODE') && CLONING_MODE === true)) {
                 $col_field = 'new_' . str_replace('col_id_', '', $col_field);
             }
             $column['col_id'] = (strpos($col_field, 'new_') === false)

--- a/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/grid/Library/GridLibApplySettingsTest.php
+++ b/system/ee/ExpressionEngine/Tests/ExpressionEngine/Addons/grid/Library/GridLibApplySettingsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace ExpressionEngine\Tests\ExpressionEngine\Addons\grid\Library;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class GridLibApplySettingsTest extends TestCase
+{
+    /**
+     * Load the Grid settings classes and reset EE dependencies.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        require_once BASEPATH . 'core/Model.php';
+        require_once BASEPATH . 'models/grid_model.php';
+        require_once PATH_ADDONS . 'grid/libraries/Grid_lib.php';
+
+        ee()->resetMocks();
+    }
+
+    /**
+     * Release singleton mocks after each settings save.
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        ee()->resetMocks();
+
+        parent::tearDown();
+    }
+
+    /**
+     * Keep source column IDs out of new tables while preserving normal edits.
+     *
+     * @dataProvider settingsSaveProvider
+     * @param bool $newField Whether the destination data table was just created.
+     * @param bool $cloning Whether this request still carries the clone action.
+     * @param array $expectedIds Column IDs passed to persistence, or false for new columns.
+     * @return void
+     */
+    public function testApplySettingsUsesIndependentColumnsForNewFields($newField, $cloning, $expectedIds): void
+    {
+        define('CLONING_MODE', $cloning);
+
+        $columns = [];
+        foreach ([31 => ['file', 'file'], 32 => ['topic', 'text'], 33 => ['link', 'text']] as $id => $definition) {
+            $columns[$id] = [
+                'col_id' => $id,
+                'col_type' => $definition[1],
+                'col_name' => $definition[0],
+                'col_label' => ucfirst($definition[0]),
+                'col_instructions' => '',
+                'col_required' => 'n',
+                'col_search' => 'n',
+                'col_width' => 0,
+                'col_settings' => [],
+            ];
+        }
+
+        $posted = [];
+        foreach ($columns as $id => $column) {
+            $posted['col_id_' . $id] = $column;
+        }
+        $posted['new_0'] = array_merge($columns[32], ['col_name' => 'extra', 'col_label' => 'Extra']);
+
+        $model = $this->getMockBuilder(\Grid_model::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['create_field', 'get_columns_for_field', 'save_col_settings', 'update_grid_search', 'delete_columns'])
+            ->getMock();
+        $model->expects($this->once())->method('create_field')->with(22, 'channel')->willReturn($newField);
+        $model->expects($this->once())->method('get_columns_for_field')
+            ->with(22, 'channel', false)->willReturn($newField ? [] : $columns);
+        $model->expects($this->once())->method('update_grid_search')->with([22]);
+        $model->expects($this->never())->method('delete_columns');
+
+        $savedIds = [];
+        $savedColumns = [];
+        $model->expects($this->exactly(4))->method('save_col_settings')
+            ->willReturnCallback(function ($column, $id, $contentType) use (&$savedIds, &$savedColumns) {
+                $this->assertSame('channel', $contentType);
+                $savedIds[] = $id;
+                $savedColumns[] = $column;
+
+                return $id ?: 100 + count($savedIds);
+            });
+        ee()->setMock('grid_model', $model);
+
+        $library = $this->getMockBuilder(\Grid_lib::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['_save_settings'])
+            ->getMock();
+        $library->method('_save_settings')->willReturn([]);
+        $library->field_id = 22;
+        $library->content_type = 'channel';
+        $library->apply_settings(['field_id' => 22, 'grid' => ['cols' => $posted]]);
+
+        $this->assertSame($expectedIds, $savedIds);
+        $this->assertSame([22, 22, 22, 22], array_column($savedColumns, 'field_id'));
+        $this->assertSame(['file', 'topic', 'link', 'extra'], array_column($savedColumns, 'col_name'));
+        $this->assertSame([0, 1, 2, 3], array_column($savedColumns, 'col_order'));
+    }
+
+    /**
+     * Cover a clone retry, an uninterrupted clone, and an existing field edit.
+     *
+     * @return array Settings save scenarios and expected persistence IDs.
+     */
+    public function settingsSaveProvider(): array
+    {
+        return [
+            'clone retry after validation error' => [true, false, [false, false, false, false]],
+            'normal clone' => [true, true, [false, false, false, false]],
+            'existing field edit' => [false, false, ['31', '32', '33', false]],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- treat Grid columns as new whenever the destination Grid table is being created
- preserve the original field's column ownership when a failed clone is saved again
- retain normal behavior for ordinary clones and existing-field edits
- add regression coverage for clone retries and newly added columns

## Root cause

When a Grid or File Grid clone encounters a validation error, the subsequent ordinary save can retain the original column IDs without the cloning flag. Those definitions can then be reassigned to the new field, leaving the original content inaccessible and the clone referencing missing database columns.

This prevents the failure on future clones; it does not repair fields that are already damaged.

Fixes #5382

## Validation

- regression failed before the fix and passed afterward
- coverage includes clone retries, normal clones, existing-field edits, and an additional new column
- PHP 7.4 and 8.5: 104 tests, 290 assertions per version, with no failures, errors, or skips
- syntax and `git diff --check` passed
- independent review found no actionable issues

The reporter's exact workflow has not been reproduced through a browser with MySQL.
